### PR TITLE
Changes

### DIFF
--- a/Scripts/Services/Seasonal Events/ForsakenFoes/Items/ExplodingJackOLantern.cs
+++ b/Scripts/Services/Seasonal Events/ForsakenFoes/Items/ExplodingJackOLantern.cs
@@ -18,7 +18,11 @@ namespace Server.Items
 
         public override void OnDoubleClick(Mobile from)
         {
-            if (from.Mounted)
+            if (!IsChildOf(from.Backpack))
+            {
+                from.SendLocalizedMessage(1042010); // You must have the object in your backpack to use it.
+            }
+            else if (from.Mounted)
             {
                 from.SendLocalizedMessage(1061130); // You can't do that while riding a mount.
             }
@@ -34,7 +38,7 @@ namespace Server.Items
             private readonly Mobile m_From;
 
             public ThrowTarget(Mobile from)
-                : base(12, true, TargetFlags.None)
+                : base(10, true, TargetFlags.None)
             {
                 m_From = from;
             }

--- a/Scripts/Services/Seasonal Events/ForsakenFoes/Items/PumpkinCannonDeed.cs
+++ b/Scripts/Services/Seasonal Events/ForsakenFoes/Items/PumpkinCannonDeed.cs
@@ -2,18 +2,19 @@ using Server.Multis;
 
 namespace Server.Items
 {
-    public class PumpkinDeed : ShipCannonDeed
+    [TypeAlias("Server.Items.PumpkinDeed")]
+    public class PumpkinCannonDeed : ShipCannonDeed
     {
         public override CannonPower CannonType => CannonPower.Pumpkin;
         public override int LabelNumber => 1159232;  // Pumpkin Cannon
 
         [Constructable]
-        public PumpkinDeed()
+        public PumpkinCannonDeed()
         {
             Hue = 1192;
         }
 
-        public PumpkinDeed(Serial serial)
+        public PumpkinCannonDeed(Serial serial)
             : base(serial)
         {
         }
@@ -36,7 +37,7 @@ namespace Server.Items
         public override int LabelNumber => 1023691;  // cannon
 
         public override int Range => 10;
-        public override ShipCannonDeed GetDeed => new PumpkinDeed();
+        public override ShipCannonDeed GetDeed => new PumpkinCannonDeed();
         public override CannonPower Power => CannonPower.Pumpkin;
 
         public PumpkinCannon(BaseGalleon g)

--- a/Scripts/Services/Seasonal Events/ForsakenFoes/Rewards.cs
+++ b/Scripts/Services/Seasonal Events/ForsakenFoes/Rewards.cs
@@ -13,7 +13,7 @@ namespace Server.Engines.Fellowship
             Rewards = new List<CollectionItem>
             {
                 new CollectionItem(typeof(TinctureOfSilver), 0x183B, 1155619, 1900, 10000),
-                new CollectionItem(typeof(PumpkinDeed), 0x14F2, 1159232, 1922, 50000),
+                new CollectionItem(typeof(PumpkinCannonDeed), 0x14F2, 1159232, 1922, 50000),
                 new CollectionItem(typeof(PumpkinRowBoatDeed), 0x14F2, 1159233, 0, 250000),
                 new CollectionItem(typeof(JackOLanternHelm), 0xA3EA, 1125986, 0, 150000),
                 new CollectionItem(typeof(AdmiralJacksPumpkinSpiceAle), 0xA40B, 1159230, 1922, 50000),


### PR DESCRIPTION
- Exploding JackOLantern should require it be in backpack. Set the range down to 10. (same as snow pile)
- Renamed PumpkinDeed to PumpkinCannonDeed.