### PR TITLE
Changes/Fixes

### DIFF
--- a/Scripts/Commands/GenerateGameDocs.cs
+++ b/Scripts/Commands/GenerateGameDocs.cs
@@ -77,7 +77,7 @@ namespace Server.Commands
             csv.AddValue("Dex Requirement", wep.DexRequirement);
             csv.AddValue("Int Requirement", wep.IntRequirement);
             csv.AddValue("Skill", wep.Skill);
-            csv.AddValue("Race", wep.RequiredRace);
+            //csv.AddValue("Race", wep.RequiredRace);
             csv.AddValue("Speed", wep.Speed);
             csv.AddValue("Min Damage", wep.MinDamage);
             csv.AddValue("Max Damage", wep.MaxDamage);

--- a/Scripts/Items/Artifacts/Equipment/Armor/CrownOfArcaneTemperament.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/CrownOfArcaneTemperament.cs
@@ -1,10 +1,10 @@
 namespace Server.Items
 {
-    public class CrownOfArcaneTemperament : Circlet
+    public class CrownOfArcaneTemperament : Circlet, ICanBeElfOrHuman
     {
         public override bool IsArtifact => true;
+        public bool ElfOnly { get { return false; } set { } }
 
-        public override Race RequiredRace => null;
         public override int LabelNumber => 1113762;  // Crown of Arcane Temperament
 
         [Constructable]

--- a/Scripts/Items/Artifacts/Equipment/Armor/FeyLeggings.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/FeyLeggings.cs
@@ -5,7 +5,6 @@ namespace Server.Items
         public override bool IsArtifact => true;
 
         private bool _ElfOnly;
-        public override Race RequiredRace => _ElfOnly ? Race.Elf : null;
 
         [CommandProperty(AccessLevel.GameMaster)]
         public bool ElfOnly { get { return _ElfOnly; } set { _ElfOnly = value; InvalidateProperties(); } }

--- a/Scripts/Items/Artifacts/Equipment/Armor/GargishWoodenShield.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/GargishWoodenShield.cs
@@ -24,8 +24,7 @@ namespace Server.Items
         public override int InitMinHits => 20;
         public override int InitMaxHits => 25;
         public override int StrReq => 20;
-        public override bool CanBeWornByGargoyles => true;
-        public override Race RequiredRace => Race.Gargoyle;
+
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);

--- a/Scripts/Items/Artifacts/Equipment/Armor/GlovesOfMining.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/GlovesOfMining.cs
@@ -124,9 +124,6 @@ namespace Server.Items
     [FlipableAttribute(0x13eb, 0x13f2)]
     public class GargishKiltOfMining : BaseGlovesOfMining
     {
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         [Constructable]
         public GargishKiltOfMining() : this(5)
         {

--- a/Scripts/Items/Artifacts/Equipment/Armor/HelmOfSwiftness.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/HelmOfSwiftness.cs
@@ -5,7 +5,6 @@ namespace Server.Items
         public override bool IsArtifact => true;
 
         private bool _ElfOnly;
-        public override Race RequiredRace => _ElfOnly ? Race.Elf : null;
 
         [CommandProperty(AccessLevel.GameMaster)]
         public bool ElfOnly { get { return _ElfOnly; } set { _ElfOnly = value; InvalidateProperties(); } }

--- a/Scripts/Items/Artifacts/Equipment/Clothing/ConjurersGarb.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/ConjurersGarb.cs
@@ -3,7 +3,6 @@ namespace Server.Items
     [Flipable(0x1F03, 0x1F04)]
     public class ConjureresGarb : BaseOuterTorso
     {
-        public override bool CanBeWornByGargoyles => true;
         public override bool IsArtifact => true;
         public override int LabelNumber => 1114052; // Conjurer's Garb
 

--- a/Scripts/Items/Artifacts/Equipment/Clothing/ConjurersGarbHarbringer.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/ConjurersGarbHarbringer.cs
@@ -3,7 +3,6 @@ namespace Server.Items
     [Flipable(0x1F03, 0x1F04)]
     public class ConjureresGarbHarbringer : BaseOuterTorso
     {
-        public override bool CanBeWornByGargoyles => true;
         public override bool IsArtifact => true;
         public override int LabelNumber => 1114052; // Conjurer's Garb
 

--- a/Scripts/Items/Artifacts/Equipment/Clothing/MysticsGarb.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/MysticsGarb.cs
@@ -22,8 +22,7 @@ namespace Server.Items
 
         public override int InitMinHits => 255;
         public override int InitMaxHits => 255;
-        public override bool CanBeWornByGargoyles => true;
-        public override Race RequiredRace => Race.Gargoyle;
+
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Artifacts/Equipment/Clothing/RobeOfTheEclipse.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/RobeOfTheEclipse.cs
@@ -3,7 +3,6 @@ namespace Server.Items
     [Flipable(0x1F03, 0x1F04)]
     public class RobeOfTheEclipse : BaseOuterTorso
     {
-        public override bool CanBeWornByGargoyles => true;
         public override bool IsArtifact => true;
 
         [Constructable]

--- a/Scripts/Items/Artifacts/Equipment/Clothing/RobeOfTheEquinox.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/RobeOfTheEquinox.cs
@@ -6,7 +6,6 @@ namespace Server.Items
         public override bool IsArtifact => true;
 
         private bool _ElfOnly;
-        public override Race RequiredRace => _ElfOnly ? Race.Elf : null;
 
         [CommandProperty(AccessLevel.GameMaster)]
         public bool ElfOnly { get { return _ElfOnly; } set { _ElfOnly = value; InvalidateProperties(); } }

--- a/Scripts/Items/Artifacts/Equipment/Clothing/RunedSashOfWarding.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/RunedSashOfWarding.cs
@@ -1,4 +1,4 @@
-﻿using Server.Engines.Craft;
+using Server.Engines.Craft;
 using System;
 using System.Collections.Generic;
 
@@ -138,9 +138,6 @@ namespace Server.Items
 
     public class GargishRunedSashOfWarding : RunedSashOfWarding
     {
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         [Constructable]
         public GargishRunedSashOfWarding()
         {

--- a/Scripts/Items/Artifacts/Equipment/Clothing/ShroudOfTheCondemned.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/ShroudOfTheCondemned.cs
@@ -4,7 +4,6 @@ namespace Server.Items
     public class ShroudOfTheCondemned : BaseOuterTorso
     {
         public override bool IsArtifact => true;
-        public override bool CanBeWornByGargoyles => true;
 
         public override int LabelNumber => 1113703;  // Shroud of the Condemned
 

--- a/Scripts/Items/Artifacts/Equipment/Glasses/GargishGlasses.cs
+++ b/Scripts/Items/Artifacts/Equipment/Glasses/GargishGlasses.cs
@@ -7,9 +7,6 @@ namespace Server.Items
     {
         public CraftSystem RepairSystem => DefTinkering.CraftSystem;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         [Constructable]
         public GargishGlasses()
             : base(0x4644)

--- a/Scripts/Items/Artifacts/Equipment/Jewelry/DragonJadeEarrings.cs
+++ b/Scripts/Items/Artifacts/Equipment/Jewelry/DragonJadeEarrings.cs
@@ -30,8 +30,7 @@ namespace Server.Items
 
         public override int InitMinHits => 255;
         public override int InitMaxHits => 255;
-        public override bool CanBeWornByGargoyles => true;
-        public override Race RequiredRace => Race.Gargoyle;
+
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Artifacts/Equipment/Jewelry/ObsidianEarrings.cs
+++ b/Scripts/Items/Artifacts/Equipment/Jewelry/ObsidianEarrings.cs
@@ -28,8 +28,7 @@ namespace Server.Items
 
         public override int InitMinHits => 255;
         public override int InitMaxHits => 255;
-        public override bool CanBeWornByGargoyles => true;
-        public override Race RequiredRace => Race.Gargoyle;
+
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Artifacts/Equipment/Jewelry/TorcOfTheGuardians.cs
+++ b/Scripts/Items/Artifacts/Equipment/Jewelry/TorcOfTheGuardians.cs
@@ -29,8 +29,7 @@ namespace Server.Items
 
         public override int InitMinHits => 255;
         public override int InitMaxHits => 255;
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
+
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Artifacts/Equipment/Weapons/InfusedGlassStave.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/InfusedGlassStave.cs
@@ -27,8 +27,7 @@ namespace Server.Items
 
         public override int InitMinHits => 31;
         public override int InitMaxHits => 70;
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
+
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Consumables/GorgonLens.cs
+++ b/Scripts/Items/Consumables/GorgonLens.cs
@@ -65,7 +65,7 @@ namespace Server.Items
                 else if (targeted is BaseArmor)
                 {
                     BaseArmor armor = (BaseArmor)targeted;
-                    if (armor.Layer == Layer.Neck || armor.Layer == Layer.Helm || armor is BaseShield || (armor.RequiredRace == Race.Gargoyle && armor.Layer == Layer.Earrings))
+                    if (armor.Layer == Layer.Neck || armor.Layer == Layer.Helm || armor is BaseShield || (Race.Gargoyle.ValidateEquipment(armor) && armor.Layer == Layer.Earrings))
                     {
                         if (armor.GorgonLenseCharges > 0 && armor.GorgonLenseType != LenseType)
                             from.SendGump(new GorgonLenseWarningGump(this, armor));

--- a/Scripts/Items/Equipment/Armor/Circlet.cs
+++ b/Scripts/Items/Equipment/Armor/Circlet.cs
@@ -25,7 +25,6 @@ namespace Server.Items
         public override int StrReq => 10;
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Plate;
         public override ArmorMeditationAllowance DefMedAllowance => ArmorMeditationAllowance.All;
-        public override Race RequiredRace => Race.Elf;
 
         public override void Serialize(GenericWriter writer)
         {

--- a/Scripts/Items/Equipment/Armor/FemaleGargishLeatherArms.cs
+++ b/Scripts/Items/Equipment/Armor/FemaleGargishLeatherArms.cs
@@ -40,9 +40,6 @@ namespace Server.Items
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Leather;
         public override CraftResource DefaultResource => CraftResource.RegularLeather;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override int OnCraft(int quality, bool makersMark, Mobile from, CraftSystem craftSystem, Type typeRes, ITool tool, CraftItem craftItem, int resHue)
         {
             Quality = (ItemQuality)quality;

--- a/Scripts/Items/Equipment/Armor/FemaleGargishLeatherChest.cs
+++ b/Scripts/Items/Equipment/Armor/FemaleGargishLeatherChest.cs
@@ -39,9 +39,6 @@ namespace Server.Items
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Leather;
         public override CraftResource DefaultResource => CraftResource.RegularLeather;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override int OnCraft(int quality, bool makersMark, Mobile from, CraftSystem craftSystem, Type typeRes, ITool tool, CraftItem craftItem, int resHue)
         {
             Quality = (ItemQuality)quality;

--- a/Scripts/Items/Equipment/Armor/FemaleGargishLeatherKilt.cs
+++ b/Scripts/Items/Equipment/Armor/FemaleGargishLeatherKilt.cs
@@ -40,9 +40,6 @@ namespace Server.Items
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Leather;
         public override CraftResource DefaultResource => CraftResource.RegularLeather;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override int OnCraft(int quality, bool makersMark, Mobile from, CraftSystem craftSystem, Type typeRes, ITool tool, CraftItem craftItem, int resHue)
         {
             Quality = (ItemQuality)quality;

--- a/Scripts/Items/Equipment/Armor/FemaleGargishLeatherLegs.cs
+++ b/Scripts/Items/Equipment/Armor/FemaleGargishLeatherLegs.cs
@@ -39,9 +39,6 @@ namespace Server.Items
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Leather;
         public override CraftResource DefaultResource => CraftResource.RegularLeather;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override int OnCraft(int quality, bool makersMark, Mobile from, CraftSystem craftSystem, Type typeRes, ITool tool, CraftItem craftItem, int resHue)
         {
             Quality = (ItemQuality)quality;

--- a/Scripts/Items/Equipment/Armor/FemaleGargishPlateArms.cs
+++ b/Scripts/Items/Equipment/Armor/FemaleGargishPlateArms.cs
@@ -34,9 +34,6 @@ namespace Server.Items
 
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Plate;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Armor/FemaleGargishPlateChest.cs
+++ b/Scripts/Items/Equipment/Armor/FemaleGargishPlateChest.cs
@@ -34,9 +34,6 @@ namespace Server.Items
 
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Plate;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Armor/FemaleGargishPlateKilt.cs
+++ b/Scripts/Items/Equipment/Armor/FemaleGargishPlateKilt.cs
@@ -34,9 +34,6 @@ namespace Server.Items
 
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Plate;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Armor/FemaleGargishPlateLegs.cs
+++ b/Scripts/Items/Equipment/Armor/FemaleGargishPlateLegs.cs
@@ -34,9 +34,6 @@ namespace Server.Items
 
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Plate;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Armor/FemaleGargishStoneArms.cs
+++ b/Scripts/Items/Equipment/Armor/FemaleGargishStoneArms.cs
@@ -34,9 +34,6 @@ namespace Server.Items
 
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Stone;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Armor/FemaleGargishStoneChest.cs
+++ b/Scripts/Items/Equipment/Armor/FemaleGargishStoneChest.cs
@@ -34,9 +34,6 @@ namespace Server.Items
 
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Stone;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Armor/FemaleGargishStoneKilt.cs
+++ b/Scripts/Items/Equipment/Armor/FemaleGargishStoneKilt.cs
@@ -34,9 +34,6 @@ namespace Server.Items
 
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Stone;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Armor/FemaleGargishStoneLegs.cs
+++ b/Scripts/Items/Equipment/Armor/FemaleGargishStoneLegs.cs
@@ -34,9 +34,6 @@ namespace Server.Items
 
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Stone;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Armor/GargishChaosShield.cs
+++ b/Scripts/Items/Equipment/Armor/GargishChaosShield.cs
@@ -11,8 +11,6 @@ namespace Server.Items
         public override int InitMinHits => 100;
         public override int InitMaxHits => 125;
         public override int StrReq => 95;
-        public override bool CanBeWornByGargoyles => true;
-        public override Race RequiredRace => Race.Gargoyle;
 
         [Constructable]
         public GargishChaosShield()

--- a/Scripts/Items/Equipment/Armor/GargishClothArmor.cs
+++ b/Scripts/Items/Equipment/Armor/GargishClothArmor.cs
@@ -62,9 +62,6 @@ namespace Server.Items
             return false;
         }
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public GargishClothArmsArmor(Serial serial)
             : base(serial)
         {
@@ -188,9 +185,6 @@ namespace Server.Items
             from.SendLocalizedMessage(502440); // Scissors can not be used on that to produce anything.
             return false;
         }
-
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
 
         public GargishClothChestArmor(Serial serial)
             : base(serial)
@@ -317,9 +311,6 @@ namespace Server.Items
             return false;
         }
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public GargishClothLegsArmor(Serial serial)
             : base(serial)
         {
@@ -444,9 +435,6 @@ namespace Server.Items
             from.SendLocalizedMessage(502440); // Scissors can not be used on that to produce anything.
             return false;
         }
-
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
 
         public GargishClothKiltArmor(Serial serial)
             : base(serial)

--- a/Scripts/Items/Equipment/Armor/GargishKiteShield.cs
+++ b/Scripts/Items/Equipment/Armor/GargishKiteShield.cs
@@ -23,8 +23,7 @@ namespace Server.Items
         public override int InitMinHits => 45;
         public override int InitMaxHits => 60;
         public override int StrReq => 45;
-        public override bool CanBeWornByGargoyles => true;
-        public override Race RequiredRace => Race.Gargoyle;
+
         public bool Dye(Mobile from, DyeTub sender)
         {
             if (Deleted)

--- a/Scripts/Items/Equipment/Armor/GargishLeatherArms.cs
+++ b/Scripts/Items/Equipment/Armor/GargishLeatherArms.cs
@@ -37,9 +37,6 @@ namespace Server.Items
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Leather;
         public override CraftResource DefaultResource => CraftResource.RegularLeather;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Armor/GargishLeatherChest.cs
+++ b/Scripts/Items/Equipment/Armor/GargishLeatherChest.cs
@@ -36,9 +36,6 @@ namespace Server.Items
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Leather;
         public override CraftResource DefaultResource => CraftResource.RegularLeather;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Armor/GargishLeatherKilt.cs
+++ b/Scripts/Items/Equipment/Armor/GargishLeatherKilt.cs
@@ -37,9 +37,6 @@ namespace Server.Items
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Leather;
         public override CraftResource DefaultResource => CraftResource.RegularLeather;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Armor/GargishLeatherLegs.cs
+++ b/Scripts/Items/Equipment/Armor/GargishLeatherLegs.cs
@@ -36,9 +36,6 @@ namespace Server.Items
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Leather;
         public override CraftResource DefaultResource => CraftResource.RegularLeather;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Armor/GargishLeatherWingArmor.cs
+++ b/Scripts/Items/Equipment/Armor/GargishLeatherWingArmor.cs
@@ -36,8 +36,6 @@ namespace Server.Items
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Leather;
         public override CraftResource DefaultResource => CraftResource.RegularLeather;
         public override ArmorMeditationAllowance DefMedAllowance => ArmorMeditationAllowance.All;
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
 
         public override int GetLuckBonus() { return 0; }
 

--- a/Scripts/Items/Equipment/Armor/GargishOrderShield.cs
+++ b/Scripts/Items/Equipment/Armor/GargishOrderShield.cs
@@ -23,8 +23,7 @@ namespace Server.Items
         public override int InitMinHits => 100;
         public override int InitMaxHits => 125;
         public override int StrReq => 95;
-        public override bool CanBeWornByGargoyles => true;
-        public override Race RequiredRace => Race.Gargoyle;
+
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);

--- a/Scripts/Items/Equipment/Armor/GargishPlateArms.cs
+++ b/Scripts/Items/Equipment/Armor/GargishPlateArms.cs
@@ -34,9 +34,6 @@ namespace Server.Items
 
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Plate;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Armor/GargishPlateChest.cs
+++ b/Scripts/Items/Equipment/Armor/GargishPlateChest.cs
@@ -34,9 +34,6 @@ namespace Server.Items
 
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Plate;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Armor/GargishPlateKilt.cs
+++ b/Scripts/Items/Equipment/Armor/GargishPlateKilt.cs
@@ -34,9 +34,6 @@ namespace Server.Items
 
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Plate;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Armor/GargishPlateLegs.cs
+++ b/Scripts/Items/Equipment/Armor/GargishPlateLegs.cs
@@ -34,9 +34,6 @@ namespace Server.Items
 
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Plate;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Armor/GargishStoneArms.cs
+++ b/Scripts/Items/Equipment/Armor/GargishStoneArms.cs
@@ -34,8 +34,6 @@ namespace Server.Items
 
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Stone;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
 
         public override void Serialize(GenericWriter writer)
         {

--- a/Scripts/Items/Equipment/Armor/GargishStoneChest.cs
+++ b/Scripts/Items/Equipment/Armor/GargishStoneChest.cs
@@ -34,9 +34,6 @@ namespace Server.Items
 
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Stone;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Armor/GargishStoneKilt.cs
+++ b/Scripts/Items/Equipment/Armor/GargishStoneKilt.cs
@@ -34,9 +34,6 @@ namespace Server.Items
 
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Stone;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Armor/GargishStoneLegs.cs
+++ b/Scripts/Items/Equipment/Armor/GargishStoneLegs.cs
@@ -34,9 +34,6 @@ namespace Server.Items
 
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Stone;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Armor/GemmedCirclet.cs
+++ b/Scripts/Items/Equipment/Armor/GemmedCirclet.cs
@@ -15,7 +15,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Elf;
         public override int BasePhysicalResistance => 1;
         public override int BaseFireResistance => 5;
         public override int BaseColdResistance => 2;

--- a/Scripts/Items/Equipment/Armor/HideChest.cs
+++ b/Scripts/Items/Equipment/Armor/HideChest.cs
@@ -15,7 +15,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Elf;
         public override int BasePhysicalResistance => 3;
         public override int BaseFireResistance => 3;
         public override int BaseColdResistance => 4;

--- a/Scripts/Items/Equipment/Armor/HideFemaleChest.cs
+++ b/Scripts/Items/Equipment/Armor/HideFemaleChest.cs
@@ -15,7 +15,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Elf;
         public override int BasePhysicalResistance => 3;
         public override int BaseFireResistance => 3;
         public override int BaseColdResistance => 4;

--- a/Scripts/Items/Equipment/Armor/HideGloves.cs
+++ b/Scripts/Items/Equipment/Armor/HideGloves.cs
@@ -15,7 +15,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Elf;
         public override int BasePhysicalResistance => 3;
         public override int BaseFireResistance => 3;
         public override int BaseColdResistance => 4;

--- a/Scripts/Items/Equipment/Armor/HideGorget.cs
+++ b/Scripts/Items/Equipment/Armor/HideGorget.cs
@@ -15,7 +15,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Elf;
         public override int BasePhysicalResistance => 3;
         public override int BaseFireResistance => 3;
         public override int BaseColdResistance => 4;

--- a/Scripts/Items/Equipment/Armor/HidePants.cs
+++ b/Scripts/Items/Equipment/Armor/HidePants.cs
@@ -15,7 +15,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Elf;
         public override int BasePhysicalResistance => 3;
         public override int BaseFireResistance => 3;
         public override int BaseColdResistance => 4;

--- a/Scripts/Items/Equipment/Armor/HidePauldrons.cs
+++ b/Scripts/Items/Equipment/Armor/HidePauldrons.cs
@@ -15,7 +15,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Elf;
         public override int BasePhysicalResistance => 3;
         public override int BaseFireResistance => 3;
         public override int BaseColdResistance => 4;

--- a/Scripts/Items/Equipment/Armor/LargePlateShield.cs
+++ b/Scripts/Items/Equipment/Armor/LargePlateShield.cs
@@ -23,8 +23,7 @@ namespace Server.Items
         public override int InitMinHits => 50;
         public override int InitMaxHits => 65;
         public override int StrReq => 90;
-        public override bool CanBeWornByGargoyles => true;
-        public override Race RequiredRace => Race.Gargoyle;
+
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);

--- a/Scripts/Items/Equipment/Armor/LargeStoneShield.cs
+++ b/Scripts/Items/Equipment/Armor/LargeStoneShield.cs
@@ -23,8 +23,7 @@ namespace Server.Items
         public override int InitMinHits => 50;
         public override int InitMaxHits => 65;
         public override int StrReq => 20;
-        public override bool CanBeWornByGargoyles => true;
-        public override Race RequiredRace => Race.Gargoyle;
+
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);

--- a/Scripts/Items/Equipment/Armor/LeafArms.cs
+++ b/Scripts/Items/Equipment/Armor/LeafArms.cs
@@ -18,7 +18,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Elf;
         public override int BasePhysicalResistance => 2;
         public override int BaseFireResistance => 3;
         public override int BaseColdResistance => 2;

--- a/Scripts/Items/Equipment/Armor/LeafChest.cs
+++ b/Scripts/Items/Equipment/Armor/LeafChest.cs
@@ -18,7 +18,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Elf;
         public override int BasePhysicalResistance => 2;
         public override int BaseFireResistance => 3;
         public override int BaseColdResistance => 2;

--- a/Scripts/Items/Equipment/Armor/LeafGloves.cs
+++ b/Scripts/Items/Equipment/Armor/LeafGloves.cs
@@ -3,7 +3,6 @@ namespace Server.Items
     [Flipable]
     public class LeafGloves : BaseArmor
     {
-        public override Race RequiredRace => Race.Elf;
         public override int BasePhysicalResistance => 2;
         public override int BaseFireResistance => 3;
         public override int BaseColdResistance => 2;

--- a/Scripts/Items/Equipment/Armor/LeafGorget.cs
+++ b/Scripts/Items/Equipment/Armor/LeafGorget.cs
@@ -14,7 +14,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Elf;
         public override int BasePhysicalResistance => 2;
         public override int BaseFireResistance => 3;
         public override int BaseColdResistance => 2;

--- a/Scripts/Items/Equipment/Armor/LeafLegs.cs
+++ b/Scripts/Items/Equipment/Armor/LeafLegs.cs
@@ -18,7 +18,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Elf;
         public override int BasePhysicalResistance => 2;
         public override int BaseFireResistance => 3;
         public override int BaseColdResistance => 2;

--- a/Scripts/Items/Equipment/Armor/LeafTonlet.cs
+++ b/Scripts/Items/Equipment/Armor/LeafTonlet.cs
@@ -18,7 +18,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Elf;
         public override int BasePhysicalResistance => 2;
         public override int BaseFireResistance => 3;
         public override int BaseColdResistance => 2;

--- a/Scripts/Items/Equipment/Armor/MediumPlateShield.cs
+++ b/Scripts/Items/Equipment/Armor/MediumPlateShield.cs
@@ -23,8 +23,7 @@ namespace Server.Items
         public override int InitMinHits => 50;
         public override int InitMaxHits => 65;
         public override int StrReq => 45;
-        public override bool CanBeWornByGargoyles => true;
-        public override Race RequiredRace => Race.Gargoyle;
+
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);

--- a/Scripts/Items/Equipment/Armor/RavenHelm.cs
+++ b/Scripts/Items/Equipment/Armor/RavenHelm.cs
@@ -15,7 +15,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Elf;
         public override int BasePhysicalResistance => 5;
         public override int BaseFireResistance => 1;
         public override int BaseColdResistance => 2;

--- a/Scripts/Items/Equipment/Armor/RoyalCirclet.cs
+++ b/Scripts/Items/Equipment/Armor/RoyalCirclet.cs
@@ -15,7 +15,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Elf;
         public override int BasePhysicalResistance => 1;
         public override int BaseFireResistance => 5;
         public override int BaseColdResistance => 2;

--- a/Scripts/Items/Equipment/Armor/SmallPlateShield.cs
+++ b/Scripts/Items/Equipment/Armor/SmallPlateShield.cs
@@ -23,8 +23,7 @@ namespace Server.Items
         public override int InitMinHits => 25;
         public override int InitMaxHits => 30;
         public override int StrReq => 35;
-        public override bool CanBeWornByGargoyles => true;
-        public override Race RequiredRace => Race.Gargoyle;
+
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);

--- a/Scripts/Items/Equipment/Armor/VultureHelm.cs
+++ b/Scripts/Items/Equipment/Armor/VultureHelm.cs
@@ -15,7 +15,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Elf;
         public override int BasePhysicalResistance => 5;
         public override int BaseFireResistance => 1;
         public override int BaseColdResistance => 2;

--- a/Scripts/Items/Equipment/Armor/WingedHelm.cs
+++ b/Scripts/Items/Equipment/Armor/WingedHelm.cs
@@ -15,7 +15,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Elf;
         public override int BasePhysicalResistance => 5;
         public override int BaseFireResistance => 1;
         public override int BaseColdResistance => 2;

--- a/Scripts/Items/Equipment/Armor/WoodlandArms.cs
+++ b/Scripts/Items/Equipment/Armor/WoodlandArms.cs
@@ -24,7 +24,7 @@ namespace Server.Items
         public override int InitMaxHits => 65;
         public override int StrReq => 80;
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Wood;
-        public override Race RequiredRace => Race.Elf;
+
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Armor/WoodlandChest.cs
+++ b/Scripts/Items/Equipment/Armor/WoodlandChest.cs
@@ -24,7 +24,7 @@ namespace Server.Items
         public override int InitMaxHits => 65;
         public override int StrReq => 95;
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Wood;
-        public override Race RequiredRace => Race.Elf;
+
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Armor/WoodlandGloves.cs
+++ b/Scripts/Items/Equipment/Armor/WoodlandGloves.cs
@@ -24,7 +24,7 @@ namespace Server.Items
         public override int InitMaxHits => 65;
         public override int StrReq => 70;
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Wood;
-        public override Race RequiredRace => Race.Elf;
+
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Armor/WoodlandGorget.cs
+++ b/Scripts/Items/Equipment/Armor/WoodlandGorget.cs
@@ -23,7 +23,6 @@ namespace Server.Items
         public override int InitMaxHits => 65;
         public override int StrReq => 45;
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Wood;
-        public override Race RequiredRace => Race.Elf;
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Armor/WoodlandLegs.cs
+++ b/Scripts/Items/Equipment/Armor/WoodlandLegs.cs
@@ -24,7 +24,6 @@ namespace Server.Items
         public override int InitMaxHits => 65;
         public override int StrReq => 90;
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Wood;
-        public override Race RequiredRace => Race.Elf;
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Clothing/Arms.cs
+++ b/Scripts/Items/Equipment/Clothing/Arms.cs
@@ -20,8 +20,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
         public override void OnAdded(object parent)
         {
             base.OnAdded(parent);
@@ -68,8 +66,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
@@ -103,8 +99,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Clothing/BaseClothing.cs
+++ b/Scripts/Items/Equipment/Clothing/BaseClothing.cs
@@ -1,6 +1,8 @@
 using Server.ContextMenus;
 using Server.Engines.Craft;
 using Server.Network;
+using Server.Misc;
+
 using System;
 using System.Collections.Generic;
 
@@ -385,10 +387,6 @@ namespace Server.Items
             }
         }
 
-        public virtual Race RequiredRace => null;
-
-        public virtual bool CanBeWornByGargoyles => false;
-
         public override bool CanEquip(Mobile from)
         {
             if (from.IsPlayer())
@@ -416,22 +414,8 @@ namespace Server.Items
                     return false;
                 }
 
-                bool morph = from.FindItemOnLayer(Layer.Earrings) is MorphEarrings;
-
-                if (from.Race == Race.Gargoyle && !CanBeWornByGargoyles)
+                if (!RaceDefinitions.ValidateEquipment(from, this))
                 {
-                    from.LocalOverheadMessage(MessageType.Regular, 0x3B2, 1111708); // Gargoyles can't wear this.
-                    return false;
-                }
-                else if (RequiredRace != null && from.Race != RequiredRace && !morph)
-                {
-                    if (RequiredRace == Race.Elf)
-                        from.SendLocalizedMessage(1072203); // Only Elves may use this.
-                    else if (RequiredRace == Race.Gargoyle)
-                        from.LocalOverheadMessage(MessageType.Regular, 0x3B2, 1111707); // Only gargoyles can wear this.
-                    else
-                        from.SendMessage("Only {0} may use this.", RequiredRace.PluralName);
-
                     return false;
                 }
                 else if (!AllowMaleWearer && !from.Female)
@@ -538,21 +522,8 @@ namespace Server.Items
                 {
                     BaseClothing clothing = (BaseClothing)item;
 
-                    if (m.Race == Race.Gargoyle && !clothing.CanBeWornByGargoyles)
+                    if (!RaceDefinitions.ValidateEquipment(m, clothing))
                     {
-                        m.SendLocalizedMessage(1111708); // Gargoyles can't wear this.
-                        m.AddToBackpack(clothing);
-                    }
-
-                    if (clothing.RequiredRace != null && m.Race != clothing.RequiredRace)
-                    {
-                        if (clothing.RequiredRace == Race.Elf)
-                            m.SendLocalizedMessage(1072203); // Only Elves may use this.
-                        else if (clothing.RequiredRace == Race.Gargoyle)
-                            m.SendLocalizedMessage(1111707); // Only gargoyles can wear this.
-                        else
-                            m.SendMessage("Only {0} may use this.", clothing.RequiredRace.PluralName);
-
                         m.AddToBackpack(clothing);
                     }
                     else if (!clothing.AllowMaleWearer && !m.Female && m.AccessLevel < AccessLevel.GameMaster)
@@ -958,10 +929,14 @@ namespace Server.Items
                 }
             }
 
-            if (RequiredRace == Race.Elf)
+            if (RaceDefinitions.GetRequiredRace(this) == Race.Elf)
+            {
                 list.Add(1075086); // Elves Only
-            else if (RequiredRace == Race.Gargoyle)
+            }
+            else if (RaceDefinitions.GetRequiredRace(this) == Race.Gargoyle)
+            {
                 list.Add(1111709); // Gargoyles Only
+            }
 
             if (m_NegativeAttributes != null)
                 m_NegativeAttributes.GetProperties(list, this);

--- a/Scripts/Items/Equipment/Clothing/Cloaks.cs
+++ b/Scripts/Items/Equipment/Clothing/Cloaks.cs
@@ -329,8 +329,6 @@ namespace Server.Items
         }
 
         public override int StrReq => 10;
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
 
         public GargishClothWingArmor(Serial serial)
             : base(serial)
@@ -353,9 +351,6 @@ namespace Server.Items
     [Flipable(0x4002, 0x4003)]
     public class GargishFancyRobe : BaseClothing
     {
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         [Constructable]
         public GargishFancyRobe()
             : this(0)
@@ -390,9 +385,6 @@ namespace Server.Items
     [Flipable(0x4000, 0x4001)]
     public class GargishRobe : BaseClothing
     {
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         [Constructable]
         public GargishRobe()
             : this(0)

--- a/Scripts/Items/Equipment/Clothing/LeatherTalons.cs
+++ b/Scripts/Items/Equipment/Clothing/LeatherTalons.cs
@@ -21,8 +21,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
         public override CraftResource DefaultResource => CraftResource.RegularLeather;
         public override void Serialize(GenericWriter writer)
         {

--- a/Scripts/Items/Equipment/Clothing/MiddleTorso.cs
+++ b/Scripts/Items/Equipment/Clothing/MiddleTorso.cs
@@ -345,8 +345,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Clothing/OuterLegs.cs
+++ b/Scripts/Items/Equipment/Clothing/OuterLegs.cs
@@ -196,9 +196,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-		
         public override void OnAdded(object parent)
         {
             base.OnAdded(parent);
@@ -245,9 +242,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-		
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
@@ -281,9 +275,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-		
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Clothing/OuterTorso.cs
+++ b/Scripts/Items/Equipment/Clothing/OuterTorso.cs
@@ -866,9 +866,6 @@ namespace Server.Items
 
     public class RewardGargishRobe : BaseOuterTorso, IRewardItem
     {
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         private int m_LabelNumber;
         private bool m_IsRewardItem;
 
@@ -978,9 +975,6 @@ namespace Server.Items
 
     public class RewardGargishFancyRobe : BaseOuterTorso, IRewardItem
     {
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         private int m_LabelNumber;
         private bool m_IsRewardItem;
 
@@ -1172,8 +1166,6 @@ namespace Server.Items
             : base(serial)
         {
         }
-
-        public override bool CanBeWornByGargoyles => true;
 
         public override void Serialize(GenericWriter writer)
         {
@@ -1456,8 +1448,6 @@ namespace Server.Items
     [Flipable(0x2FB9, 0x3173)]
     public class MaleElvenRobe : BaseOuterTorso
     {
-        public override Race RequiredRace => Race.Elf;
-
         [Constructable]
         public MaleElvenRobe()
             : this(0)
@@ -1494,7 +1484,6 @@ namespace Server.Items
     [Flipable(0x2FBA, 0x3174)]
     public class FemaleElvenRobe : BaseOuterTorso
     {
-        public override Race RequiredRace => Race.Elf;
         [Constructable]
         public FemaleElvenRobe()
             : this(0)
@@ -1636,9 +1625,6 @@ namespace Server.Items
     public class GargishEpaulette : BaseClothing
     {
         public override int LabelNumber => 1123326;  // Gargish Epaulette
-
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
 
         [Constructable]
         public GargishEpaulette()

--- a/Scripts/Items/Equipment/Clothing/Pants.cs
+++ b/Scripts/Items/Equipment/Clothing/Pants.cs
@@ -249,8 +249,6 @@ namespace Server.Items
     [FlipableAttribute(0x2FC3, 0x3179)]
     public class ElvenPants : BasePants
     {
-        public override Race RequiredRace => Race.Elf;
-
         [Constructable]
         public ElvenPants()
             : this(0)
@@ -286,9 +284,6 @@ namespace Server.Items
 
     public class GargishClothLegs : BaseClothing
     {
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         [Constructable]
         public GargishClothLegs()
             : this(0)
@@ -335,9 +330,6 @@ namespace Server.Items
 
     public class FemaleGargishClothLegs : BaseClothing
     {
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         [Constructable]
         public FemaleGargishClothLegs()
             : this(0)
@@ -371,9 +363,6 @@ namespace Server.Items
 
     public class MaleGargishClothLegs : BaseClothing
     {
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         [Constructable]
         public MaleGargishClothLegs()
             : this(0)

--- a/Scripts/Items/Equipment/Clothing/PlateTalons.cs
+++ b/Scripts/Items/Equipment/Clothing/PlateTalons.cs
@@ -21,8 +21,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
         public override CraftResource DefaultResource => CraftResource.Iron;
         public override void Serialize(GenericWriter writer)
         {

--- a/Scripts/Items/Equipment/Clothing/Shirts.cs
+++ b/Scripts/Items/Equipment/Clothing/Shirts.cs
@@ -161,8 +161,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Elf;
-		
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
@@ -198,8 +196,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Elf;
-		
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
@@ -235,10 +231,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Gargoyle;
-		
-        public override bool CanBeWornByGargoyles => true;
-		
         public override void OnAdded(object parent)
         {
             base.OnAdded(parent);
@@ -285,10 +277,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Gargoyle;
-		
-        public override bool CanBeWornByGargoyles => true;
-		
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
@@ -322,10 +310,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Gargoyle;
-		
-        public override bool CanBeWornByGargoyles => true;
-		
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Clothing/Shoes.cs
+++ b/Scripts/Items/Equipment/Clothing/Shoes.cs
@@ -516,8 +516,6 @@ namespace Server.Items
     {
         public override CraftResource DefaultResource => CraftResource.RegularLeather;
 
-        public override Race RequiredRace => Race.Elf;
-
         [Constructable]
         public ElvenBoots()
             : this(0)

--- a/Scripts/Items/Equipment/Clothing/Waist.cs
+++ b/Scripts/Items/Equipment/Clothing/Waist.cs
@@ -128,7 +128,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Elf;
         public override bool Dye(Mobile from, DyeTub sender)
         {
             from.SendLocalizedMessage(sender.FailMessage);
@@ -177,8 +176,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
@@ -215,8 +212,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Jewelry/BaseJewel.cs
+++ b/Scripts/Items/Equipment/Jewelry/BaseJewel.cs
@@ -1,5 +1,7 @@
 using Server.ContextMenus;
 using Server.Engines.Craft;
+using Server.Misc;
+
 using System;
 using System.Collections.Generic;
 
@@ -343,9 +345,6 @@ namespace Server.Items
         public virtual int InitMinHits => 0;
         public virtual int InitMaxHits => 0;
 
-        public virtual Race RequiredRace => null;
-        public virtual bool CanBeWornByGargoyles => true;
-
         public override int LabelNumber
         {
             get
@@ -505,26 +504,9 @@ namespace Server.Items
                 }
             }
 
-            if (from.AccessLevel < AccessLevel.GameMaster)
+            if (from.AccessLevel < AccessLevel.GameMaster && !RaceDefinitions.ValidateEquipment(from, this))
             {
-                bool morph = from.FindItemOnLayer(Layer.Earrings) is MorphEarrings;
-
-                if (from.Race == Race.Gargoyle && !CanBeWornByGargoyles)
-                {
-                    from.SendLocalizedMessage(1111708); // Gargoyles can't wear 
-                    return false;
-                }
-                else if (RequiredRace != null && from.Race != RequiredRace && !morph)
-                {
-                    if (RequiredRace == Race.Elf)
-                        from.SendLocalizedMessage(1072203); // Only Elves may use 
-                    else if (RequiredRace == Race.Gargoyle)
-                        from.SendLocalizedMessage(1111707); // Only gargoyles can wear 
-                    else
-                        from.SendMessage("Only {0} may use ", RequiredRace.PluralName);
-
-                    return false;
-                }
+                return false;
             }
 
             return base.CanEquip(from);
@@ -754,12 +736,14 @@ namespace Server.Items
 
             int prop;
 
-            #region Stygian Abyss
-            if (RequiredRace == Race.Elf)
+            if (RaceDefinitions.GetRequiredRace(this) == Race.Elf)
+            {
                 list.Add(1075086); // Elves Only
-            else if (RequiredRace == Race.Gargoyle)
+            }
+            else if (RaceDefinitions.GetRequiredRace(this) == Race.Gargoyle)
+            {
                 list.Add(1111709); // Gargoyles Only
-            #endregion
+            }
 
             if ((prop = ArtifactRarity) > 0)
                 list.Add(1061078, prop.ToString()); // artifact rarity ~1_val~

--- a/Scripts/Items/Equipment/Jewelry/GargishBracelet.cs
+++ b/Scripts/Items/Equipment/Jewelry/GargishBracelet.cs
@@ -14,8 +14,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Jewelry/GargishEarrings.cs
+++ b/Scripts/Items/Equipment/Jewelry/GargishEarrings.cs
@@ -2,9 +2,6 @@ namespace Server.Items
 {
     public class GargishEarrings : BaseArmor
     {
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Chainmail;
         public override ArmorMeditationAllowance DefMedAllowance => ArmorMeditationAllowance.All;
 

--- a/Scripts/Items/Equipment/Jewelry/GargishNecklace.cs
+++ b/Scripts/Items/Equipment/Jewelry/GargishNecklace.cs
@@ -2,9 +2,6 @@ namespace Server.Items
 {
     public class GargishNecklace : BaseArmor
     {
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Chainmail;
         public override ArmorMeditationAllowance DefMedAllowance => ArmorMeditationAllowance.All;
 

--- a/Scripts/Items/Equipment/Jewelry/GargishRing.cs
+++ b/Scripts/Items/Equipment/Jewelry/GargishRing.cs
@@ -14,8 +14,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Quivers/BaseQuiver.cs
+++ b/Scripts/Items/Equipment/Quivers/BaseQuiver.cs
@@ -1,5 +1,7 @@
 using Server.ContextMenus;
 using Server.Engines.Craft;
+using Server.Misc;
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -442,9 +444,8 @@ namespace Server.Items
 
         public override bool CanEquip(Mobile m)
         {
-            if (m.Race == Race.Gargoyle)
-            {
-                m.SendLocalizedMessage(1111708); // Gargoyles can't wear 
+            if (RaceDefinitions.ValidateEquipment(m, this))
+            { 
                 return false;
             }
 

--- a/Scripts/Items/Equipment/Weapons/BloodBlade.cs
+++ b/Scripts/Items/Equipment/Weapons/BloodBlade.cs
@@ -29,9 +29,6 @@ namespace Server.Items
         public override WeaponType DefType => WeaponType.Piercing;
         public override WeaponAnimation DefAnimation => WeaponAnimation.Pierce1H;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/Boomerang.cs
+++ b/Scripts/Items/Equipment/Weapons/Boomerang.cs
@@ -27,9 +27,6 @@ namespace Server.Items
         public override int InitMinHits => 31;
         public override int InitMaxHits => 60;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/Cyclone.cs
+++ b/Scripts/Items/Equipment/Weapons/Cyclone.cs
@@ -27,9 +27,6 @@ namespace Server.Items
         public override int InitMinHits => 31;
         public override int InitMaxHits => 60;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/DiscMace.cs
+++ b/Scripts/Items/Equipment/Weapons/DiscMace.cs
@@ -24,9 +24,6 @@ namespace Server.Items
         public override int InitMinHits => 31;
         public override int InitMaxHits => 110;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/DreadSword.cs
+++ b/Scripts/Items/Equipment/Weapons/DreadSword.cs
@@ -27,9 +27,6 @@ namespace Server.Items
         public override int InitMinHits => 31;
         public override int InitMaxHits => 110;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/DualPointedSpear.cs
+++ b/Scripts/Items/Equipment/Weapons/DualPointedSpear.cs
@@ -25,9 +25,6 @@ namespace Server.Items
         public override int InitMinHits => 31;
         public override int InitMaxHits => 80;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/DualShortAxes.cs
+++ b/Scripts/Items/Equipment/Weapons/DualShortAxes.cs
@@ -23,8 +23,7 @@ namespace Server.Items
 
         public override int InitMinHits => 31;
         public override int InitMaxHits => 110;
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
+
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/GargishAxe.cs
+++ b/Scripts/Items/Equipment/Weapons/GargishAxe.cs
@@ -25,9 +25,6 @@ namespace Server.Items
         public override int InitMinHits => 31;
         public override int InitMaxHits => 110;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/GargishBardiche.cs
+++ b/Scripts/Items/Equipment/Weapons/GargishBardiche.cs
@@ -24,8 +24,7 @@ namespace Server.Items
 
         public override int InitMinHits => 31;
         public override int InitMaxHits => 100;
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
+
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/GargishBattleAxe.cs
+++ b/Scripts/Items/Equipment/Weapons/GargishBattleAxe.cs
@@ -25,8 +25,7 @@ namespace Server.Items
 
         public override int InitMinHits => 31;
         public override int InitMaxHits => 70;
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
+
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/GargishBoneHarvester.cs
+++ b/Scripts/Items/Equipment/Weapons/GargishBoneHarvester.cs
@@ -27,9 +27,6 @@ namespace Server.Items
         public override int InitMinHits => 31;
         public override int InitMaxHits => 70;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/GargishButcherKnife.cs
+++ b/Scripts/Items/Equipment/Weapons/GargishButcherKnife.cs
@@ -25,9 +25,6 @@ namespace Server.Items
         public override int InitMinHits => 31;
         public override int InitMaxHits => 40;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/GargishCleaver.cs
+++ b/Scripts/Items/Equipment/Weapons/GargishCleaver.cs
@@ -25,9 +25,6 @@ namespace Server.Items
         public override int InitMinHits => 31;
         public override int InitMaxHits => 50;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/GargishDagger.cs
+++ b/Scripts/Items/Equipment/Weapons/GargishDagger.cs
@@ -27,9 +27,6 @@ namespace Server.Items
         public override WeaponType DefType => WeaponType.Piercing;
         public override WeaponAnimation DefAnimation => WeaponAnimation.Pierce1H;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/GargishDaisho.cs
+++ b/Scripts/Items/Equipment/Weapons/GargishDaisho.cs
@@ -28,9 +28,6 @@ namespace Server.Items
         public override int InitMinHits => 45;
         public override int InitMaxHits => 65;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/GargishGnarledStaff.cs
+++ b/Scripts/Items/Equipment/Weapons/GargishGnarledStaff.cs
@@ -25,9 +25,6 @@ namespace Server.Items
         public override int InitMinHits => 31;
         public override int InitMaxHits => 50;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/GargishKatana.cs
+++ b/Scripts/Items/Equipment/Weapons/GargishKatana.cs
@@ -27,9 +27,6 @@ namespace Server.Items
         public override int InitMinHits => 31;
         public override int InitMaxHits => 90;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/GargishKryss.cs
+++ b/Scripts/Items/Equipment/Weapons/GargishKryss.cs
@@ -30,9 +30,6 @@ namespace Server.Items
         public override WeaponType DefType => WeaponType.Piercing;
         public override WeaponAnimation DefAnimation => WeaponAnimation.Pierce1H;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/GargishLance.cs
+++ b/Scripts/Items/Equipment/Weapons/GargishLance.cs
@@ -30,9 +30,6 @@ namespace Server.Items
         public override WeaponType DefType => WeaponType.Piercing;
         public override WeaponAnimation DefAnimation => WeaponAnimation.Pierce1H;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/GargishMaul.cs
+++ b/Scripts/Items/Equipment/Weapons/GargishMaul.cs
@@ -25,9 +25,6 @@ namespace Server.Items
         public override int InitMinHits => 31;
         public override int InitMaxHits => 70;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/GargishPike.cs
+++ b/Scripts/Items/Equipment/Weapons/GargishPike.cs
@@ -25,9 +25,6 @@ namespace Server.Items
         public override int InitMinHits => 31;
         public override int InitMaxHits => 110;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/GargishScythe.cs
+++ b/Scripts/Items/Equipment/Weapons/GargishScythe.cs
@@ -28,9 +28,6 @@ namespace Server.Items
         public override int InitMaxHits => 100;
         public override HarvestSystem HarvestSystem => null;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/GargishTalwar.cs
+++ b/Scripts/Items/Equipment/Weapons/GargishTalwar.cs
@@ -27,9 +27,6 @@ namespace Server.Items
         public override int InitMinHits => 31;
         public override int InitMaxHits => 80;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/GargishTekagi.cs
+++ b/Scripts/Items/Equipment/Weapons/GargishTekagi.cs
@@ -31,9 +31,6 @@ namespace Server.Items
         public override WeaponType DefType => WeaponType.Piercing;
         public override WeaponAnimation DefAnimation => WeaponAnimation.Pierce1H;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/GargishTessen.cs
+++ b/Scripts/Items/Equipment/Weapons/GargishTessen.cs
@@ -29,9 +29,6 @@ namespace Server.Items
         public override int InitMaxHits => 60;
         public override WeaponAnimation DefAnimation => WeaponAnimation.Bash2H;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/GargishWarFork.cs
+++ b/Scripts/Items/Equipment/Weapons/GargishWarFork.cs
@@ -28,9 +28,6 @@ namespace Server.Items
         public override int InitMaxHits => 110;
         public override WeaponAnimation DefAnimation => WeaponAnimation.Pierce1H;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/GargishWarHammer.cs
+++ b/Scripts/Items/Equipment/Weapons/GargishWarHammer.cs
@@ -27,9 +27,6 @@ namespace Server.Items
         public override int InitMaxHits => 110;
         public override WeaponAnimation DefAnimation => WeaponAnimation.Bash2H;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/GlassStaff.cs
+++ b/Scripts/Items/Equipment/Weapons/GlassStaff.cs
@@ -25,9 +25,6 @@ namespace Server.Items
         public override int InitMinHits => 31;
         public override int InitMaxHits => 70;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/GlassSword.cs
+++ b/Scripts/Items/Equipment/Weapons/GlassSword.cs
@@ -27,9 +27,6 @@ namespace Server.Items
         public override int InitMinHits => 31;
         public override int InitMaxHits => 90;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/Pickaxe.cs
+++ b/Scripts/Items/Equipment/Weapons/Pickaxe.cs
@@ -28,9 +28,6 @@ namespace Server.Items
         public override float Speed => 3.00f;
         public override int InitMinHits => 31;
         public override int InitMaxHits => 60;
-
-        public override bool CanBeWornByGargoyles => true;
-
         public override WeaponAnimation DefAnimation => WeaponAnimation.Slash1H;
 		
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Items/Equipment/Weapons/SerpentStoneStaff.cs
+++ b/Scripts/Items/Equipment/Weapons/SerpentStoneStaff.cs
@@ -25,9 +25,6 @@ namespace Server.Items
         public override int InitMinHits => 31;
         public override int InitMaxHits => 50;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/ShepherdsCrook.cs
+++ b/Scripts/Items/Equipment/Weapons/ShepherdsCrook.cs
@@ -31,8 +31,6 @@ namespace Server.Items
         public override int InitMinHits => 31;
         public override int InitMaxHits => 50;
 
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/Shortblade.cs
+++ b/Scripts/Items/Equipment/Weapons/Shortblade.cs
@@ -30,9 +30,6 @@ namespace Server.Items
         public override WeaponType DefType => WeaponType.Piercing;
         public override WeaponAnimation DefAnimation => WeaponAnimation.Pierce1H;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/SkullGnarledStaff.cs
+++ b/Scripts/Items/Equipment/Weapons/SkullGnarledStaff.cs
@@ -36,8 +36,6 @@ namespace Server.Items
     public class GargishSkullGnarledStaff : GnarledStaff
     {
         public override int LabelNumber => 1125823;  // gargish skull gnarled staff
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
 
         [Constructable]
         public GargishSkullGnarledStaff()

--- a/Scripts/Items/Equipment/Weapons/SkullLongsword.cs
+++ b/Scripts/Items/Equipment/Weapons/SkullLongsword.cs
@@ -36,8 +36,6 @@ namespace Server.Items
     public class GargishSkullLongsword : Longsword
     {
         public override int LabelNumber => 1125821;  // gargish skull longsword
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
 
         [Constructable]
         public GargishSkullLongsword()

--- a/Scripts/Items/Equipment/Weapons/SoulGlaive.cs
+++ b/Scripts/Items/Equipment/Weapons/SoulGlaive.cs
@@ -27,9 +27,6 @@ namespace Server.Items
         public override int InitMinHits => 31;
         public override int InitMaxHits => 65;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Weapons/StoneWarSword.cs
+++ b/Scripts/Items/Equipment/Weapons/StoneWarSword.cs
@@ -26,9 +26,6 @@ namespace Server.Items
         public override int InitMinHits => 31;
         public override int InitMaxHits => 100;
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Functional/AuctionSafe/Auction.cs
+++ b/Scripts/Items/Functional/AuctionSafe/Auction.cs
@@ -448,10 +448,10 @@ namespace Server.Engines.Auction
         public void RemoveAuction()
         {
             Auctions.Remove(this);
+            AuctionItem = null;
             Safe.Auction = null;
             OnGoing = false;
 
-            AuctionItem = null;
             ClaimPeriod = DateTime.MinValue;
         }
 

--- a/Scripts/Items/Functional/AuctionSafe/AuctionSafe.cs
+++ b/Scripts/Items/Functional/AuctionSafe/AuctionSafe.cs
@@ -67,6 +67,7 @@ namespace Server.Engines.Auction
                 if (m.Backpack != null && m.Backpack.TryDropItem(m, item, false))
                 {
                     m.SendLocalizedMessage(1152339, name); // A reward of ~1_ITEM~ has been placed in your backpack.
+                    Auction.AuctionItem = null;
                     item.Movable = true;
 
                     Auction.Reset();

--- a/Scripts/Items/StoreBought/VirtueShield.cs
+++ b/Scripts/Items/StoreBought/VirtueShield.cs
@@ -9,9 +9,6 @@ namespace Server.Items
         public override int BasePoisonResistance => 8;
         public override int BaseEnergyResistance => 8;
 
-        public override bool CanBeWornByGargoyles => true;
-        public override int LabelNumber => 1109616;  // Virtue Shield
-
         public override int InitMinHits => 255;
         public override int InitMaxHits => 255;
         public override bool IsArtifact => true;

--- a/Scripts/Items/Tools/BaseRunicTool.cs
+++ b/Scripts/Items/Tools/BaseRunicTool.cs
@@ -502,7 +502,7 @@ namespace Server.Items
                 m_Props.Set(0, true); // remove lower requirements from possible properties for leather armor
                 m_Props.Set(2, true); // remove durability bonus from possible properties
             }
-            if (armor.RequiredRace == Race.Elf)
+            if (Race.Elf.ValidateEquipment(armor))
                 m_Props.Set(7, true); // elves inherently have night sight and elf only armor doesn't get night sight as a mod
 
             for (int i = 0; i < attributeCount; ++i)

--- a/Scripts/Misc/RaceDefinitions.cs
+++ b/Scripts/Misc/RaceDefinitions.cs
@@ -1,3 +1,8 @@
+using System;
+using System.Linq;
+
+using Server.Items;
+
 namespace Server.Misc
 {
     public class RaceDefinitions
@@ -114,6 +119,20 @@ namespace Server.Misc
                 int rand = Utility.Random(9);
 
                 return 15172 + rand;
+            }
+
+            public override bool ValidateEquipment(Item item)
+            {
+                var elfOrHuman = item as ICanBeElfOrHuman;
+
+                if (elfOrHuman != null)
+                {
+                    return !elfOrHuman.ElfOnly;
+                }
+
+                var itemID = item.ItemID;
+
+                return !GargoyleOnlyIDs.Any(id => id == itemID) && !ElfOnlyIDs.Any(id => id == itemID);
             }
 
             public override int ClipSkinHue(int hue)
@@ -250,6 +269,20 @@ namespace Server.Misc
                 return 15172 + rand;
             }
 
+            public override bool ValidateEquipment(Item item)
+            {
+                var elfOrHuman = item as ICanBeElfOrHuman;
+
+                if (elfOrHuman != null && elfOrHuman.ElfOnly)
+                {
+                    return true;
+                }
+
+                var itemID = item.ItemID;
+
+                return !GargoyleOnlyIDs.Any(id => id == itemID);
+            }
+
             public override int ClipSkinHue(int hue)
             {
                 for (int i = 0; i < m_SkinHues.Length; i++)
@@ -378,6 +411,13 @@ namespace Server.Misc
                 return 22137 + rand;
             }
 
+            public override bool ValidateEquipment(Item item)
+            {
+                var itemID = item.ItemID;
+
+                return !(item is BaseQuiver) && GargoyleOnlyIDs.Any(id => id == itemID);
+            }
+
             public override int ClipSkinHue(int hue)
             {
                 return hue; // for hue infomation gathering
@@ -419,5 +459,169 @@ namespace Server.Misc
                 return RandomSkinHue();
             }
         }
+
+        public static bool ValidateEquipment(Mobile from, Item equipment)
+        {
+            return ValidateEquipment(from, equipment, true);
+        }
+
+        public static bool ValidateEquipment(Mobile from, Item equipment, bool message)
+        {
+            if (AllRaceTypes.Any(type => type == equipment.GetType()) || AllRaceIDs.Any(id => id == equipment.ItemID))
+            {
+                return true;
+            }
+
+            if (!from.Race.ValidateEquipment(equipment))
+            {
+                if (from.Race == Race.Gargoyle)
+                {
+                    if (message)
+                    {
+                        from.LocalOverheadMessage(Network.MessageType.Regular, 0x3B2, 1111708); // Gargoyles can't wear this.
+                    }
+                }
+                else
+                {
+                    var required = GetRequiredRace(equipment);
+
+                    if (required == Race.Elf)
+                    {
+                        if (from.FindItemOnLayer(Layer.Earrings) is MorphEarrings)
+                        {
+                            return true;
+                        }
+
+                        if (message)
+                        {
+                            from.SendLocalizedMessage(1072203); // Only Elves may use this.
+                        }
+                    }
+                    else if (required == Race.Gargoyle)
+                    {
+                        if (message)
+                        {
+                            from.LocalOverheadMessage(Network.MessageType.Regular, 0x3B2, 1111707); // Only gargoyles can wear this.
+                        }
+                    }
+                    else if (required != Race.Human)
+                    {
+                        if (message)
+                        {
+                            from.SendMessage("Only {0} may use this.", required.PluralName);
+                        }
+                    }
+                }
+
+                return false;
+            }
+
+            return true;
+        }
+
+        public static Race GetRequiredRace(Item item)
+        {
+            var itemID = item.ItemID;
+
+            if (GargoyleOnlyIDs.Any(id => id == itemID))
+            {
+                return Race.Gargoyle;
+            }
+
+            if (ElfOnlyIDs.Any(id => id == itemID))
+            {
+                return Race.Elf;
+            }
+
+            var elfOrHuman = item as ICanBeElfOrHuman;
+
+            if (elfOrHuman != null && elfOrHuman.ElfOnly)
+            {
+                return Race.Elf;
+            }
+
+            return Race.Human;
+        }
+
+        public static Type[] AllRaceTypes = new[]
+        {
+            typeof(BootsOfBallast)
+        };
+
+        public static int[] AllRaceIDs = new[]
+        {
+            0xA289, 0xA28A, 0xA28B, 0xA291, 0xA292, 0xA293, // whips
+            0xE85, 0xE86, // Tools
+            0x1F03, 0x1F04, // Robe
+            0xE81,
+        };
+
+        public static int[] GargoyleOnlyIDs = new[]
+        {
+            0x283, 0x284, 0x286, 0x287, 0x288, 0x289, 0x28A,        // Armor
+            0x301, 0x302, 0x303, 0x304, 0x305, 0x306, 0x310, 0x311, 
+            0x307, 0x308, 0x309, 0x30A, 0x30B, 0x30C, 0x30D, 0x30E, 
+            0x403, 0x404, 0x405, 0x406, 0x407, 0x408, 0x409, 0x40A, 
+
+            0x8FD, 0x8FE, 0x8FF, 0x900, 0x901, 0x902, 0x903, 0x904, // Weapons
+            0x905, 0x906, 0x907, 0x908, 0x909, 0x90A, 0x90B, 0x90C,
+            0x48AE, 0x48AF, 0x48B0, 0x48B1, 0x48B2, 0x48B3, 0x48B4,
+            0x48B5, 0x48B6, 0x48B7, 0x48B8, 0x48B9, 0x48BA, 0x48BB,
+            0x48BC, 0x48BD, 0x48BE, 0x48BF, 0x48C0, 0x48C1, 0x48C2,
+            0x48C3, 0x48C4, 0x48C5, 0x48C6, 0x48C7, 0x48C8, 0x48C9,
+            0x48CA, 0x48CB, 0x48CC, 0x48CD, 0x48CE, 0x48CF, 0x48D0,
+            0x48D1, 0x48D2, 0x48D3,
+
+            0x4000, 0x4001, 0x4002, 0x4003,                         // Robes
+            0x9986,                                                 // Apaulets
+
+            0x4047, 0x4048, 0x4049, 0x404A, 0x404B, 0x404C, 0x404D, // Armor/Weapons
+            0x404E, 0x404F, 0x4050, 0x4051, 0x4052, 0x4053, 0x4054,
+            0x4055, 0x4056, 0x4057, 0x4058, 0x4058, 0x4059, 0x405A,
+            0x405B, 0x405C, 0x405D, 0x405E, 0x405F, 0x4060, 0x4061,
+            0x4062, 0x4063, 0x4064, 0x4065, 0x4066, 0x4067, 0x4068,
+            0x4068, 0x4069, 0x406A, 0x406B, 0x406C, 0x406D, 0x406E,
+            0x406F, 0x4070, 0x4071, 0x4072, 0x4072, 0x7073, 0x4074,
+            0x4075, 0x4076,
+
+            0x4200, 0x4201, 0x4202, 0x4203, 0x4204, 0x4205, 0x4206, // Shields
+            0x4207, 0x4208, 0x4209, 0x420A, 0x420B, 0x4228, 0x4229,
+            0x422A, 0x422C,
+
+            0x4210, 0x4211, 0x4212, 0x4213, 0x4D0A, 0x4D0B,        // Jewelry
+
+            0x450D, 0x450E,                                         // Belts
+            0x457E, 0x457F, 0x45A4, 0x45A5,                         // Wing Armor
+            0x45B1, 0x45B3, 0x4644, 0x4645,                         // Glasses
+            0x46AA, 0x46AB, 0x46B4, 0x46B5,                         // Sashes
+
+            0xA1C9, 0xA1CA                                          // Special
+        };
+
+        public static int[] ElfOnlyIDs = new[]
+        {
+            0x2B67, 0x2B68, 0x2B69, 0x2B6A, 0x2B6B, 0x2B6C, 0x2B6D, // Armor
+            0x2B6E, 0x2B6F, 0x2B70, 0x2B71, 0x2B72, 0x2B73, 0x2B74,
+            0x2B75, 0x2B76, 0x2B77, 0x2B78, 0x2B79, 0x3160, 0x3161,
+            0x3162, 0x3163, 0x3164, 0x3165, 0x3166, 0x3167, 0x3168,
+            0x3169, 0x316A, 0x316B, 0x316C, 0x316D, 0x316E, 0x316F,
+            0x3170, 0x3171, 0x3172, 0x3173, 0x3174, 0x3175, 0x3176,
+            0x3177, 0x3178, 0x3179, 0x317A, 0x317B, 0x317C, 0x317D,
+            0x317E, 0x317F, 0x3180, 0x3181,
+
+            0x2D1E, 0x2D1F, 0x2D20, 0x2D21, 0x2D22, 0x2D23, 0x2D24, // Weapons
+            0x2D25, 0x2D26, 0x2D27, 0x2D28, 0x2D29, 0x2D2A, 0x2D2B,
+            0x2D2C, 0x2D2D, 0x2D2E, 0x2D2F, 0x2D30, 0x2D31, 0x2D32,
+            0x2D33, 0x2D34, 0x2D35, 0x316A, 0x316B, 0x316C, 0x316D,
+                
+            0x2FB8,                                                 // Glasses
+
+            0x2FB9, 0x2FBA,                                         // Robes
+
+            0x2FC3, 0x2FC4, 0x2FC5, 0x2FC6, 0x2FC7, 0x2FC8, 0x2FC9, // Cloths
+            0x2FCA, 0x2FCB,
+
+            0x315F, // Belt
+        };
     }
 }

--- a/Scripts/Misc/RaceDefinitions.cs
+++ b/Scripts/Misc/RaceDefinitions.cs
@@ -543,12 +543,14 @@ namespace Server.Misc
             return Race.Human;
         }
 
-        public static Type[] AllRaceTypes = new[]
-        {
+        public static Type[] AllRaceTypes { get { return _AllRaceTypes; } }
+        private static Type[] _AllRaceTypes = new[]
+         {
             typeof(BootsOfBallast)
         };
 
-        public static int[] AllRaceIDs = new[]
+        public static int[] AllRaceIDs { get { return _AllRaceIDs; } }
+        private static int[] _AllRaceIDs = new[]
         {
             0xA289, 0xA28A, 0xA28B, 0xA291, 0xA292, 0xA293, // whips
             0xE85, 0xE86, // Tools
@@ -556,7 +558,8 @@ namespace Server.Misc
             0xE81,
         };
 
-        public static int[] GargoyleOnlyIDs = new[]
+        public static int[] GargoyleOnlyIDs { get { return _GargoyleOnlyIDs; } }
+        private static int[] _GargoyleOnlyIDs = new[]
         {
             0x283, 0x284, 0x286, 0x287, 0x288, 0x289, 0x28A,        // Armor
             0x301, 0x302, 0x303, 0x304, 0x305, 0x306, 0x310, 0x311, 
@@ -598,7 +601,8 @@ namespace Server.Misc
             0xA1C9, 0xA1CA                                          // Special
         };
 
-        public static int[] ElfOnlyIDs = new[]
+        public static int[] ElfOnlyIDs { get { return _ElfOnlyIDs; } }
+        private static int[] _ElfOnlyIDs = new[]
         {
             0x2B67, 0x2B68, 0x2B69, 0x2B6A, 0x2B6B, 0x2B6C, 0x2B6D, // Armor
             0x2B6E, 0x2B6F, 0x2B70, 0x2B71, 0x2B72, 0x2B73, 0x2B74,

--- a/Scripts/Mobiles/AI/BaseAI.cs
+++ b/Scripts/Mobiles/AI/BaseAI.cs
@@ -1812,8 +1812,10 @@ namespace Server.Mobiles
             {
                 Timer.DelayCall(TimeSpan.FromSeconds(2), m_Mobile.Delete);
             }
-
-            m_Mobile.BeginDeleteTimer();
+            else
+            {
+                m_Mobile.BeginDeleteTimer();
+            }
 
             if (m_Mobile is BaseHire)
             {

--- a/Scripts/Mobiles/NPCs/Mannequin/Property/OtherProperty.cs
+++ b/Scripts/Mobiles/NPCs/Mannequin/Property/OtherProperty.cs
@@ -1,4 +1,6 @@
 using Server.Items;
+using Server.Misc;
+
 using System.Collections.Generic;
 
 namespace Server.Mobiles.MannequinProperty
@@ -158,19 +160,7 @@ namespace Server.Mobiles.MannequinProperty
 
         public override bool Matches(Item item)
         {
-            if (item is BaseArmor && ((BaseArmor)item).CanBeWornByGargoyles)
-                return true;
-
-            if (item is BaseJewel && ((BaseJewel)item).CanBeWornByGargoyles)
-                return true;
-
-            if (item is BaseWeapon && ((BaseWeapon)item).CanBeWornByGargoyles)
-                return true;
-
-            if (item is BaseClothing && ((BaseClothing)item).CanBeWornByGargoyles)
-                return true;
-
-            return false;
+            return RaceDefinitions.GetRequiredRace(item) == Race.Gargoyle;
         }
     }
 
@@ -184,19 +174,7 @@ namespace Server.Mobiles.MannequinProperty
 
         public override bool Matches(Item item)
         {
-            if (item is BaseArmor && ((BaseArmor)item).RequiredRace == Race.Elf)
-                return true;
-
-            if (item is BaseJewel && ((BaseJewel)item).RequiredRace == Race.Elf)
-                return true;
-
-            if (item is BaseWeapon && ((BaseWeapon)item).RequiredRace == Race.Elf)
-                return true;
-
-            if (item is BaseClothing && ((BaseClothing)item).RequiredRace == Race.Elf)
-                return true;
-
-            return false;
+            return RaceDefinitions.GetRequiredRace(item) == Race.Elf;
         }
     }
 

--- a/Scripts/Mobiles/NPCs/PlayerVendor.cs
+++ b/Scripts/Mobiles/NPCs/PlayerVendor.cs
@@ -231,7 +231,6 @@ namespace Server.Mobiles
         private Hashtable m_SellItems;
         private BaseHouse m_House;
         private string m_ShopName;
-        private Timer m_PayTimer;
 
         public double CommissionPerc => 5.25;
         public virtual bool IsCommission => false;
@@ -258,16 +257,8 @@ namespace Server.Mobiles
 
             if (!IsCommission)
             {
-                TimeSpan delay = PayTimer.GetInterval();
-
-                m_PayTimer = new PayTimer(this, delay);
-                m_PayTimer.Start();
-
-                NextPayTime = DateTime.UtcNow + delay;
+                NextPayTime = DateTime.UtcNow + PayTimer.GetInterval();
             }
-
-            if (PlayerVendors == null)
-                PlayerVendors = new List<PlayerVendor>();
 
             PlayerVendors.Add(this);
         }
@@ -308,7 +299,7 @@ namespace Server.Mobiles
         }
 
         [CommandProperty(AccessLevel.GameMaster)]
-        public DateTime NextPayTime { get; private set; }
+        public DateTime NextPayTime { get; set; }
 
         public PlayerVendorPlaceholder Placeholder { get; set; }
 
@@ -481,18 +472,7 @@ namespace Server.Mobiles
                 VendorSearch = true;
             }
 
-            if (!IsCommission)
-            {
-                TimeSpan delay = NextPayTime - DateTime.UtcNow;
-
-                m_PayTimer = new PayTimer(this, delay > TimeSpan.Zero ? delay : TimeSpan.Zero);
-                m_PayTimer.Start();
-            }
-
             Blessed = false;
-
-            if (PlayerVendors == null)
-                PlayerVendors = new List<PlayerVendor>();
 
             PlayerVendors.Add(this);
         }
@@ -635,11 +615,6 @@ namespace Server.Mobiles
         public override void OnAfterDelete()
         {
             base.OnAfterDelete();
-
-            if (m_PayTimer != null)
-            {
-                m_PayTimer.Stop();
-            }
 
             House = null;
 
@@ -1300,44 +1275,6 @@ namespace Server.Mobiles
             }
         }
 
-        private class PayTimer : Timer
-        {
-            private readonly PlayerVendor m_Vendor;
-
-            public PayTimer(PlayerVendor vendor, TimeSpan delay)
-                : base(delay, GetInterval())
-            {
-                m_Vendor = vendor;
-
-                Priority = TimerPriority.OneMinute;
-            }
-
-            public static TimeSpan GetInterval()
-            {
-                return TimeSpan.FromDays(1.0);
-            }
-
-            protected override void OnTick()
-            {
-                m_Vendor.NextPayTime = DateTime.UtcNow + Interval;
-
-                int pay;
-                int totalGold;
-
-                pay = m_Vendor.ChargePerRealWorldDay;
-                totalGold = m_Vendor.HoldGold;
-
-                if (pay > totalGold)
-                {
-                    m_Vendor.Destroy(false);
-                }
-                else
-                {                   
-                    m_Vendor.HoldGold -= pay;
-                }
-            }
-        }
-
         [PlayerVendorTarget]
         private class PVBuyTarget : Target
         {
@@ -1559,7 +1496,7 @@ namespace Server.Mobiles
             }
         }
 
-        public static List<PlayerVendor> PlayerVendors { get; set; }
+        public static List<PlayerVendor> PlayerVendors { get; set; } = new List<PlayerVendor>();
     }
 
     public class PlayerVendorPlaceholder : Item
@@ -1642,6 +1579,78 @@ namespace Server.Mobiles
             {
                 m_Placeholder.Delete();
             }
+        }
+    }
+
+    public class PayTimer : Timer
+    {
+        public static void Initialize()
+        {
+            var timer = new PayTimer();
+            timer.Start();
+        }  
+
+        public PayTimer()
+            : base(TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1))
+        {
+        }
+
+        public static TimeSpan GetInterval()
+        {
+            return TimeSpan.FromDays(1.0);
+        }
+
+        protected override void OnTick()
+        {
+            var list = PlayerVendor.PlayerVendors.Where(v => !v.IsCommission && v.NextPayTime <= DateTime.UtcNow).ToList();
+
+            for (int i = 0; i < list.Count; i++)
+            {
+                var vendor = list[i];
+                vendor.NextPayTime = DateTime.UtcNow + GetInterval();
+
+                int pay;
+                int totalGold;
+
+                pay = vendor.ChargePerRealWorldDay;
+                totalGold = vendor.HoldGold;
+
+                if (pay > totalGold)
+                {
+                    vendor.Destroy(false);
+                }
+                else
+                {
+                    vendor.HoldGold -= pay;
+                }
+            }
+
+            ColUtility.Free(list);
+
+            var rentals = PlayerVendor.PlayerVendors.OfType<RentedVendor>().Where(rv => rv.RentalExpireTime <= DateTime.UtcNow).ToList();
+
+            for (int i = 0; i < rentals.Count; i++)
+            {
+                var vendor = rentals[i];
+
+                int renewalPrice = vendor.RenewalPrice;
+
+                if (vendor.Renew && vendor.HoldGold >= renewalPrice)
+                {
+                    vendor.HoldGold -= renewalPrice;
+                    vendor.RentalGold += renewalPrice;
+
+                    vendor.RentalPrice = renewalPrice;
+
+                    vendor.RentalExpireTime = DateTime.UtcNow + vendor.RentalDuration.Duration;
+                }
+                else
+                {
+                    vendor.Destroy(false);
+                }
+            }
+
+            ColUtility.Free(rentals);
         }
     }
 }

--- a/Scripts/Mobiles/NPCs/RentedVendor.cs
+++ b/Scripts/Mobiles/NPCs/RentedVendor.cs
@@ -54,7 +54,6 @@ namespace Server.Mobiles
         private int m_RenewalPrice;
         private int m_RentalGold;
         private DateTime m_RentalExpireTime;
-        //private Timer m_RentalExpireTimer;
 
         public RentedVendor(Mobile owner, BaseHouse house, VendorRentalDuration duration, int rentalPrice, bool landlordRenew, int rentalGold)
             : base(owner, house)
@@ -67,8 +66,6 @@ namespace Server.Mobiles
             m_RentalGold = rentalGold;
 
             m_RentalExpireTime = DateTime.UtcNow + duration.Duration;
-            //m_RentalExpireTimer = new RentalExpireTimer(this, duration.Duration);
-            //m_RentalExpireTimer.Start();
         }
 
         public RentedVendor(Serial serial)
@@ -277,10 +274,6 @@ namespace Server.Mobiles
             m_RentalGold = reader.ReadInt();
 
             m_RentalExpireTime = reader.ReadDeltaTime();
-
-            //TimeSpan delay = m_RentalExpireTime - DateTime.UtcNow;
-            //m_RentalExpireTimer = new RentalExpireTimer(this, delay > TimeSpan.Zero ? delay : TimeSpan.Zero);
-            //m_RentalExpireTimer.Start();
         }
 
         private class ContractOptionsEntry : ContextMenuEntry
@@ -409,38 +402,6 @@ namespace Server.Mobiles
 
                     owner.CloseGump(typeof(VendorRentalRefundGump));
                     owner.SendGump(new VendorRentalRefundGump(m_Vendor, from, amount));
-                }
-            }
-        }
-
-        private class RentalExpireTimer : Timer
-        {
-            private readonly RentedVendor m_Vendor;
-
-            public RentalExpireTimer(RentedVendor vendor, TimeSpan delay)
-                : base(delay, vendor.RentalDuration.Duration)
-            {
-                m_Vendor = vendor;
-
-                Priority = TimerPriority.OneMinute;
-            }
-
-            protected override void OnTick()
-            {
-                int renewalPrice = m_Vendor.RenewalPrice;
-
-                if (m_Vendor.Renew && m_Vendor.HoldGold >= renewalPrice)
-                {
-                    m_Vendor.HoldGold -= renewalPrice;
-                    m_Vendor.RentalGold += renewalPrice;
-
-                    m_Vendor.RentalPrice = renewalPrice;
-
-                    m_Vendor.m_RentalExpireTime = DateTime.UtcNow + m_Vendor.RentalDuration.Duration;
-                }
-                else
-                {
-                    m_Vendor.Destroy(false);
                 }
             }
         }

--- a/Scripts/Mobiles/NPCs/RentedVendor.cs
+++ b/Scripts/Mobiles/NPCs/RentedVendor.cs
@@ -54,7 +54,7 @@ namespace Server.Mobiles
         private int m_RenewalPrice;
         private int m_RentalGold;
         private DateTime m_RentalExpireTime;
-        private Timer m_RentalExpireTimer;
+        //private Timer m_RentalExpireTimer;
 
         public RentedVendor(Mobile owner, BaseHouse house, VendorRentalDuration duration, int rentalPrice, bool landlordRenew, int rentalGold)
             : base(owner, house)
@@ -67,8 +67,8 @@ namespace Server.Mobiles
             m_RentalGold = rentalGold;
 
             m_RentalExpireTime = DateTime.UtcNow + duration.Duration;
-            m_RentalExpireTimer = new RentalExpireTimer(this, duration.Duration);
-            m_RentalExpireTimer.Start();
+            //m_RentalExpireTimer = new RentalExpireTimer(this, duration.Duration);
+            //m_RentalExpireTimer.Start();
         }
 
         public RentedVendor(Serial serial)
@@ -196,13 +196,6 @@ namespace Server.Mobiles
             to.SendLocalizedMessage(1062464, days.ToString() + "\t" + hours.ToString()); // The rental contract on this vendor will expire in ~1_DAY~ day(s) and ~2_HOUR~ hour(s).
         }
 
-        public override void OnAfterDelete()
-        {
-            base.OnAfterDelete();
-
-            m_RentalExpireTimer.Stop();
-        }
-
         public override void Destroy(bool toBackpack)
         {
             if (RentalGold > 0 && House != null)
@@ -285,9 +278,9 @@ namespace Server.Mobiles
 
             m_RentalExpireTime = reader.ReadDeltaTime();
 
-            TimeSpan delay = m_RentalExpireTime - DateTime.UtcNow;
-            m_RentalExpireTimer = new RentalExpireTimer(this, delay > TimeSpan.Zero ? delay : TimeSpan.Zero);
-            m_RentalExpireTimer.Start();
+            //TimeSpan delay = m_RentalExpireTime - DateTime.UtcNow;
+            //m_RentalExpireTimer = new RentalExpireTimer(this, delay > TimeSpan.Zero ? delay : TimeSpan.Zero);
+            //m_RentalExpireTimer.Start();
         }
 
         private class ContractOptionsEntry : ContextMenuEntry

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -347,6 +347,7 @@ namespace Server.Mobiles
             set
             {
                 m_IsStabled = value;
+
                 if (m_IsStabled)
                 {
                     StopDeleteTimer();
@@ -434,6 +435,7 @@ namespace Server.Mobiles
         private bool m_IsDeadPet;
         private DateTime m_BondingBegin;
         private DateTime m_OwnerAbandonTime;
+        private DateTime m_DeleteTime;
 
         [CommandProperty(AccessLevel.GameMaster)]
         public Spawner MySpawner
@@ -482,58 +484,23 @@ namespace Server.Mobiles
 
         [CommandProperty(AccessLevel.GameMaster)]
         public DateTime OwnerAbandonTime { get { return m_OwnerAbandonTime; } set { m_OwnerAbandonTime = value; } }
-        #endregion
-
-        #region Delete Previously Tamed Timer
-        private DeleteTimer m_DeleteTimer;
 
         [CommandProperty(AccessLevel.GameMaster)]
-        public TimeSpan DeleteTimeLeft
+        public DateTime DeleteTime
         {
-            get
+            get { return m_DeleteTime; }
+            set
             {
-                if (m_DeleteTimer != null && m_DeleteTimer.Running)
+                m_DeleteTime = value;
+
+                if (m_DeleteTime != DateTime.MinValue)
                 {
-                    return m_DeleteTimer.Next - DateTime.UtcNow;
+                    CreatureDeleteTimer.RegisterTimer(this);
                 }
-
-                return TimeSpan.Zero;
-            }
-        }
-
-        private class DeleteTimer : Timer
-        {
-            private readonly Mobile m;
-
-            public DeleteTimer(Mobile creature, TimeSpan delay)
-                : base(delay)
-            {
-                m = creature;
-                Priority = TimerPriority.OneMinute;
-            }
-
-            protected override void OnTick()
-            {
-                m.Delete();
-            }
-        }
-
-        public void BeginDeleteTimer()
-        {
-            if (!Summoned && !Deleted && !IsStabled)
-            {
-                StopDeleteTimer();
-                m_DeleteTimer = new DeleteTimer(this, TimeSpan.FromDays(3.0));
-                m_DeleteTimer.Start();
-            }
-        }
-
-        public void StopDeleteTimer()
-        {
-            if (m_DeleteTimer != null)
-            {
-                m_DeleteTimer.Stop();
-                m_DeleteTimer = null;
+                else
+                {
+                    CreatureDeleteTimer.RemoveFromTimer(this);
+                }
             }
         }
         #endregion
@@ -1468,6 +1435,18 @@ namespace Server.Mobiles
             return ((double)chance / 1000);
         }
 
+        public static readonly TimeSpan DeleteTimeSpan = TimeSpan.FromDays(3);
+
+        public virtual void BeginDeleteTimer()
+        {
+            DeleteTime = DateTime.UtcNow + DeleteTimeSpan;
+        }
+
+        public virtual void StopDeleteTimer()
+        {
+            DeleteTime = DateTime.MinValue;
+        }
+
         public virtual bool CanTransfer(Mobile m)
         {
             return !Allured;
@@ -2217,7 +2196,7 @@ namespace Server.Mobiles
         {
             base.Serialize(writer);
 
-            writer.Write(31); // version
+            writer.Write(32); // version
 
             writer.Write(StealPackGenerated);
             writer.Write(HasBeenStolen);
@@ -2347,11 +2326,11 @@ namespace Server.Mobiles
             // Version 17
             if (IsStabled || (Controlled && ControlMaster != null))
             {
-                writer.Write(TimeSpan.Zero);
+                writer.Write(DateTime.MinValue);
             }
             else
             {
-                writer.Write(DeleteTimeLeft);
+                writer.Write(m_DeleteTime);
             }
 
             // Version 18
@@ -2405,6 +2384,7 @@ namespace Server.Mobiles
 
             switch (version)
             {
+                case 32:
                 case 31:
                     StealPackGenerated = reader.ReadBool();
                     HasBeenStolen = reader.ReadBool();
@@ -2637,18 +2617,19 @@ namespace Server.Mobiles
 
             if (version >= 17)
             {
-                deleteTime = reader.ReadTimeSpan();
-            }
-
-            if (deleteTime > TimeSpan.Zero || LastOwner != null && !Controlled && !IsStabled)
-            {
-                if (deleteTime == TimeSpan.Zero)
+                if (version < 32)
                 {
-                    deleteTime = TimeSpan.FromDays(3.0);
-                }
+                    var span = reader.ReadTimeSpan();
 
-                m_DeleteTimer = new DeleteTimer(this, deleteTime);
-                m_DeleteTimer.Start();
+                    if (span > TimeSpan.Zero)
+                    {
+                        DeleteTime = DateTime.UtcNow + reader.ReadTimeSpan();
+                    }
+                }
+                else
+                {
+                    DeleteTime = reader.ReadDateTime();
+                }
             }
 
             if (version >= 18)
@@ -3408,6 +3389,7 @@ namespace Server.Mobiles
                 RemoveFollowers();
                 m_ControlMaster = value;
                 AddFollowers();
+
                 if (m_ControlMaster != null)
                 {
                     StopDeleteTimer();
@@ -3719,18 +3701,9 @@ namespace Server.Mobiles
                 m_AI = null;
             }
 
-            if (m_DeleteTimer != null)
-            {
-                m_DeleteTimer.Stop();
-                m_DeleteTimer = null;
-            }
+            StopDeleteTimer();
 
             FocusMob = null;
-
-            if (IsAnimatedDead)
-            {
-                AnimateDeadSpell.Unregister(m_SummonMaster, this);
-            }
 
             base.OnAfterDelete();
         }
@@ -6201,11 +6174,7 @@ namespace Server.Mobiles
                 AdjustSpeeds();
                 CurrentSpeed = m_dActiveSpeed;
 
-                if (m_DeleteTimer != null)
-                {
-                    m_DeleteTimer.Stop();
-                    m_DeleteTimer = null;
-                }
+                StopDeleteTimer();
 
                 RemoveAggressed(m);
                 RemoveAggressor(m);
@@ -7553,6 +7522,76 @@ namespace Server.Mobiles
             ColUtility.Free(toRemove);
         }
     }
+
+    #region Delete Previously Tamed Timer
+    public class CreatureDeleteTimer : Timer
+    {
+        public static CreatureDeleteTimer Instance { get; set; }
+
+        public List<BaseCreature> ToDelete { get; set; } = new List<BaseCreature>();
+
+        public CreatureDeleteTimer()
+            : base(TimeSpan.FromMinutes(5), TimeSpan.FromSeconds(5))
+        {
+            Priority = TimerPriority.OneMinute;
+        }
+
+        protected override void OnTick()
+        {
+            var toDelete = ToDelete.Where(bc => bc.Deleted || bc.DeleteTime < DateTime.UtcNow).ToList();
+
+            for (int i = 0; i < toDelete.Count; i++)
+            {
+                var bc = toDelete[i];
+
+                if (!bc.Summoned && !bc.Deleted && !bc.IsStabled && bc.DeleteTime != DateTime.MinValue)
+                {
+                    bc.Delete();
+                }
+
+                RemoveFromTimer(bc);
+            }
+
+            ColUtility.Free(toDelete);
+        }
+
+        public static void RegisterTimer(BaseCreature bc)
+        {
+            if (Instance == null)
+            {
+                Instance = new CreatureDeleteTimer();
+            }
+
+            if (!Instance.Running)
+            {
+                Instance.Start();
+            }
+
+            if (!Instance.ToDelete.Contains(bc) && !bc.Summoned && !bc.Deleted && !bc.IsStabled)
+            {
+                Instance.ToDelete.Add(bc);
+            }
+        }
+
+        public static void RemoveFromTimer(BaseCreature bc)
+        {
+            if (Instance == null)
+            {
+                return;
+            }
+
+            if (Instance.ToDelete.Contains(bc))
+            {
+                Instance.ToDelete.Remove(bc);
+
+                if (Instance.ToDelete.Count == 0)
+                {
+                    Instance.Stop();
+                }
+            }
+        }
+    }
+    #endregion
 
     public sealed class PetWindow : Packet
     {

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -2613,8 +2613,6 @@ namespace Server.Mobiles
                 m_RemoveStep = reader.ReadInt();
             }
 
-            TimeSpan deleteTime = TimeSpan.Zero;
-
             if (version >= 17)
             {
                 if (version < 32)

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -1342,30 +1342,31 @@ namespace Server.Mobiles
                     }
 
                     Item item = items[i];
+                    bool drop = false;
 
-                    bool morph = from.FindItemOnLayer(Layer.Earrings) is MorphEarrings;
+                    if (!RaceDefinitions.ValidateEquipment(from, item, false))
+                    {
+                        drop = true;
+                    }
 
                     if (item is BaseWeapon)
                     {
                         BaseWeapon weapon = (BaseWeapon)item;
 
-                        bool drop = false;
-
-                        if (dex < weapon.DexRequirement)
+                        if (!drop)
                         {
-                            drop = true;
-                        }
-                        else if (str < AOS.Scale(weapon.StrRequirement, 100 - weapon.GetLowerStatReq()))
-                        {
-                            drop = true;
-                        }
-                        else if (intel < weapon.IntRequirement)
-                        {
-                            drop = true;
-                        }
-                        else if (weapon.RequiredRace != null && weapon.RequiredRace != Race && !morph)
-                        {
-                            drop = true;
+                            if (dex < weapon.DexRequirement)
+                            {
+                                drop = true;
+                            }
+                            else if (str < AOS.Scale(weapon.StrRequirement, 100 - weapon.GetLowerStatReq()))
+                            {
+                                drop = true;
+                            }
+                            else if (intel < weapon.IntRequirement)
+                            {
+                                drop = true;
+                            }
                         }
 
                         if (drop)
@@ -1386,37 +1387,34 @@ namespace Server.Mobiles
                     {
                         BaseArmor armor = (BaseArmor)item;
 
-                        bool drop = false;
-
-                        if (!armor.AllowMaleWearer && !from.Female && from.AccessLevel < AccessLevel.GameMaster)
+                        if (!drop)
                         {
-                            drop = true;
-                        }
-                        else if (!armor.AllowFemaleWearer && from.Female && from.AccessLevel < AccessLevel.GameMaster)
-                        {
-                            drop = true;
-                        }
-                        else if (armor.RequiredRace != null && armor.RequiredRace != Race && !morph)
-                        {
-                            drop = true;
-                        }
-                        else
-                        {
-                            int strBonus = armor.ComputeStatBonus(StatType.Str), strReq = armor.ComputeStatReq(StatType.Str);
-                            int dexBonus = armor.ComputeStatBonus(StatType.Dex), dexReq = armor.ComputeStatReq(StatType.Dex);
-                            int intBonus = armor.ComputeStatBonus(StatType.Int), intReq = armor.ComputeStatReq(StatType.Int);
-
-                            if (dex < dexReq || (dex + dexBonus) < 1)
+                            if (!armor.AllowMaleWearer && !from.Female && from.AccessLevel < AccessLevel.GameMaster)
                             {
                                 drop = true;
                             }
-                            else if (str < strReq || (str + strBonus) < 1)
+                            else if (!armor.AllowFemaleWearer && from.Female && from.AccessLevel < AccessLevel.GameMaster)
                             {
                                 drop = true;
                             }
-                            else if (intel < intReq || (intel + intBonus) < 1)
+                            else
                             {
-                                drop = true;
+                                int strBonus = armor.ComputeStatBonus(StatType.Str), strReq = armor.ComputeStatReq(StatType.Str);
+                                int dexBonus = armor.ComputeStatBonus(StatType.Dex), dexReq = armor.ComputeStatReq(StatType.Dex);
+                                int intBonus = armor.ComputeStatBonus(StatType.Int), intReq = armor.ComputeStatReq(StatType.Int);
+
+                                if (dex < dexReq || (dex + dexBonus) < 1)
+                                {
+                                    drop = true;
+                                }
+                                else if (str < strReq || (str + strBonus) < 1)
+                                {
+                                    drop = true;
+                                }
+                                else if (intel < intReq || (intel + intBonus) < 1)
+                                {
+                                    drop = true;
+                                }
                             }
                         }
 
@@ -1446,28 +1444,25 @@ namespace Server.Mobiles
                     {
                         BaseClothing clothing = (BaseClothing)item;
 
-                        bool drop = false;
-
-                        if (!clothing.AllowMaleWearer && !from.Female && from.AccessLevel < AccessLevel.GameMaster)
+                        if (!drop)
                         {
-                            drop = true;
-                        }
-                        else if (!clothing.AllowFemaleWearer && from.Female && from.AccessLevel < AccessLevel.GameMaster)
-                        {
-                            drop = true;
-                        }
-                        else if (clothing.RequiredRace != null && clothing.RequiredRace != Race && !morph)
-                        {
-                            drop = true;
-                        }
-                        else
-                        {
-                            int strBonus = clothing.ComputeStatBonus(StatType.Str);
-                            int strReq = clothing.ComputeStatReq(StatType.Str);
-
-                            if (str < strReq || (str + strBonus) < 1)
+                            if (!clothing.AllowMaleWearer && !from.Female && from.AccessLevel < AccessLevel.GameMaster)
                             {
                                 drop = true;
+                            }
+                            else if (!clothing.AllowFemaleWearer && from.Female && from.AccessLevel < AccessLevel.GameMaster)
+                            {
+                                drop = true;
+                            }
+                            else
+                            {
+                                int strBonus = clothing.ComputeStatBonus(StatType.Str);
+                                int strReq = clothing.ComputeStatReq(StatType.Str);
+
+                                if (str < strReq || (str + strBonus) < 1)
+                                {
+                                    drop = true;
+                                }
                             }
                         }
 
@@ -1486,15 +1481,12 @@ namespace Server.Mobiles
                             moved = true;
                         }
                     }
-                    else if (item is BaseQuiver)
+                    else if (item is BaseQuiver && drop)
                     {
-                        if (Race == Race.Gargoyle)
-                        {
-                            from.AddToBackpack(item);
+                        from.AddToBackpack(item);
 
-                            from.SendLocalizedMessage(1062002, "quiver"); // You can no longer wear your ~1_ARMOR~
-                            moved = true;
-                        }
+                        from.SendLocalizedMessage(1062002, "quiver"); // You can no longer wear your ~1_ARMOR~
+                        moved = true;
                     }
 
                     #region Vice Vs Virtue

--- a/Scripts/Services/City Loyalty System/Mobiles/Raider.cs
+++ b/Scripts/Services/City Loyalty System/Mobiles/Raider.cs
@@ -7,7 +7,7 @@ namespace Server.Mobiles
 {
     public class Raider : BaseCreature
     {
-        public DateTime DeleteTime { get; set; }
+        public DateTime TimeToDelete { get; set; }
 
         public override bool Commandable => false;
         public override bool ReduceSpeedWithDamage => false;
@@ -97,7 +97,7 @@ namespace Server.Mobiles
             }
             else
             {
-                DeleteTime = DateTime.UtcNow + TimeSpan.FromHours(1);
+                TimeToDelete = DateTime.UtcNow + TimeSpan.FromHours(1);
 
                 SetControlMaster(m);
                 IsBonded = false;
@@ -122,7 +122,7 @@ namespace Server.Mobiles
 
         public void CheckDelete()
         {
-            if (DeleteTime != DateTime.MinValue && DateTime.UtcNow > DeleteTime)
+            if (TimeToDelete != DateTime.MinValue && DateTime.UtcNow > TimeToDelete)
             {
                 if (ControlMaster != null && ControlMaster.NetState != null)
                 {
@@ -152,7 +152,7 @@ namespace Server.Mobiles
 
             Timer.DelayCall(TimeSpan.FromSeconds(10), CheckDelete);
 
-            writer.Write(DeleteTime);
+            writer.Write(TimeToDelete);
         }
 
         public override void Deserialize(GenericReader reader)
@@ -160,7 +160,7 @@ namespace Server.Mobiles
             base.Deserialize(reader);
             int version = reader.ReadInt();
 
-            DeleteTime = reader.ReadDateTime();
+            TimeToDelete = reader.ReadDateTime();
         }
     }
 }

--- a/Scripts/Services/Craft/Core/AlterItem.cs
+++ b/Scripts/Services/Craft/Core/AlterItem.cs
@@ -375,7 +375,7 @@ namespace Server.Engines.Craft
                 if (weapon.SetID != SetItem.None || !weapon.CanAlter || weapon.NegativeAttributes.Antique != 0)
                     return false;
 
-                if ((weapon.RequiredRace != null && weapon.RequiredRace == Race.Gargoyle && !weapon.IsArtifact))
+                if ((Race.Gargoyle.ValidateEquipment(weapon) && !weapon.IsArtifact))
                     return false;
             }
 
@@ -386,7 +386,7 @@ namespace Server.Engines.Craft
                 if (armor.SetID != SetItem.None || !armor.CanAlter || armor.NegativeAttributes.Antique != 0)
                     return false;
 
-                if ((armor.RequiredRace != null && armor.RequiredRace == Race.Gargoyle && !armor.IsArtifact))
+                if ((Race.Gargoyle.ValidateEquipment(armor) && !armor.IsArtifact))
                     return false;
 
                 if (ArmorType.Any(t => t == armor.GetType()) && armor.Resource > CraftResource.Iron)
@@ -400,7 +400,7 @@ namespace Server.Engines.Craft
                 if (cloth.SetID != SetItem.None || !cloth.CanAlter || cloth.NegativeAttributes.Antique != 0)
                     return false;
 
-                if ((cloth.RequiredRace != null && cloth.RequiredRace == Race.Gargoyle && !cloth.IsArtifact))
+                if ((Race.Gargoyle.ValidateEquipment(cloth) && !cloth.IsArtifact))
                     return false;
             }
 

--- a/Scripts/Services/Dungeons/BlackthornDungeon/Items/CloakOfDeathBase/GargishEpauletteBearingTheCrestOfBlackthorn.cs
+++ b/Scripts/Services/Dungeons/BlackthornDungeon/Items/CloakOfDeathBase/GargishEpauletteBearingTheCrestOfBlackthorn.cs
@@ -3,8 +3,6 @@ namespace Server.Items
     public class GargishEpauletteBearingTheCrestOfBlackthorn6 : Cloak
     {
         public override bool IsArtifact => true;
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
 
         public override int LabelNumber => 1123326;  // Gargish Epaulette
 

--- a/Scripts/Services/Dungeons/BlackthornDungeon/Items/CloakOfLifeBase/GargishEpauletteBearingTheCrestOfBlackthorn.cs
+++ b/Scripts/Services/Dungeons/BlackthornDungeon/Items/CloakOfLifeBase/GargishEpauletteBearingTheCrestOfBlackthorn.cs
@@ -3,8 +3,6 @@ namespace Server.Items
     public class GargishEpauletteBearingTheCrestOfBlackthorn5 : Cloak
     {
         public override bool IsArtifact => true;
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
 
         public override int LabelNumber => 1123326;  // Gargish Epaulette
 

--- a/Scripts/Services/Dungeons/BlackthornDungeon/Items/CloakOfPowerBase/GargishEpauletteBearingTheCrestOfBlackthorn.cs
+++ b/Scripts/Services/Dungeons/BlackthornDungeon/Items/CloakOfPowerBase/GargishEpauletteBearingTheCrestOfBlackthorn.cs
@@ -3,8 +3,6 @@ namespace Server.Items
     public class GargishEpauletteBearingTheCrestOfBlackthorn4 : Cloak
     {
         public override bool IsArtifact => true;
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
 
         public override int LabelNumber => 1123326;  // Gargish Epaulette
 

--- a/Scripts/Services/Dungeons/BlackthornDungeon/Items/CloakOfSilenceBase/GargishEpauletteBearingTheCrestOfBlackthorn.cs
+++ b/Scripts/Services/Dungeons/BlackthornDungeon/Items/CloakOfSilenceBase/GargishEpauletteBearingTheCrestOfBlackthorn.cs
@@ -3,8 +3,6 @@ namespace Server.Items
     public class GargishEpauletteBearingTheCrestOfBlackthorn3 : Cloak
     {
         public override bool IsArtifact => true;
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
 
         public override int LabelNumber => 1123326;  // Gargish Epaulette
 

--- a/Scripts/Services/Dungeons/BlackthornDungeon/Items/ConjurersGarbBase/GargishEpauletteBearingTheCrestOfBlackthorn.cs
+++ b/Scripts/Services/Dungeons/BlackthornDungeon/Items/ConjurersGarbBase/GargishEpauletteBearingTheCrestOfBlackthorn.cs
@@ -3,8 +3,6 @@ namespace Server.Items
     public class GargishEpauletteBearingTheCrestOfBlackthorn7 : Cloak
     {
         public override bool IsArtifact => true;
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
 
         public override int LabelNumber => 1123326;  // Gargish Epaulette
 

--- a/Scripts/Services/Dungeons/BlackthornDungeon/Items/MysticsGarbBase/GargishEpauletteBearingTheCrestOfBlackthorn.cs
+++ b/Scripts/Services/Dungeons/BlackthornDungeon/Items/MysticsGarbBase/GargishEpauletteBearingTheCrestOfBlackthorn.cs
@@ -3,8 +3,6 @@ namespace Server.Items
     public class GargishEpauletteBearingTheCrestOfBlackthorn2 : Cloak
     {
         public override bool IsArtifact => true;
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
 
         public override int LabelNumber => 1123326;  // Gargish Epaulette
 

--- a/Scripts/Services/Dungeons/BlackthornDungeon/Items/ShroudOfTheCondemnedBase/GargishEpauletteBearingTheCrestOfBlackthorn.cs
+++ b/Scripts/Services/Dungeons/BlackthornDungeon/Items/ShroudOfTheCondemnedBase/GargishEpauletteBearingTheCrestOfBlackthorn.cs
@@ -3,8 +3,6 @@ namespace Server.Items
     public class GargishEpauletteBearingTheCrestOfBlackthorn1 : Cloak
     {
         public override bool IsArtifact => true;
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
 
         public override int LabelNumber => 1123326;  // Gargish Epaulette
 

--- a/Scripts/Services/Dungeons/Shadowguard/Items.cs
+++ b/Scripts/Services/Dungeons/Shadowguard/Items.cs
@@ -476,13 +476,21 @@ namespace Server.Engines.Shadowguard
             set
             {
                 _Purified = value;
+
+                if (value)
+                {
+                    Hue = 0;
+                }
+
                 InvalidateProperties();
             }
         }
 
         [Constructable]
-        public Phylactery() : base(0x4686)
+        public Phylactery()
+            : base(0x4686)
         {
+            Hue = 2075;
         }
 
         public override void OnDoubleClick(Mobile m)

--- a/Scripts/Services/Dungeons/TheExodusEncounter/Items/ExodusSacrificalDagger.cs
+++ b/Scripts/Services/Dungeons/TheExodusEncounter/Items/ExodusSacrificalDagger.cs
@@ -231,9 +231,6 @@ namespace Server.Items
             Weight = 4.0;
         }
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public ExodusSacrificalGargishDagger(Serial serial) : base(serial)
         {
         }

--- a/Scripts/Services/ExploringTheDeep/Items/QuestItems/BootsOfBallast.cs
+++ b/Scripts/Services/ExploringTheDeep/Items/QuestItems/BootsOfBallast.cs
@@ -1,11 +1,10 @@
-﻿using Server.Network;
+using Server.Network;
 
 namespace Server.Items
 {
     public class BootsOfBallast : Boots
     {
         public override int LabelNumber => 1154242;  // Boots of Ballast
-        public override bool CanBeWornByGargoyles => true;
 
         [Constructable]
         public BootsOfBallast()

--- a/Scripts/Services/ExploringTheDeep/Items/QuestItems/CanvassRobe.cs
+++ b/Scripts/Services/ExploringTheDeep/Items/QuestItems/CanvassRobe.cs
@@ -1,11 +1,10 @@
-﻿using Server.Network;
+using Server.Network;
 
 namespace Server.Items
 {
     public class CanvassRobe : Robe
     {
         public override int LabelNumber => 1154238;  // A Canvass Robe
-        public override bool CanBeWornByGargoyles => true;
 
         [Constructable]
         public CanvassRobe()

--- a/Scripts/Services/LootGeneration/Imbuing/Core/Imbuing.cs
+++ b/Scripts/Services/LootGeneration/Imbuing/Core/Imbuing.cs
@@ -192,12 +192,12 @@ namespace Server.SkillHandlers
             return true;
         }
 
-        private static bool IsSpecialImbuable(Item item)
+        public static bool IsSpecialImbuable(Item item)
         {
             return IsSpecialImbuable(item.GetType());
         }
 
-        private static bool IsSpecialImbuable(Type type)
+        public static bool IsSpecialImbuable(Type type)
         {
             if (_SpecialImbuable.Any(i => i == type))
                 return true;

--- a/Scripts/Services/LootGeneration/ItemPropertyInfo.cs
+++ b/Scripts/Services/LootGeneration/ItemPropertyInfo.cs
@@ -723,8 +723,8 @@ namespace Server.Items
             {
                 PropInfo info = Table[id].GetItemTypeInfo(GetItemType(item));
 
-                // First, we try to get the max intensity from the PropInfo. If null or we're getting an intensity for imbuing purpopses, we go to the default MaxIntenity
-                if (info == null || (imbuing && !_ForceUseNewTable.Any(i => i == id)))
+                // First, we try to get the max intensity from the PropInfo. If null or we're getting an intensity for special imbuing purpopses, we go to the default MaxIntenity
+                if (info == null || (imbuing && !ForcesNewLootMax(item, id)))
                 {
                     if (item is BaseWeapon && (id == 25 || id == 27))
                     {
@@ -745,6 +745,23 @@ namespace Server.Items
             }
 
             return 0;
+        }
+
+        /// <summary>
+        /// We may want to force the new loot tables for items such as ranged weapons that have a different max than melee, think hci/dci (15/25).
+        /// This will be bypassed for special items, such as clockwork leggings
+        /// </summary>
+        /// <param name="item"></param>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        public static bool ForcesNewLootMax(Item item, int id)
+        {
+            if (Server.SkillHandlers.Imbuing.IsSpecialImbuable(item.GetType()))
+            {
+                return false;
+            }
+
+            return _ForceUseNewTable.Any(i => i == id);
         }
 
         public static int[] GetMaxOvercappedRange(Item item, int id)

--- a/Scripts/Services/MondainsLegacyQuests/BaseQuest.cs
+++ b/Scripts/Services/MondainsLegacyQuests/BaseQuest.cs
@@ -126,9 +126,14 @@ namespace Server.Engines.Quests
             m_Rewards = new List<BaseReward>();
         }
 
+        public bool HasTimer()
+        {
+            return m_Objectives.Any(obj => obj.Timed);
+        }
+
         public void StartTimer()
         {
-            if (m_Timer != null)
+            if (m_Timer != null || !HasTimer())
                 return;
 
             m_Timer = Timer.DelayCall(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1), Slice);
@@ -215,7 +220,7 @@ namespace Server.Engines.Quests
                 }
             }
 
-            // tick tack	
+            // tick tack
             StartTimer();
         }
 

--- a/Scripts/Services/New Magincia/MaginciaPlants/Hoe.cs
+++ b/Scripts/Services/New Magincia/MaginciaPlants/Hoe.cs
@@ -28,8 +28,6 @@ namespace Server.Items
         public override int InitMinHits => 31;
         public override int InitMaxHits => 60;
 
-        public override bool CanBeWornByGargoyles => true;
-
         public override WeaponAnimation DefAnimation => WeaponAnimation.Slash1H;
 
         public override void OnDoubleClick(Mobile from)

--- a/Scripts/Services/Seasonal Events/KrampusEncounter/Items/BarbedWhip.cs
+++ b/Scripts/Services/Seasonal Events/KrampusEncounter/Items/BarbedWhip.cs
@@ -17,7 +17,6 @@ namespace Server.Items
         {
         }
 
-        public override bool CanBeWornByGargoyles => true;
         public override WeaponAbility PrimaryAbility => WeaponAbility.ConcussionBlow;
         public override WeaponAbility SecondaryAbility => WeaponAbility.WhirlwindAttack;
         public override int StrengthReq => 20;

--- a/Scripts/Services/Seasonal Events/KrampusEncounter/Items/BladedWhip.cs
+++ b/Scripts/Services/Seasonal Events/KrampusEncounter/Items/BladedWhip.cs
@@ -17,7 +17,6 @@ namespace Server.Items
         {
         }
 
-        public override bool CanBeWornByGargoyles => true;
         public override WeaponAbility PrimaryAbility => WeaponAbility.BleedAttack;
         public override WeaponAbility SecondaryAbility => WeaponAbility.WhirlwindAttack;
         public override int StrengthReq => 20;

--- a/Scripts/Services/Seasonal Events/KrampusEncounter/Items/KrampusMinionEarrings.cs
+++ b/Scripts/Services/Seasonal Events/KrampusEncounter/Items/KrampusMinionEarrings.cs
@@ -16,9 +16,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override ArmorMaterialType MaterialType => ArmorMaterialType.Chainmail;
         public override ArmorMeditationAllowance DefMedAllowance => ArmorMeditationAllowance.All;
 

--- a/Scripts/Services/Seasonal Events/KrampusEncounter/Items/KrampusMinionTalons.cs
+++ b/Scripts/Services/Seasonal Events/KrampusEncounter/Items/KrampusMinionTalons.cs
@@ -22,9 +22,6 @@ namespace Server.Items
         {
         }
 
-        public override Race RequiredRace => Race.Gargoyle;
-        public override bool CanBeWornByGargoyles => true;
-
         public override CraftResource DefaultResource => CraftResource.RegularLeather;
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Services/Seasonal Events/KrampusEncounter/Items/SpikedWhip.cs
+++ b/Scripts/Services/Seasonal Events/KrampusEncounter/Items/SpikedWhip.cs
@@ -17,7 +17,6 @@ namespace Server.Items
         {
         }
 
-        public override bool CanBeWornByGargoyles => true;
         public override WeaponAbility PrimaryAbility => WeaponAbility.ArmorPierce;
         public override WeaponAbility SecondaryAbility => WeaponAbility.WhirlwindAttack;
         public override int StrengthReq => 20;

--- a/Scripts/Services/Vendor Searching/VendorSearch.cs
+++ b/Scripts/Services/Vendor Searching/VendorSearch.cs
@@ -496,46 +496,12 @@ namespace Server.Engines.VendorSearching
 
         public static bool IsGargoyle(Item item)
         {
-            if (item is BaseArmor)
-            {
-                return ((BaseArmor)item).RequiredRace == Race.Gargoyle;
-            }
-            else if (item is BaseWeapon)
-            {
-                return ((BaseWeapon)item).RequiredRace == Race.Gargoyle;
-            }
-            else if (item is BaseClothing)
-            {
-                return ((BaseClothing)item).RequiredRace == Race.Gargoyle;
-            }
-            else if (item is BaseJewel)
-            {
-                return ((BaseJewel)item).RequiredRace == Race.Gargoyle;
-            }
-
-            return false;
+            return Race.Gargoyle.ValidateEquipment(item);
         }
 
         public static bool IsElf(Item item)
         {
-            if (item is BaseArmor)
-            {
-                return ((BaseArmor)item).RequiredRace == Race.Elf;
-            }
-            else if (item is BaseWeapon)
-            {
-                return ((BaseWeapon)item).RequiredRace == Race.Elf;
-            }
-            else if (item is BaseClothing)
-            {
-                return ((BaseClothing)item).RequiredRace == Race.Elf;
-            }
-            else if (item is BaseJewel)
-            {
-                return ((BaseJewel)item).RequiredRace == Race.Elf;
-            }
-
-            return false;
+            return Race.Elf.ValidateEquipment(item);
         }
 
         public static SearchCriteria AddNewContext(PlayerMobile pm)

--- a/Scripts/Services/ViceVsVirtue/Items/Rewards/MorphEarrings.cs
+++ b/Scripts/Services/ViceVsVirtue/Items/Rewards/MorphEarrings.cs
@@ -35,21 +35,12 @@ namespace Server.Items
 
             foreach (Item item in list)
             {
-                bool drop = false;
-
-                if (item is BaseArmor && ((BaseArmor)item).RequiredRace != null && ((BaseArmor)item).RequiredRace != race)
-                    drop = true;
-                else if (item is BaseWeapon && ((BaseWeapon)item).RequiredRace != null && ((BaseWeapon)item).RequiredRace != race)
-                    drop = true;
-                else if (item is BaseJewel && ((BaseJewel)item).RequiredRace != null && ((BaseJewel)item).RequiredRace != race)
-                    drop = true;
-                else if (item is BaseClothing && ((BaseClothing)item).RequiredRace != null && ((BaseClothing)item).RequiredRace != race)
-                    drop = true;
-
-                if (drop)
+                if (!race.ValidateEquipment(item))
                 {
                     if (!didDrop)
+                    {
                         didDrop = true;
+                    }
 
                     if (m.Backpack == null || !m.Backpack.TryDropItem(m, item, false))
                     {
@@ -61,7 +52,9 @@ namespace Server.Items
             ColUtility.Free(list);
 
             if (didDrop)
+            {
                 m.SendLocalizedMessage(500647); // Some equipment has been moved to your backpack.
+            }
         }
 
         public MorphEarrings(Serial serial)

--- a/Scripts/Services/ViceVsVirtue/Items/VvVAltar.cs
+++ b/Scripts/Services/ViceVsVirtue/Items/VvVAltar.cs
@@ -11,7 +11,7 @@ namespace Server.Engines.VvV
 
         [CommandProperty(AccessLevel.GameMaster)]
         public bool IsActive { get; set; }
-
+        
         public List<Item> Braziers { get; set; }
         public List<Item> Torches { get; set; }
 
@@ -269,8 +269,11 @@ namespace Server.Engines.VvV
 
         private void Clear()
         {
-            OccupationTimer.Stop();
-            OccupationTimer = null;
+            if (OccupationTimer != null)
+            {
+                OccupationTimer.Stop();
+                OccupationTimer = null;
+            }
 
             Torches.ForEach(t => t.Delete());
             Torches.Clear();
@@ -349,6 +352,18 @@ namespace Server.Engines.VvV
             base.Delete();
 
             Torches.ForEach(t => t.Delete());
+
+            if (OccupationTimer != null)
+            {
+                OccupationTimer.Stop();
+                OccupationTimer = null;
+            }
+
+            if (CheckTimer != null)
+            {
+                CheckTimer.Stop();
+                CheckTimer = null;
+            }
         }
 
         public VvVAltar(Serial serial)

--- a/Server/Race.cs
+++ b/Server/Race.cs
@@ -165,6 +165,8 @@ namespace Server
         }
         public abstract int RandomFace(bool female);
 
+        public abstract bool ValidateEquipment(Item item);
+
         public abstract int ClipSkinHue(int hue);
         public abstract int RandomSkinHue();
 


### PR DESCRIPTION
- Removed CanBeWornByGargoyle, RequiredRace properties from all equipment. It is now handled in RaceDefinitions.cs and each race is responsible for validating their own equipment. It is, for the most part, done by ItemID
- Consolidated various timers into one static timer: PlayerVendor, RentedVendor, FountainOfLife, Hireables
- Fixed a few timer memory leaks
- Clockwork leggings can now be imbued
- Fixed Phylactery hue