### PR TITLE
Paroxysmus Fix

### DIFF
--- a/Scripts/Mobiles/Bosses/ChiefParoxysmus.cs
+++ b/Scripts/Mobiles/Bosses/ChiefParoxysmus.cs
@@ -101,7 +101,9 @@ namespace Server.Mobiles
 
                 if (creature.Controlled || creature.Summoned)
                 {
-                    Heal(creature.Hits);
+                    if (Hits < HitsMax)
+                        Hits = HitsMax;
+
                     creature.Kill();
 
                     Effects.PlaySound(Location, Map, 0x574);
@@ -122,15 +124,13 @@ namespace Server.Mobiles
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
-            int version = reader.ReadInt();
+            reader.ReadInt();
         }
 
         public virtual void SpawnBulbous()


### PR DESCRIPTION
- Confirmed on EA - When he eats a pets or summons, regardless of what his HP is at, it restores his HP to max.