### PR TITLE
Bug Fix

### DIFF
--- a/Scripts/Items/Equipment/Weapons/Bow.cs
+++ b/Scripts/Items/Equipment/Weapons/Bow.cs
@@ -32,6 +32,7 @@ namespace Server.Items
         public override int InitMinHits => 31;
         public override int InitMaxHits => 60;
         public override WeaponAnimation DefAnimation => WeaponAnimation.ShootBow;
+		
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/JukaBow.cs
+++ b/Scripts/Items/Equipment/Weapons/JukaBow.cs
@@ -5,16 +5,16 @@ namespace Server.Items
     {
         [Constructable]
         public JukaBow()
-        { }
+        { 
+		}
 
         public JukaBow(Serial serial)
             : base(serial)
-        { }
+        { 
+		}
 
         [CommandProperty(AccessLevel.GameMaster)]
         public bool IsModified => Slayer != SlayerName.None;
-        public override int StrengthReq => 80;
-        public override int DexterityReq => 80;
 
         public override bool CanEquip(Mobile from)
         {
@@ -54,7 +54,7 @@ namespace Server.Items
 
             if (g == null || !g.IsChildOf(from.Backpack))
             {
-                from.SendMessage("Those are not gears."); // Apparently gears that aren't in your backpack aren't really gears at all. :-(
+                from.SendMessage("Those are not gears."); 
             }
             else if (IsModified)
             {


### PR DESCRIPTION
- Confirmed on EA
- Juka bows do not have a dex requirement.
- Juka bows have the same str requirement as normal bows. It is no longer 80.