### PR TITLE
Fix to prevent RecipeBook from becoming unusable

### DIFF
--- a/Scripts/Items/Books/SpecialScrollBooks/RecipeBook/RecipeBookGump.cs
+++ b/Scripts/Items/Books/SpecialScrollBooks/RecipeBook/RecipeBookGump.cs
@@ -465,6 +465,7 @@ namespace Server.Items
                             {
                                 from.Prompt = new SetPricePrompt(m_Book, recipe, m_Page, m_List);
                                 from.SendLocalizedMessage(1062383); // Type in a price for the deed:
+                                m_Book.Using = false;
                             }
                             else if (m_Book.RootParent is PlayerVendor)
                             {


### PR DESCRIPTION
Discovered when canceling a prompt for setting the price of a recipe, the book becomes unusable and stuck in a "the book is in use" message when trying to open it again.  The book becomes unusable at that point.