### PR TITLE
Cleanup

### DIFF
--- a/Scripts/Multis/Houses/BaseHouse.cs
+++ b/Scripts/Multis/Houses/BaseHouse.cs
@@ -3331,36 +3331,7 @@ namespace Server.Multis
                     }
                 case 0:
                     {
-                        if (version < 17)
-                            Carpets = new List<Item>();
-
-                        if (version < 14)
-                            m_RelativeBanLocation = BaseBanLocation;
-
-                        if (version < 12)
-                        {
-                            VendorRentalContracts = new List<Item>();
-                            InternalizedVendors = new List<Mobile>();
-                        }
-
-                        if (version < 4)
-                            Addons = new Dictionary<Item, Mobile>();
-
-                        if (version < 7)
-                            Access = new List<Mobile>();
-
-                        if (version < 8)
-                            Price = DefaultPrice;
-
                         m_Owner = reader.ReadMobile();
-
-                        if (version < 5)
-                        {
-                            count = reader.ReadInt();
-
-                            for (int i = 0; i < count; i++)
-                                reader.ReadRect2D();
-                        }
 
                         UpdateRegion();
 
@@ -3404,23 +3375,6 @@ namespace Server.Multis
                         for (int i = 0; i < VendorRentalContracts.Count; ++i)
                             VendorRentalContracts[i].IsLockedDown = true;
 
-                        if (version < 3)
-                        {
-                            List<Item> items = reader.ReadStrongItemList();
-                            Secures = new List<SecureInfo>(items.Count);
-
-                            for (int i = 0; i < items.Count; ++i)
-                            {
-                                Container c = items[i] as Container;
-
-                                if (c != null)
-                                {
-                                    c.IsSecure = true;
-                                    Secures.Add(new SecureInfo(c, SecureLevel.CoOwners, Owner));
-                                }
-                            }
-                        }
-
                         MaxLockDowns = reader.ReadInt();
                         MaxSecures = reader.ReadInt();
 
@@ -3441,21 +3395,6 @@ namespace Server.Multis
                     }
             }
 
-            if (version <= 1)
-                ChangeSignType(0xBD2);//private house, plain brass sign
-
-            if (version < 10)
-            {
-                /* NOTE: This can exceed the house lockdown limit. It must be this way, because
-                * we do not want players' items to decay without them knowing. Or not even
-                * having a chance to fix it themselves.
-                */
-                Timer.DelayCall(TimeSpan.Zero, FixLockdowns_Sandbox);
-            }
-
-            if (version < 11)
-                LastRefreshed = DateTime.UtcNow + TimeSpan.FromHours(24 * Utility.RandomDouble());
-
             if (DynamicDecay.Enabled && !loadedDynamicDecay)
             {
                 DecayLevel old = GetOldDecayLevel();
@@ -3473,16 +3412,6 @@ namespace Server.Multis
 
                 //if (m_Owner == null && m_Friends.Count == 0 && m_CoOwners.Count == 0)
                 //    Timer.DelayCall(TimeSpan.FromSeconds(10.0), new TimerCallback(Delete));
-            }
-
-            if (version == 19)
-            {
-                Timer.DelayCall(CheckUnregisteredAddons);
-            }
-
-            if (version < 23)
-            {
-                Timer.DelayCall(FixRentalContracts);
             }
         }
 
@@ -4200,8 +4129,6 @@ namespace Server.Multis
         public virtual int ConvertOffsetX => 0;
         public virtual int ConvertOffsetY => 0;
         public virtual int ConvertOffsetZ => 0;
-
-        public virtual int DefaultPrice => 0;
 
         [CommandProperty(AccessLevel.GameMaster)]
         public int Price { get; set; }

--- a/Scripts/Multis/Houses/HouseFoundation.cs
+++ b/Scripts/Multis/Houses/HouseFoundation.cs
@@ -695,10 +695,6 @@ namespace Server.Multis
             base.Serialize(writer);
         }
 
-        private int m_DefaultPrice;
-
-        public override int DefaultPrice => m_DefaultPrice;
-
         public override void Deserialize(GenericReader reader)
         {
             int version = reader.ReadInt();
@@ -726,20 +722,8 @@ namespace Server.Multis
                         goto case 1;
                     }
                 case 1:
-                    {
-                        if (version < 5)
-                            m_DefaultPrice = reader.ReadInt();
-
-                        goto case 0;
-                    }
                 case 0:
