### PR TITLE
Only boat owners can refresh a boats decay timer

### DIFF
--- a/Scripts/Multis/Boats/BaseBoat.cs
+++ b/Scripts/Multis/Boats/BaseBoat.cs
@@ -3146,7 +3146,8 @@ namespace Server.Multis
 
         public void Refresh(Mobile from = null)
         {
-            // DJR - Shouldn't this only be for the owner of the boat?
+            if (from != null && from.Account != Owner.Account)
+                return;
 
             if (from != null && Status > 1043010)
             {

--- a/Scripts/Multis/Boats/Plank.cs
+++ b/Scripts/Multis/Boats/Plank.cs
@@ -273,7 +273,7 @@ namespace Server.Items
             if (Boat == null)
                 return;
 
-            Boat.Refresh();
+            Boat.Refresh(from);
 
             if (BaseBoat.IsDriving(from))
             {


### PR DESCRIPTION
Code was in place from BaseGalleon to send the mobile clicking on mooring line, I had to add the mobile clicking on the BaseBoat Plank object (plank.cs) to the call.  

Its a simple return out of the method if the mobile is not the owner.