### PR TITLE
Travesty

### DIFF
--- a/Scripts/Spells/Ninjitsu/MirrorImage.cs
+++ b/Scripts/Spells/Ninjitsu/MirrorImage.cs
@@ -153,6 +153,8 @@ namespace Server.Mobiles
 {
     public class Clone : BaseCreature
     {
+        public override bool AlwaysAttackable => m_Caster is Travesty;
+
         private Mobile m_Caster;
         public Clone(Mobile caster)
             : base(AIType.AI_Melee, FightMode.None, 10, 1, 0.2, 0.4)


### PR DESCRIPTION
- When travesty casts MirrorImage if a pet or another player procs an AOE spell and kills it, it flags them as criminal.

This fixes that.

https://trueuo.com/threads/travesty-causing-players-to-go-criminal.2778/