### PR TITLE
Fixes

### DIFF
--- a/Scripts/Services/Dungeons/Shadowguard/Items.cs
+++ b/Scripts/Services/Dungeons/Shadowguard/Items.cs
@@ -129,7 +129,6 @@ namespace Server.Engines.Shadowguard
         public OrchardEncounter Encounter { get; set; }
 
         private bool _Thrown;
-        private bool _EatenByPet;
 
         public ShadowguardApple(OrchardEncounter encounter, ShadowguardCypress tree)
         {
@@ -237,7 +236,7 @@ namespace Server.Engines.Shadowguard
         {
             base.OnDelete();
 
-            if (!_Thrown && !_EatenByPet && Encounter != null)
+            if (!_Thrown && Encounter != null)
             {
                 foreach (PlayerMobile pm in Encounter.Region.GetEnumeratedMobiles().OfType<PlayerMobile>())
                 {
@@ -267,18 +266,6 @@ namespace Server.Engines.Shadowguard
                     Encounter.AddSpawn(creature);
                 }
             }
-        }
-
-        public override bool DropToMobile(Mobile from, Mobile target, Point3D p)
-        {
-            var bc = target as BaseCreature;
-
-            if (bc != null && !bc.IsDeadPet && bc.Controlled && (bc.ControlMaster == from || bc.IsPetFriend(from)))
-            {
-                _EatenByPet = true;
-            }
-
-            return base.DropToMobile(from, target, p);
         }
 
         public override void Delete()

--- a/Scripts/Services/Help/HelpGump.cs
+++ b/Scripts/Services/Help/HelpGump.cs
@@ -206,6 +206,10 @@ namespace Server.Engines.Help
                         {
                             from.Location = house.BanLocation;
                         }
+                        else if (CityLoyalty.CityTradeSystem.HasTrade(from))
+                        {
+                            from.SendLocalizedMessage(1151733); // You cannot do that while carrying a Trade Order.
+                        }
                         else if (from.Region.IsPartOf<Regions.Jail>())
                         {
                             from.SendLocalizedMessage(1114345, "", 0x35); // You'll need a better jailbreak plan than that!
@@ -262,6 +266,10 @@ namespace Server.Engines.Help
                             if (from.Region.IsPartOf<Regions.Jail>())
                             {
                                 from.SendLocalizedMessage(1114345, "", 0x35); // You'll need a better jailbreak plan than that!
+                            }
+                            else if (CityLoyalty.CityTradeSystem.HasTrade(from))
+                            {
+                                from.SendLocalizedMessage(1151733); // You cannot do that while carrying a Trade Order.
                             }
                             else if (from.Region.IsPartOf("Haven Island"))
                             {

--- a/Scripts/Services/Help/StuckMenu.cs
+++ b/Scripts/Services/Help/StuckMenu.cs
@@ -1,3 +1,4 @@
+using Server.Engines.CityLoyalty;
 using Server.Gumps;
 using Server.Mobiles;
 using Server.Network;
@@ -190,6 +191,10 @@ namespace Server.Menus.Questions
             {
                 if (m_Mobile == m_Sender)
                     m_Mobile.SendLocalizedMessage(1010588); // You choose not to go to any city.
+            }
+            else if (CityTradeSystem.HasTrade(m_Mobile))
+            {
+                m_Mobile.SendLocalizedMessage(1151733); // You cannot do that while carrying a Trade Order.
             }
             else
             {


### PR DESCRIPTION
- Fixes an issue where players could use the Help menu to bypass checks for trade orders.
- Needed a 2nd check in StuckMenu otherwise they could get the travel gump up, then pick a trade order, and still bypass.