### PR TITLE
Revert GC

### DIFF
--- a/ServUO.exe.config
+++ b/ServUO.exe.config
@@ -1,9 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-	<startup>
-		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
-	</startup>
-	<runtime>
-		<gcServer enabled="true" />
-	</runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>


### PR DESCRIPTION
With GC enabled server memory usage spiked to 1.4gb. Once shut off it dropped below 650mb again.

This is something that needs to be looked into more before defaulting it to on for production shards.