### PR TITLE
Fix for Crash when using Mannequin function

### DIFF
--- a/Scripts/Mobiles/NPCs/Mannequin/Mannequin.cs
+++ b/Scripts/Mobiles/NPCs/Mannequin/Mannequin.cs
@@ -321,7 +321,14 @@ namespace Server.Mobiles
 
                 protected override void OnTarget(Mobile from, object targeted)
                 {
-                    from.SendGump(new MannequinCompareGump(_Mannequin, (Item)targeted));
+                    if (targeted is Item)
+                        from.SendGump(new MannequinCompareGump(_Mannequin, (Item)targeted));
+                    else
+                    {
+                        // TODO : Action
+                        // This was a temporary crash fix
+                    }
+
                 }
             }
         }


### PR DESCRIPTION
Fix for Crash when using Mannequin function "Compare Item with Slot Item"