### PR TITLE
Fix

### DIFF
--- a/Scripts/Quests/Eodon/Hawkwind/Hawkwind.cs
+++ b/Scripts/Quests/Eodon/Hawkwind/Hawkwind.cs
@@ -39,7 +39,10 @@ namespace Server.Engines.Quests.TimeLord
         public override void OnTalk(PlayerMobile player, bool contextMenu)
         {
             if (player.Quest is TimeForLegendsQuest && ((TimeForLegendsQuest)player.Quest).Objectives.Count == 0)
+            {
+                player.CloseGump(typeof(ChooseMasteryGump));
                 player.SendGump(new ChooseMasteryGump(player, (TimeForLegendsQuest)player.Quest));
+            }
             else if (player.Quest == null && CanRecieveQuest(player))
             {
                 Direction = GetDirectionTo(player);


### PR DESCRIPTION
Fixes an exploit where you could claim the gump over and over and then on completion of the quest get X times the reward. X being how ever many times you exploited the gump at the beginning.