-                    {
-                        if (version < 3)
-                            Type = FoundationType.Stone;
-
-                        if (version < 4)
-                            SignpostGraphic = 9;
-
+                    {                       
                         LastRevision = reader.ReadInt();
                         Fixtures = reader.ReadStrongItemList();
 

--- a/Scripts/Multis/Houses/Houses.cs
+++ b/Scripts/Multis/Houses/Houses.cs
@@ -23,7 +23,6 @@ namespace Server.Multis
 
         public override Rectangle2D[] Area => AreaArray;
         public override Point3D BaseBanLocation => new Point3D(2, 4, 0);
-        public override int DefaultPrice => 43800;
         public override HousePlacementEntry ConvertEntry => HousePlacementEntry.TwoStoryFoundations[0];
         public override HouseDeed GetDeed()
         {
@@ -79,7 +78,6 @@ namespace Server.Multis
         {
         }
 
-        public override int DefaultPrice => 144500;
         public override HousePlacementEntry ConvertEntry => HousePlacementEntry.ThreeStoryFoundations[20];
         public override int ConvertOffsetX => -1;
         public override int ConvertOffsetY => -1;
@@ -126,7 +124,6 @@ namespace Server.Multis
 
         public override Rectangle2D[] Area => AreaArray;
         public override Point3D BaseBanLocation => new Point3D(2, 8, 0);
-        public override int DefaultPrice => 192400;
         public override HouseDeed GetDeed()
         {
             switch (ItemID)
@@ -174,7 +171,6 @@ namespace Server.Multis
         {
         }
 
-        public override int DefaultPrice => 433200;
         public override HousePlacementEntry ConvertEntry => HousePlacementEntry.ThreeStoryFoundations[37];
         public override int ConvertOffsetY => -1;
         public override Rectangle2D[] Area => AreaArray;
@@ -215,7 +211,6 @@ namespace Server.Multis
         {
         }
 
-        public override int DefaultPrice => 665200;
         public override Rectangle2D[] Area => AreaArray;
         public override Point3D BaseBanLocation => new Point3D(5, 13, 0);
         public override HouseDeed GetDeed()
@@ -258,7 +253,6 @@ namespace Server.Multis
         {
         }
 
-        public override int DefaultPrice => 1022800;
         public override Rectangle2D[] Area => AreaArray;
         public override Point3D BaseBanLocation => new Point3D(5, 17, 0);
 
@@ -307,7 +301,6 @@ namespace Server.Multis
         {
         }
 
-        public override int DefaultPrice => 152800;
         public override HousePlacementEntry ConvertEntry => HousePlacementEntry.ThreeStoryFoundations[29];
         public override int ConvertOffsetY => -1;
         public override Rectangle2D[] Area => AreaArray;
@@ -348,7 +341,6 @@ namespace Server.Multis
         {
         }
 
-        public override int DefaultPrice => 192000;
         public override HousePlacementEntry ConvertEntry => HousePlacementEntry.ThreeStoryFoundations[29];
         public override int ConvertOffsetY => -1;
         public override Rectangle2D[] Area => AreaArray;
@@ -389,7 +381,6 @@ namespace Server.Multis
         {
         }
 
-        public override int DefaultPrice => 88500;
         public override HousePlacementEntry ConvertEntry => HousePlacementEntry.TwoStoryFoundations[6];
         public override Rectangle2D[] Area => AreaArray;
         public override Point3D BaseBanLocation => new Point3D(1, 4, 0);
@@ -431,7 +422,6 @@ namespace Server.Multis
         {
         }
 
-        public override int DefaultPrice => 97800;
         public override HousePlacementEntry ConvertEntry => HousePlacementEntry.TwoStoryFoundations[12];
         public override Rectangle2D[] Area => AreaArray;
         public override Point3D BaseBanLocation => new Point3D(5, 8, 0);
@@ -471,7 +461,6 @@ namespace Server.Multis
         {
         }
 
-        public override int DefaultPrice => 90900;
         public override HousePlacementEntry ConvertEntry => HousePlacementEntry.TwoStoryFoundations[35];
         public override int ConvertOffsetY => -1;
         public override Rectangle2D[] Area => AreaArray;
@@ -515,7 +504,6 @@ namespace Server.Multis
         {
         }
 
-        public override int DefaultPrice => 136500;
         public override HousePlacementEntry ConvertEntry => HousePlacementEntry.TwoStoryFoundations[31];
         public override Rectangle2D[] Area => AreaArray;
         public override Point3D BaseBanLocation => new Point3D(3, 8, 0);
@@ -567,7 +555,6 @@ namespace Server.Multis
 
         public override Rectangle2D[] Area => (ItemID == 0x40A2 ? AreaArray1 : AreaArray2);
         public override Point3D BaseBanLocation => new Point3D(3, 4, 0);
-        public override int DefaultPrice => 63000;
         public override HousePlacementEntry ConvertEntry => HousePlacementEntry.TwoStoryFoundations[0];
         public override HouseDeed GetDeed()
         {

--- a/Scripts/Multis/Houses/PreviewHouse.cs
+++ b/Scripts/Multis/Houses/PreviewHouse.cs
@@ -81,7 +81,6 @@ namespace Server.Multis
             }
         }
 
-
         public PreviewHouse(Serial serial)
             : base(serial)
         {

--- a/ServUO.exe.config
+++ b/ServUO.exe.config
@@ -1,9 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-	<startup>
-		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
-	</startup>
-	<runtime>
-		<gcServer enabled="true" />
-	</runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>


### PR DESCRIPTION
Removed unused DefaultPrice from Houses.cs This was used in RunUO 1.0 to find house prices.

Cleaned up some ser/deser from decades ago. Tested on Heritage.