### PR TITLE
Fix

### DIFF
--- a/Scripts/Services/ExploringTheDeep/Regions.cs
+++ b/Scripts/Services/ExploringTheDeep/Regions.cs
@@ -40,7 +40,7 @@ namespace Server.Regions
                 }
                 else if (m.Region.Name == "Obsidian Wyvern" && pm.ExploringTheDeepQuest == ExploringTheDeepQuestChain.CollectTheComponent)
                 {
-                    creature = ObsidianWyvern.Spawn(new Point3D(5136 + Utility.RandomMinMax(-5, 5), 966 + Utility.RandomMinMax(-5, 5), 0), Map.Trammel);
+                    creature = ObsidianWyvern.Spawn(new Point3D(5136, 966, 0), Map.Trammel);
                 }
                 else if (m.Region.Name == "Orc Engineer" && pm.ExploringTheDeepQuest == ExploringTheDeepQuestChain.CollectTheComponent)
                 {


### PR DESCRIPTION
- The spawn location for the Obsidian Wyrm was tight enough. Removed the +5 -5 randomness of this location due to it always getting stuck in the mountains or lava.


![unknown](https://user-images.githubusercontent.com/20760229/89452039-112dc800-d72b-11ea-8e50-d8b75abd828b.png)
