### PR TITLE
Fix

### DIFF
--- a/Data/TeleporterRegions.xml
+++ b/Data/TeleporterRegions.xml
@@ -1219,11 +1219,6 @@
 		<tiles from="(5140, 1773, 0)" frommap="Felucca" to="(5171, 1586, 0)" tomap="Felucca" />
 	</Teleporter>
 	<Teleporter>
-		<tiles from="(6992, 1367, -15)" frommap="Felucca" to="(511, 585, 11)" tomap="TerMur" />
-		<tiles from="(6993, 1367, -15)" frommap="Felucca" to="(512, 585, 11)" tomap="TerMur" />
-		<tiles from="(6994, 1367, -15)" frommap="Felucca" to="(513, 585, 11)" tomap="TerMur" />
-	</Teleporter>
-	<Teleporter>
 		<tiles from="(2186, 294, -27)" frommap="Ilshenar" to="(2186, 33, -27)" tomap="Ilshenar" />
 		<tiles from="(2187, 294, -27)" frommap="Ilshenar" to="(2187, 33, -27)" tomap="Ilshenar" />
 		<tiles from="(2188, 294, -27)" frommap="Ilshenar" to="(2188, 33, -27)" tomap="Ilshenar" />

--- a/Scripts/Items/Internal/UnderworldTele.cs
+++ b/Scripts/Items/Internal/UnderworldTele.cs
@@ -24,9 +24,10 @@ namespace Server.Items
                 {
                     return base.OnMoveOver(m);
                 }
-                else
-                    player.SendLocalizedMessage(1077196); // You may not enter this area.				
+
+                player.SendLocalizedMessage(1112226); // Thou must be on a Sacred Quest to pass through.	
             }
+
             return true;
         }
 
@@ -39,7 +40,7 @@ namespace Server.Items
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-            int version = reader.ReadInt();
+            reader.ReadInt();
         }
     }
 }


### PR DESCRIPTION
Players can use the teleporters from the fel champ spawn to get into the Abyss, it does not check access. This removed those teleporters from the Fel side where they can be replaced with the UnderworldTele.cs