### PR TITLE
Clean Up

### DIFF
--- a/Scripts/Accounting/AccountHandler.cs
+++ b/Scripts/Accounting/AccountHandler.cs
@@ -30,33 +30,7 @@ namespace Server.Misc
         private static readonly bool RestrictDeletion = Config.Get("Accounts.RestrictDeletion", !TestCenter.Enabled);
         private static readonly TimeSpan DeleteDelay = Config.Get("Accounts.DeleteDelay", TimeSpan.FromDays(7.0));
 
-        private static readonly CityInfo[] StartingCitiesT2A = new CityInfo[]
-        {
-            new CityInfo("New Haven",   "New Haven Bank",   1150168, 3503,  2574,   14, Map.Felucca),
-            new CityInfo("Yew", "The Empath Abbey", 1075072, 633,   858,    0, Map.Felucca),
-            new CityInfo("Minoc", "The Barnacle", 1075073, 2476,    413,    15, Map.Felucca),
-            new CityInfo("Britain", "The Wayfarer's Inn",   1075074, 1602,  1591,   20, Map.Felucca),
-            new CityInfo("Moonglow",    "The Scholars Inn", 1075075, 4408,  1168,   0, Map.Felucca),
-            new CityInfo("Trinsic", "The Traveler's Inn",   1075076, 1845,  2745,   0, Map.Felucca),
-            new CityInfo("Jhelom", "The Mercenary Inn", 1075078, 1374,  3826,   0, Map.Felucca),
-            new CityInfo("Skara Brae",  "The Falconer's Inn",   1075079, 618,   2234,   0, Map.Felucca),
-            new CityInfo("Vesper", "The Ironwood Inn",  1075080, 2771,  976,    0, Map.Felucca)
-        };
-
         private static readonly CityInfo[] StartingCities = new CityInfo[]
-        {
-            new CityInfo("New Haven",   "New Haven Bank",   1150168, 3503,  2574,   14),
-            new CityInfo("Yew", "The Empath Abbey", 1075072, 633,   858,    0),
-            new CityInfo("Minoc", "The Barnacle", 1075073, 2476,    413,    15),
-            new CityInfo("Britain", "The Wayfarer's Inn",   1075074, 1602,  1591,   20),
-            new CityInfo("Moonglow",    "The Scholars Inn", 1075075, 4408,  1168,   0),
-            new CityInfo("Trinsic", "The Traveler's Inn",   1075076, 1845,  2745,   0),
-            new CityInfo("Jhelom", "The Mercenary Inn", 1075078, 1374,  3826,   0),
-            new CityInfo("Skara Brae",  "The Falconer's Inn",   1075079, 618,   2234,   0),
-            new CityInfo("Vesper", "The Ironwood Inn",  1075080, 2771,  976,    0)
-        };
-
-        private static readonly CityInfo[] StartingCitiesSA = new CityInfo[]
         {
             new CityInfo("New Haven",   "New Haven Bank",   1150168, 3503,  2574,   14),
             new CityInfo("Yew", "The Empath Abbey", 1075072, 633,   858,    0),
@@ -377,7 +351,7 @@ namespace Server.Misc
                 }
                 else
                 {
-                    e.CityInfo = StartingCitiesSA;
+                    e.CityInfo = StartingCities;
                 }
             }
 

--- a/Scripts/Misc/CharacterCreation.cs
+++ b/Scripts/Misc/CharacterCreation.cs
@@ -10,23 +10,6 @@ namespace Server.Misc
 {
     public class CharacterCreation
     {
-        private static readonly CityInfo m_NewHavenInfo = new CityInfo(
-            "New Haven",
-            "The Bountiful Harvest Inn",
-            3503,
-            2574,
-            14,
-            Map.Trammel);
-
-        private static readonly CityInfo m_SiegeInfo = new CityInfo(
-            "Britain",
-            "The Wayfarer's Inn",
-            1075074,
-            1602,
-            1591,
-            20,
-            Map.Felucca);
-
         private static Mobile m_Mobile;
 
         public static void Initialize()


### PR DESCRIPTION
Removed old, unused, default starting locations in CharacterCreation.cs (they are never called)

Removed "era" based StartingCities and renamed StartingCitiesSA to StartingCities.