### PR TITLE
Fixed issue with Tailor Gump showing Retains Color message for items …

### DIFF
--- a/Scripts/Services/Craft/Core/CraftItem.cs
+++ b/Scripts/Services/Craft/Core/CraftItem.cs
@@ -496,6 +496,11 @@ namespace Server.Engines.Craft
 
         public bool RetainsColorFrom(CraftSystem system, Type type)
         {
+            if (system.RetainsColorFromException(this, type))
+            {
+                return false;
+            }
+
             if (system.RetainsColorFrom(this, type))
             {
                 return true;

--- a/Scripts/Services/Craft/Core/CraftSystem.cs
+++ b/Scripts/Services/Craft/Core/CraftSystem.cs
@@ -15,54 +15,136 @@ namespace Server.Engines.Craft
     public abstract class CraftSystem
     {
         public static List<CraftSystem> Systems { get; set; }
+        private static readonly Type[] _GlobalNoConsume =
+        {
+            typeof(CapturedEssence), typeof(EyeOfTheTravesty), typeof(DiseasedBark),  typeof(LardOfParoxysmus), typeof(GrizzledBones), typeof(DreadHornMane),
 
-        private readonly int m_MinCraftEffect;
-        private readonly int m_MaxCraftEffect;
-        private readonly double m_Delay;
-        private bool m_Resmelt;
-        private bool m_Repair;
-        private bool m_MarkOption;
-        private bool m_CanEnhance;
+            typeof(Blight), typeof(Corruption), typeof(Muculent), typeof(Scourge), typeof(Putrefaction), typeof(Taint),
 
-        private bool m_QuestOption;
-        private bool m_CanAlter;
+            // Tailoring
+            typeof(MidnightBracers), typeof(CrimsonCincture), typeof(GargishCrimsonCincture), typeof(LeurociansMempoOfFortune),
 
-        private readonly CraftItemCol m_CraftItems;
-        private readonly CraftGroupCol m_CraftGroups;
-        private readonly CraftSubResCol m_CraftSubRes;
-        private readonly CraftSubResCol m_CraftSubRes2;
+            // Blacksmithy
+            typeof(LeggingsOfBane), typeof(GauntletsOfNobility),
 
-        public int MinCraftEffect => m_MinCraftEffect;
+            // Carpentry
+            typeof(StaffOfTheMagi), typeof(BlackrockMoonstone),
 
-        public int MaxCraftEffect => m_MaxCraftEffect;
+            // Tinkering
+            typeof(RingOfTheElements), typeof(HatOfTheMagi), typeof(AutomatonActuator),
 
-        public double Delay => m_Delay;
+            // Inscription
+            typeof(AntiqueDocumentsKit)
+        };
 
-        public CraftItemCol CraftItems => m_CraftItems;
+        private readonly Dictionary<Mobile, CraftContext> m_ContextTable = new Dictionary<Mobile, CraftContext>();
 
-        public CraftGroupCol CraftGroups => m_CraftGroups;
+        #region Properties
 
-        public CraftSubResCol CraftSubRes => m_CraftSubRes;
+        public double Delay { get; }
 
-        public CraftSubResCol CraftSubRes2 => m_CraftSubRes2;
+        public int MinCraftEffect { get; }
 
+        public int MaxCraftEffect { get; }
+
+        public CraftItemCol CraftItems { get; }
+
+        public CraftGroupCol CraftGroups { get; }
+
+        public CraftSubResCol CraftSubRes { get; }
+
+        public CraftSubResCol CraftSubRes2 { get; }
+
+        public bool CanEnhance { get; set; }
+
+        public bool CanAlter { get; set; }
+
+        public bool Resmelt { get; set; }
+
+        public bool Repair { get; set; }
+
+        public bool MarkOption { get; set; }
+
+        public bool QuestOption { get; set; }
+
+        #endregion
+
+        #region Constructor
+        public CraftSystem(int minCraftEffect, int maxCraftEffect, double delay)
+        {
+            MinCraftEffect = minCraftEffect;
+            MaxCraftEffect = maxCraftEffect;
+            Delay = delay;
+
+            CraftItems = new CraftItemCol();
+            CraftGroups = new CraftGroupCol();
+            CraftSubRes = new CraftSubResCol();
+            CraftSubRes2 = new CraftSubResCol();
+
+            InitCraftList();
+            AddSystem(this);
+        }
+        #endregion
+
+        #region Abstract
         public abstract SkillName MainSkill { get; }
 
+        public abstract double GetChanceAtMin(CraftItem item);
+
+        public abstract void InitCraftList();
+
+        public abstract void PlayCraftEffect(Mobile from);
+
+        public abstract int PlayEndingEffect(Mobile from, bool failed, bool lostMaterial, bool toolBroken, int quality, bool makersMark, CraftItem item);
+
+        public abstract int CanCraft(Mobile from, ITool tool, Type itemType);
+        #endregion
+
+        #region Virtual
         public virtual int GumpTitleNumber => 0;
 
         public virtual string GumpTitleString => "";
 
         public virtual CraftECA ECA => CraftECA.ChanceMinusSixty;
 
-        private readonly Dictionary<Mobile, CraftContext> m_ContextTable = new Dictionary<Mobile, CraftContext>();
-
-        public abstract double GetChanceAtMin(CraftItem item);
-
         public virtual bool RetainsColorFrom(CraftItem item, Type type)
         {
             return false;
         }
 
+        public virtual bool RetainsColorFromException(CraftItem item, Type type)
+        {
+            return false;
+        }
+
+        public virtual bool ConsumeOnFailure(Mobile from, Type resourceType, CraftItem craftItem)
+        {
+            return !_GlobalNoConsume.Any(t => t == resourceType);
+        }
+
+        public virtual bool ConsumeOnFailure(Mobile from, Type resourceType, CraftItem craftItem, ref MasterCraftsmanTalisman talisman)
+        {
+            if (!ConsumeOnFailure(from, resourceType, craftItem))
+                return false;
+
+            Item item = from.FindItemOnLayer(Layer.Talisman);
+
+            if (item is MasterCraftsmanTalisman)
+            {
+                MasterCraftsmanTalisman mct = (MasterCraftsmanTalisman)item;
+
+                if (mct.Charges > 0)
+                {
+                    talisman = mct;
+                    return false;
+                }
+            }
+
+            return true;
+        }
+        #endregion
+
+        #region Methods
         public void AddContext(Mobile m, CraftContext c)
         {
             if (c == null || m == null || c.System != this)
@@ -115,93 +197,6 @@ namespace Server.Engines.Craft
             EventSink.InvokeRepairItem(new RepairItemEventArgs(m, source, e));
         }
 
-        public bool Resmelt
-        {
-            get
-            {
-                return m_Resmelt;
-            }
-            set
-            {
-                m_Resmelt = value;
-            }
-        }
-
-        public bool Repair
-        {
-            get
-            {
-                return m_Repair;
-            }
-            set
-            {
-                m_Repair = value;
-            }
-        }
-
-        public bool MarkOption
-        {
-            get
-            {
-                return m_MarkOption;
-            }
-            set
-            {
-                m_MarkOption = value;
-            }
-        }
-
-        public bool CanEnhance
-        {
-            get
-            {
-                return m_CanEnhance;
-            }
-            set
-            {
-                m_CanEnhance = value;
-            }
-        }
-
-        public bool QuestOption
-        {
-            get
-            {
-                return m_QuestOption;
-            }
-            set
-            {
-                m_QuestOption = value;
-            }
-        }
-
-        public bool CanAlter
-        {
-            get
-            {
-                return m_CanAlter;
-            }
-            set
-            {
-                m_CanAlter = value;
-            }
-        }
-
-        public CraftSystem(int minCraftEffect, int maxCraftEffect, double delay)
-        {
-            m_MinCraftEffect = minCraftEffect;
-            m_MaxCraftEffect = maxCraftEffect;
-            m_Delay = delay;
-
-            m_CraftItems = new CraftItemCol();
-            m_CraftGroups = new CraftGroupCol();
-            m_CraftSubRes = new CraftSubResCol();
-            m_CraftSubRes2 = new CraftSubResCol();
-
-            InitCraftList();
-            AddSystem(this);
-        }
-
         private void AddSystem(CraftSystem system)
         {
             if (Systems == null)
@@ -210,58 +205,10 @@ namespace Server.Engines.Craft
             Systems.Add(system);
         }
 
-        private readonly Type[] _GlobalNoConsume =
-        {
-            typeof(CapturedEssence), typeof(EyeOfTheTravesty), typeof(DiseasedBark),  typeof(LardOfParoxysmus), typeof(GrizzledBones), typeof(DreadHornMane),
-
-            typeof(Blight), typeof(Corruption), typeof(Muculent), typeof(Scourge), typeof(Putrefaction), typeof(Taint),
-
-            // Tailoring
-            typeof(MidnightBracers), typeof(CrimsonCincture), typeof(GargishCrimsonCincture), typeof(LeurociansMempoOfFortune),
-
-            // Blacksmithy
-            typeof(LeggingsOfBane), typeof(GauntletsOfNobility),
-
-            // Carpentry
-            typeof(StaffOfTheMagi), typeof(BlackrockMoonstone),
-
-            // Tinkering
-            typeof(RingOfTheElements), typeof(HatOfTheMagi), typeof(AutomatonActuator),
-
-            // Inscription
-            typeof(AntiqueDocumentsKit)
-        };
-
-        public virtual bool ConsumeOnFailure(Mobile from, Type resourceType, CraftItem craftItem)
-        {
-            return !_GlobalNoConsume.Any(t => t == resourceType);
-        }
-
-        public virtual bool ConsumeOnFailure(Mobile from, Type resourceType, CraftItem craftItem, ref MasterCraftsmanTalisman talisman)
-        {
-            if (!ConsumeOnFailure(from, resourceType, craftItem))
-                return false;
-
-            Item item = from.FindItemOnLayer(Layer.Talisman);
-
-            if (item is MasterCraftsmanTalisman)
-            {
-                MasterCraftsmanTalisman mct = (MasterCraftsmanTalisman)item;
-
-                if (mct.Charges > 0)
-                {
-                    talisman = mct;
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
         public void CreateItem(Mobile from, Type type, Type typeRes, ITool tool, CraftItem realCraftItem)
         {
             // Verify if the type is in the list of the craftable item
-            CraftItem craftItem = m_CraftItems.SearchFor(type);
+            CraftItem craftItem = CraftItems.SearchFor(type);
             if (craftItem != null)
             {
                 // The item is in the list, try to create it
@@ -293,130 +240,130 @@ namespace Server.Engines.Craft
             craftItem.AddSkill(skillToMake, minSkill, maxSkill);
 
             DoGroup(group, craftItem);
-            return m_CraftItems.Add(craftItem);
+            return CraftItems.Add(craftItem);
         }
 
         private void DoGroup(TextDefinition groupName, CraftItem craftItem)
         {
-            int index = m_CraftGroups.SearchFor(groupName);
+            int index = CraftGroups.SearchFor(groupName);
 
             if (index == -1)
             {
                 CraftGroup craftGroup = new CraftGroup(groupName);
                 craftGroup.AddCraftItem(craftItem);
-                m_CraftGroups.Add(craftGroup);
+                CraftGroups.Add(craftGroup);
             }
             else
             {
-                m_CraftGroups.GetAt(index).AddCraftItem(craftItem);
+                CraftGroups.GetAt(index).AddCraftItem(craftItem);
             }
         }
 
         public void SetItemHue(int index, int hue)
         {
-            CraftItem craftItem = m_CraftItems.GetAt(index);
+            CraftItem craftItem = CraftItems.GetAt(index);
             craftItem.ItemHue = hue;
         }
 
         public void SetManaReq(int index, int mana)
         {
-            CraftItem craftItem = m_CraftItems.GetAt(index);
+            CraftItem craftItem = CraftItems.GetAt(index);
             craftItem.Mana = mana;
         }
 
         public void SetStamReq(int index, int stam)
         {
-            CraftItem craftItem = m_CraftItems.GetAt(index);
+            CraftItem craftItem = CraftItems.GetAt(index);
             craftItem.Stam = stam;
         }
 
         public void SetHitsReq(int index, int hits)
         {
-            CraftItem craftItem = m_CraftItems.GetAt(index);
+            CraftItem craftItem = CraftItems.GetAt(index);
             craftItem.Hits = hits;
         }
 
         public void SetUseAllRes(int index, bool useAll)
         {
-            CraftItem craftItem = m_CraftItems.GetAt(index);
+            CraftItem craftItem = CraftItems.GetAt(index);
             craftItem.UseAllRes = useAll;
         }
 
         public void SetForceTypeRes(int index, bool value)
         {
-            CraftItem craftItem = m_CraftItems.GetAt(index);
+            CraftItem craftItem = CraftItems.GetAt(index);
             craftItem.ForceTypeRes = value;
         }
 
         public void SetNeedHeat(int index, bool needHeat)
         {
-            CraftItem craftItem = m_CraftItems.GetAt(index);
+            CraftItem craftItem = CraftItems.GetAt(index);
             craftItem.NeedHeat = needHeat;
         }
 
         public void SetNeedOven(int index, bool needOven)
         {
-            CraftItem craftItem = m_CraftItems.GetAt(index);
+            CraftItem craftItem = CraftItems.GetAt(index);
             craftItem.NeedOven = needOven;
         }
 
         public void SetNeedMaker(int index, bool needMaker)
         {
-            CraftItem craftItem = m_CraftItems.GetAt(index);
+            CraftItem craftItem = CraftItems.GetAt(index);
             craftItem.NeedMaker = needMaker;
         }
 
         public void SetNeedWater(int index, bool needWater)
         {
-            CraftItem craftItem = m_CraftItems.GetAt(index);
+            CraftItem craftItem = CraftItems.GetAt(index);
             craftItem.NeedWater = needWater;
         }
 
         public void SetBeverageType(int index, BeverageType requiredBeverage)
         {
-            CraftItem craftItem = m_CraftItems.GetAt(index);
+            CraftItem craftItem = CraftItems.GetAt(index);
             craftItem.RequiredBeverage = requiredBeverage;
         }
 
         public void SetNeedMill(int index, bool needMill)
         {
-            CraftItem craftItem = m_CraftItems.GetAt(index);
+            CraftItem craftItem = CraftItems.GetAt(index);
             craftItem.NeedMill = needMill;
         }
 
         public void SetNeededThemePack(int index, ThemePack pack)
         {
-            CraftItem craftItem = m_CraftItems.GetAt(index);
+            CraftItem craftItem = CraftItems.GetAt(index);
             craftItem.RequiredThemePack = pack;
         }
 
         public void SetRequiresBasketWeaving(int index)
         {
-            CraftItem craftItem = m_CraftItems.GetAt(index);
+            CraftItem craftItem = CraftItems.GetAt(index);
             craftItem.RequiresBasketWeaving = true;
         }
 
         public void SetRequireResTarget(int index)
         {
-            CraftItem craftItem = m_CraftItems.GetAt(index);
+            CraftItem craftItem = CraftItems.GetAt(index);
             craftItem.RequiresResTarget = true;
         }
 
         public void SetRequiresMechanicalLife(int index)
         {
-            CraftItem craftItem = m_CraftItems.GetAt(index);
+            CraftItem craftItem = CraftItems.GetAt(index);
             craftItem.RequiresMechanicalLife = true;
         }
 
         public void SetData(int index, object data)
         {
-            CraftItem craftItem = m_CraftItems.GetAt(index);
+            CraftItem craftItem = CraftItems.GetAt(index);
             craftItem.Data = data;
         }
 
         public void SetDisplayID(int index, int id)
         {
-            CraftItem craftItem = m_CraftItems.GetAt(index);
+            CraftItem craftItem = CraftItems.GetAt(index);
             craftItem.DisplayID = id;
         }
 
@@ -427,13 +374,13 @@ namespace Server.Engines.Craft
         /// <param name="action"></param>
         public void SetMutateAction(int index, Action<Mobile, Item, ITool> action)
         {
-            CraftItem craftItem = m_CraftItems.GetAt(index);
+            CraftItem craftItem = CraftItems.GetAt(index);
             craftItem.MutateAction = action;
         }
 
         public void SetForceSuccess(int index, int success)
         {
-            CraftItem craftItem = m_CraftItems.GetAt(index);
+            CraftItem craftItem = CraftItems.GetAt(index);
             craftItem.ForceSuccessChance = success;
         }
 
@@ -444,134 +391,128 @@ namespace Server.Engines.Craft
 
         public void AddRes(int index, Type type, TextDefinition name, int amount, TextDefinition message)
         {
-            CraftItem craftItem = m_CraftItems.GetAt(index);
+            CraftItem craftItem = CraftItems.GetAt(index);
             craftItem.AddRes(type, name, amount, message);
         }
 
         public void AddResCallback(int index, Func<Mobile, ConsumeType, int> func)
         {
-            CraftItem craftItem = m_CraftItems.GetAt(index);
+            CraftItem craftItem = CraftItems.GetAt(index);
             craftItem.ConsumeResCallback = func;
         }
 
         public void AddSkill(int index, SkillName skillToMake, double minSkill, double maxSkill)
         {
-            CraftItem craftItem = m_CraftItems.GetAt(index);
+            CraftItem craftItem = CraftItems.GetAt(index);
             craftItem.AddSkill(skillToMake, minSkill, maxSkill);
         }
 
         public void SetUseSubRes2(int index, bool val)
         {
-            CraftItem craftItem = m_CraftItems.GetAt(index);
+            CraftItem craftItem = CraftItems.GetAt(index);
             craftItem.UseSubRes2 = val;
         }
 
         public void AddRecipe(int index, int id)
         {
-            CraftItem craftItem = m_CraftItems.GetAt(index);
+            CraftItem craftItem = CraftItems.GetAt(index);
             craftItem.AddRecipe(id, this);
         }
 
         public void ForceNonExceptional(int index)
         {
-            CraftItem craftItem = m_CraftItems.GetAt(index);
+            CraftItem craftItem = CraftItems.GetAt(index);
             craftItem.ForceNonExceptional = true;
         }
 
         public void ForceExceptional(int index)
         {
-            CraftItem craftItem = m_CraftItems.GetAt(index);
+            CraftItem craftItem = CraftItems.GetAt(index);
             craftItem.ForceExceptional = true;
         }
 
         public void SetMinSkillOffset(int index, double skillOffset)
         {
-            CraftItem craftItem = m_CraftItems.GetAt(index);
+            CraftItem craftItem = CraftItems.GetAt(index);
             craftItem.MinSkillOffset = skillOffset;
         }
 
         public void AddCraftAction(int index, Action<Mobile, CraftItem, ITool> action)
         {
-            CraftItem craftItem = m_CraftItems.GetAt(index);
+            CraftItem craftItem = CraftItems.GetAt(index);
             craftItem.TryCraft = action;
         }
 
         public void AddCreateItem(int index, Func<Mobile, CraftItem, ITool, Item> func)
         {
-            CraftItem craftItem = m_CraftItems.GetAt(index);
+            CraftItem craftItem = CraftItems.GetAt(index);
             craftItem.CreateItem = func;
         }
 
         public void SetSubRes(Type type, string name)
         {
-            m_CraftSubRes.ResType = type;
-            m_CraftSubRes.NameString = name;
-            m_CraftSubRes.Init = true;
+            CraftSubRes.ResType = type;
+            CraftSubRes.NameString = name;
+            CraftSubRes.Init = true;
         }
 
         public void SetSubRes(Type type, int name)
         {
-            m_CraftSubRes.ResType = type;
-            m_CraftSubRes.NameNumber = name;
-            m_CraftSubRes.Init = true;
+            CraftSubRes.ResType = type;
+            CraftSubRes.NameNumber = name;
+            CraftSubRes.Init = true;
         }
 
         public void AddSubRes(Type type, int name, double reqSkill, object message)
         {
             CraftSubRes craftSubRes = new CraftSubRes(type, name, reqSkill, message);
-            m_CraftSubRes.Add(craftSubRes);
+            CraftSubRes.Add(craftSubRes);
         }
 
         public void AddSubRes(Type type, int name, double reqSkill, int genericName, object message)
         {
             CraftSubRes craftSubRes = new CraftSubRes(type, name, reqSkill, genericName, message);
-            m_CraftSubRes.Add(craftSubRes);
+            CraftSubRes.Add(craftSubRes);
         }
 
         public void AddSubRes(Type type, string name, double reqSkill, object message)
         {
             CraftSubRes craftSubRes = new CraftSubRes(type, name, reqSkill, message);
-            m_CraftSubRes.Add(craftSubRes);
+            CraftSubRes.Add(craftSubRes);
         }
 
         public void SetSubRes2(Type type, string name)
         {
-            m_CraftSubRes2.ResType = type;
-            m_CraftSubRes2.NameString = name;
-            m_CraftSubRes2.Init = true;
+            CraftSubRes2.ResType = type;
+            CraftSubRes2.NameString = name;
+            CraftSubRes2.Init = true;
         }
 
         public void SetSubRes2(Type type, int name)
         {
-            m_CraftSubRes2.ResType = type;
-            m_CraftSubRes2.NameNumber = name;
-            m_CraftSubRes2.Init = true;
+            CraftSubRes2.ResType = type;
+            CraftSubRes2.NameNumber = name;
+            CraftSubRes2.Init = true;
         }
 
         public void AddSubRes2(Type type, int name, double reqSkill, object message)
         {
             CraftSubRes craftSubRes = new CraftSubRes(type, name, reqSkill, message);
-            m_CraftSubRes2.Add(craftSubRes);
+            CraftSubRes2.Add(craftSubRes);
         }
 
         public void AddSubRes2(Type type, int name, double reqSkill, int genericName, object message)
         {
             CraftSubRes craftSubRes = new CraftSubRes(type, name, reqSkill, genericName, message);
-            m_CraftSubRes2.Add(craftSubRes);
+            CraftSubRes2.Add(craftSubRes);
         }
 
         public void AddSubRes2(Type type, string name, double reqSkill, object message)
         {
             CraftSubRes craftSubRes = new CraftSubRes(type, name, reqSkill, message);
-            m_CraftSubRes2.Add(craftSubRes);
-        }
+            CraftSubRes2.Add(craftSubRes);
+        } 
+        #endregion
 
-        public abstract void InitCraftList();
-
-        public abstract void PlayCraftEffect(Mobile from);
-
-        public abstract int PlayEndingEffect(Mobile from, bool failed, bool lostMaterial, bool toolBroken, int quality, bool makersMark, CraftItem item);
-
-        public abstract int CanCraft(Mobile from, ITool tool, Type itemType);
     }
 }

--- a/Scripts/Services/Craft/DefTailoring.cs
+++ b/Scripts/Services/Craft/DefTailoring.cs
@@ -63,10 +63,21 @@ namespace Server.Engines.Craft
 
     public class DefTailoring : CraftSystem
     {
-        public override SkillName MainSkill => SkillName.Tailoring;
+        #region Statics
+        private static readonly Type[] m_TailorColorables = new Type[]
+   {
+            typeof(GozaMatEastDeed), typeof(GozaMatSouthDeed),
+            typeof(SquareGozaMatEastDeed), typeof(SquareGozaMatSouthDeed),
+            typeof(BrocadeGozaMatEastDeed), typeof(BrocadeGozaMatSouthDeed),
+            typeof(BrocadeSquareGozaMatEastDeed), typeof(BrocadeSquareGozaMatSouthDeed)
+   };
 
-        public override int GumpTitleNumber => 1044005;
+        private static readonly Type[] m_TailorClothNonColorables = new Type[]
+        {
+            typeof(DeerMask), typeof(BearMask), typeof(OrcMask), typeof(TribalMask), typeof(HornedTribalMask)
+        };
 
+        // singleton instance
         private static CraftSystem m_CraftSystem;
 
         public static CraftSystem CraftSystem
@@ -79,6 +90,20 @@ namespace Server.Engines.Craft
                 return m_CraftSystem;
             }
         }
+        #endregion
+
+        #region Constructor
+        private DefTailoring()
+            : base(1, 1, 1.25)// base( 1, 1, 4.5 )
+        {
+        }
+
+        #endregion
+
+        #region Overrides
+        public override SkillName MainSkill => SkillName.Tailoring;
+
+        public override int GumpTitleNumber => 1044005;
 
         public override CraftECA ECA => CraftECA.ChanceMinusSixtyToFourtyFive;
 
@@ -89,11 +114,6 @@ namespace Server.Engines.Craft
                 return 0.05; // 5%
 
             return 0.5; // 50%
-        }
-
-        private DefTailoring()
-            : base(1, 1, 1.25)// base( 1, 1, 4.5 )
-        {
         }
 
         public override int CanCraft(Mobile from, ITool tool, Type itemType)
@@ -108,14 +128,6 @@ namespace Server.Engines.Craft
             return 0;
         }
 
-        private static readonly Type[] m_TailorColorables = new Type[]
-        {
-            typeof(GozaMatEastDeed), typeof(GozaMatSouthDeed),
-            typeof(SquareGozaMatEastDeed), typeof(SquareGozaMatSouthDeed),
-            typeof(BrocadeGozaMatEastDeed), typeof(BrocadeGozaMatSouthDeed),
-            typeof(BrocadeSquareGozaMatEastDeed), typeof(BrocadeSquareGozaMatSouthDeed)
-        };
-
         public override bool RetainsColorFrom(CraftItem item, Type type)
         {
             if (type != typeof(Cloth) && type != typeof(UncutCloth) && type != typeof(AbyssalCloth))
@@ -127,6 +139,22 @@ namespace Server.Engines.Craft
 
             for (int i = 0; !contains && i < m_TailorColorables.Length; ++i)
                 contains = (m_TailorColorables[i] == type);
+
+            return contains;
+        }
+
+        public override bool RetainsColorFromException(CraftItem item, Type type)
+        {
+            if (item == null || type == null)
+                return false;
+
+            if (type != typeof(Cloth) && type != typeof(UncutCloth) && type != typeof(AbyssalCloth))
+                return false;
+
+            bool contains = false;
+
+            for (int i = 0; !contains && i < m_TailorClothNonColorables.Length; ++i)
+                contains = (m_TailorClothNonColorables[i] == item.ItemType);
 
             return contains;
         }
@@ -685,7 +713,8 @@ namespace Server.Engines.Craft
             Repair = true;
             CanEnhance = true;
             CanAlter = true;
-        }
+        } 
+        #endregion
 
         private void CutUpCloth(Mobile m, CraftItem craftItem, ITool tool)
         {


### PR DESCRIPTION
Fixed issue with Tailor Gump showing Retains Color message for items that did not
Code cleanup and organization

I should have done this as two commits to make the actual code changes more obvious as most of it is just organization of the code.

I ended up adding a virtual method in CraftSystem and then overrode that in DefTailoring to handle the exceptions of Cloth items that do not retain color.  The original code was not designed with a "one line" fix option so I figured this was the most elegant way of getting it fixed.