### PR TITLE
Timers

### DIFF
--- a/Scripts/Services/XmlSpawner/XmlSpawner2.cs
+++ b/Scripts/Services/XmlSpawner/XmlSpawner2.cs
@@ -11370,9 +11370,11 @@ namespace Server.Mobiles
             public SpawnerTimer(XmlSpawner spawner, TimeSpan delay)
                 : base(delay)
             {
-
-                // reduce timer priority if spawner is inactivated
-                if (spawner.IsInactivated)
+                if (spawner.IsInactivated) // reduce timer priority if spawner is inactivated
+                {
+                    Priority = TimerPriority.FiveSeconds;
+                }
+                else if (spawner.CurrentCount == spawner.MaxCount)
                 {
                     Priority = TimerPriority.FiveSeconds;
                 }
@@ -11380,7 +11382,6 @@ namespace Server.Mobiles
                 {
                     Priority = spawner.BasePriority;
                 }
-
 
                 m_Spawner = spawner;
             }


### PR DESCRIPTION
- If an XmlSpawner is fully spawned it will default to 5 second checks over 1 second checks.
- If it needs to spawn it will revert to its 1 second default check.