### PR TITLE
Fix

### DIFF
--- a/Scripts/Items/Addons/TheKingsCollection/ShipPainting.cs
+++ b/Scripts/Items/Addons/TheKingsCollection/ShipPainting.cs
@@ -53,7 +53,7 @@ namespace Server.Items
                 if (ResourceCount > 0)
                 {
                     ResourceCount--;
-                    Item item = new HeavyPowderCharge();
+                    Item item = new PowderCharge();
 
                     from.AddToBackpack(item);
                     from.SendLocalizedMessage(1154174); // Powder charges have been placed in your backpack.


### PR DESCRIPTION
- Ship Painting should simply give PowderCharge not HeavyPowderCharge(no longer used in UO)