### PR TITLE
[Furniture]

### DIFF
--- a/Scripts/Items/Containers/BoxOfCrystalItems.cs
+++ b/Scripts/Items/Containers/BoxOfCrystalItems.cs
@@ -1,6 +1,5 @@
 namespace Server.Items
 {
-    [Furniture]
     [Flipable(0x9AA, 0xE7D)]
     public class BoxOfCrystalItems : BaseContainer
     {

--- a/Scripts/Items/Containers/BoxOfShadowItems.cs
+++ b/Scripts/Items/Containers/BoxOfShadowItems.cs
@@ -1,6 +1,5 @@
 namespace Server.Items
 {
-    [Furniture]
     [Flipable(0x9AA, 0xE7D)]
     public class BoxOfShadowItems : BaseContainer
     {

--- a/Scripts/Items/Containers/CommodityDeedBox.cs
+++ b/Scripts/Items/Containers/CommodityDeedBox.cs
@@ -2,7 +2,6 @@ using Server.Engines.VeteranRewards;
 
 namespace Server.Items
 {
-    [Furniture]
     [Flipable(0x9AA, 0xE7D)]
     public class CommodityDeedBox : BaseContainer, IRewardItem
     {

--- a/Scripts/Items/Containers/GiftBox.cs
+++ b/Scripts/Items/Containers/GiftBox.cs
@@ -1,6 +1,5 @@
 namespace Server.Items
 {
-    [Furniture]
     [Flipable(0x232A, 0x232B)]
     public class GiftBox : BaseContainer
     {

--- a/Scripts/Items/Containers/Stockings.cs
+++ b/Scripts/Items/Containers/Stockings.cs
@@ -1,6 +1,5 @@
 namespace Server.Items
 {
-    [Furniture]
     [Flipable(0x2bd9, 0x2bda)]
     public class GreenStocking : BaseContainer
     {
@@ -32,7 +31,6 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
     [Flipable(0x2bdb, 0x2bdc)]
     public class RedStocking : BaseContainer
     {

--- a/Scripts/Items/Equipment/Clothing/OuterTorso.cs
+++ b/Scripts/Items/Equipment/Clothing/OuterTorso.cs
@@ -1656,9 +1656,6 @@ namespace Server.Items
             base.Deserialize(reader);
 
             int version = reader.ReadInt();
-
-            if (Layer != Layer.OuterTorso)
-                Layer = Layer.OuterTorso;
         }
     }
 }

--- a/Scripts/Services/Harvest/HarvestSystem.cs
+++ b/Scripts/Services/Harvest/HarvestSystem.cs
@@ -743,7 +743,10 @@ namespace Server
         private static readonly Type[] _NotChoppables = new Type[]
         {
             typeof(CommodityDeedBox), typeof(ChinaCabinet), typeof(PieSafe), typeof(AcademicBookCase), typeof(JewelryBox),
-            typeof(WoodenBookcase), typeof(Countertop), typeof(Mailbox)
+            typeof(WoodenBookcase), typeof(Countertop), typeof(Mailbox), typeof(DecorativeMagesCrystalBall), typeof(DecorativeMageThrone),
+            typeof(DecorativeMagicBookStand), typeof(DecorativeSpecimenShelve), typeof(Feedbag), typeof(ChestOfDrawers), typeof(BarrelMailbox),
+            typeof(SquirrelMailbox), typeof(FootedChestOfDrawers), typeof(CustomizableRoundedDoorMat), typeof(CowStatue),
+            typeof(DecorativeStableFencing )
         };
 
         public static bool Check(Item item)


### PR DESCRIPTION
This tag is used to determine what can be chopped and also what can be hued with furniture dye tubs.

A few of these items do not even warrent the tag and a lot needed to get added to the list as they are able to be dyed by the furniture dye tub. Maybe eventually look at making a list there specifically for the dye table? This is a good short term fix until we can look at it more.

- Removed Furniture tag from the commodity deed box. (These can not be dyed and are always that green color) Leaving them on the HarvestSystem list for now though out of caution.
- Stocking = Removed [Furniture] tag. No need to add to the list should not be furniture dye tub dyable, maybe regular?
- Added a bunch of stuff to the list to safe guard them from players destroying. As it stands a player can destory any one these items by mistake.