### PR TITLE
Ready

### DIFF
--- a/Scripts/Items/Containers/Container.cs
+++ b/Scripts/Items/Containers/Container.cs
@@ -371,7 +371,7 @@ namespace Server.Items
 
         public override bool OnDragLift(Mobile from)
         {
-            if (from.IsPlayer())
+            if (!from.IsPlayer())
                 return true;
 
             from.SendLocalizedMessage(500169); // You cannot pick that up.
@@ -391,18 +391,13 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
-            writer.Write(1); // version
+            writer.Write(0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
-            int version = reader.ReadInt();
-
-            if (version == 0)
-                Weight = 13.0;
+            reader.ReadInt();
         }
     }
 

--- a/Scripts/Items/Containers/Container.cs
+++ b/Scripts/Items/Containers/Container.cs
@@ -391,7 +391,7 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-            writer.Write(0); // version
+            writer.Write(1); // version
         }
 
         public override void Deserialize(GenericReader reader)

--- a/Scripts/Mobiles/AI/BaseAI.cs
+++ b/Scripts/Mobiles/AI/BaseAI.cs
@@ -1402,7 +1402,7 @@ namespace Server.Mobiles
 
                 for (int i = list.Count - 1; i >= 0; --i)
                 {
-                    if (i < list.Count)
+                    if (i < list.Count && list[i].Movable)
                     {
                         list[i].MoveToWorld(m_Mobile.Location, m_Mobile.Map);
                     }

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -4979,17 +4979,26 @@ namespace Server.Mobiles
                     List<Item> list = new List<Item>(Backpack.Items);
                     foreach (Item item in list)
                     {
-                        b.DropItem(item);
+                        if (item.Movable)
+                            b.DropItem(item);
+                        else
+                            item.Delete();
                     }
 
                     BaseHouse house = BaseHouse.FindHouseAt(this);
                     if (house != null)
                     {
-                        b.MoveToWorld(house.BanLocation, house.Map);
+                        if (Backpack.Items.Count == 0)
+                            b.Delete();
+                        else
+                            b.MoveToWorld(house.BanLocation, house.Map);
                     }
                     else
                     {
-                        b.MoveToWorld(Location, Map);
+                        if (Backpack.Items.Count == 0)
+                            b.Delete();
+                        else
+                            b.MoveToWorld(Location, Map);
                     }
                 }
             }


### PR DESCRIPTION
Creatures Instruments were dropping to the world and getting frozen.
Players could also pick up the Creature Backpacks and Staff could not. I believe that the logic was always reversed. 

Lastly, the BaseCreature change will take into account the 0 items in the backpack, if non-movables get deleted during the check and delete the bag and not spawn an empty one.