### PR TITLE
Starting to remove:

### DIFF
--- a/Scripts/Services/Help/HelpGump.cs
+++ b/Scripts/Services/Help/HelpGump.cs
@@ -210,7 +210,7 @@ namespace Server.Engines.Help
                         {
                             from.SendLocalizedMessage(1114345, "", 0x35); // You'll need a better jailbreak plan than that!
                         }
-                        else if (from.CanUseStuckMenu() && from.Region.CanUseStuckMenu(from) && !CheckCombat(from) && !from.Frozen && !from.Criminal)
+                        else if (from.Region.CanUseStuckMenu(from) && !CheckCombat(from) && !from.Frozen && !from.Criminal)
                         {
                             StuckMenu menu = new StuckMenu(from, from, true);
 

--- a/Scripts/Services/Help/StuckMenu.cs
+++ b/Scripts/Services/Help/StuckMenu.cs
@@ -227,8 +227,6 @@ namespace Server.Menus.Questions
                 m_Mobile.SendLocalizedMessage(1010589); // You will be teleported within the next two minutes.
 
                 new TeleportTimer(m_Mobile, entry, TimeSpan.FromSeconds(10.0 + (Utility.RandomDouble() * 110.0))).Start();
-
-                m_Mobile.UsedStuckMenu();
             }
             else
             {

--- a/Server/Mobile.cs
+++ b/Server/Mobile.cs
@@ -3542,26 +3542,6 @@ namespace Server
             Region.OnCriminalAction(this, message);
         }
 
-        public virtual bool CanUseStuckMenu()
-        {
-            if (m_StuckMenuUses == null)
-            {
-                return true;
-            }
-            else
-            {
-                for (int i = 0; i < m_StuckMenuUses.Length; ++i)
-                {
-                    if ((DateTime.UtcNow - m_StuckMenuUses[i]) > TimeSpan.FromDays(1.0))
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
-            }
-        }
-
         public virtual bool IsPlayer()
         {
             return AccessLevel == AccessLevel.Player;
@@ -5635,23 +5615,6 @@ namespace Server
 
         public virtual void OnHeal(ref int amount, Mobile from)
         { }
-
-        public void UsedStuckMenu()
-        {
-            if (m_StuckMenuUses == null)
-            {
-                m_StuckMenuUses = new DateTime[2];
-            }
-
-            for (int i = 0; i < m_StuckMenuUses.Length; ++i)
-            {
-                if ((DateTime.UtcNow - m_StuckMenuUses[i]) > TimeSpan.FromDays(1.0))
-                {
-                    m_StuckMenuUses[i] = DateTime.UtcNow;
-                    return;
-                }
-            }
-        }
 
         [CommandProperty(AccessLevel.GameMaster)]
         public bool Squelched { get { return m_Squelched; } set { m_Squelched = value; } }


### PR DESCRIPTION
- On EA UO there is no longer a "limit" on how many times you can use the stuck menu timer in a 24 hour period.
- It simply takes longer.

- Also this should probably not have been added in the core anyways as only PlayerMobiles will never use the Help stuck menu.

- I did not mess with the ser/deser of mobile.cs. There also seems to be duplicate code in Mobile and StuckMenu.cs in regards to the timers and such. If you do not mind taking a look @dexter