### PR TITLE
Bug Fix

### DIFF
--- a/Scripts/Mobiles/Normal/RestlessSoul.cs
+++ b/Scripts/Mobiles/Normal/RestlessSoul.cs
@@ -44,6 +44,7 @@ namespace Server.Mobiles
         {
         }
 
+        public override bool AlwaysMurderer => true;
         public override bool BleedImmune => true;
         public override int TreasureMapLevel => 2;
         public override void GenerateLoot()


### PR DESCRIPTION
Restless Souls should be red. We most have nuked this by mistake in a recent patch.