### PR TITLE
- No Need

### DIFF
--- a/Scripts/Quests/Discipline.cs
+++ b/Scripts/Quests/Discipline.cs
@@ -26,10 +26,6 @@ namespace Server.Engines.Quests
         public override object Refuse => 1072767;
         /* You waste my time.  The task is simple. Kill 50 rats in an hour. */
         public override object Uncomplete => 1072773;
-        public override bool CanOffer()
-        {
-            return MondainsLegacy.Spellweaving;
-        }
 
         public override void Serialize(GenericWriter writer)
         {
@@ -67,10 +63,6 @@ namespace Server.Engines.Quests
         public override object Uncomplete => 1072775;
         /* Well, where are the cotton bales? */
         public override object Complete => 1074110;
-        public override bool CanOffer()
-        {
-            return MondainsLegacy.Spellweaving;
-        }
 
         public override void Serialize(GenericWriter writer)
         {
@@ -107,10 +99,6 @@ namespace Server.Engines.Quests
         public override object Uncomplete => 1072776;
         /* Well, where are the boards? */
         public override object Complete => 1074152;
-        public override bool CanOffer()
-        {
-            return MondainsLegacy.Spellweaving;
-        }
 
         public override void Serialize(GenericWriter writer)
         {
@@ -152,10 +140,6 @@ namespace Server.Engines.Quests
         public override object Uncomplete => 1072777;
         /* Ah good, you're back.  We're eager for the feast. */
         public override object Complete => 1074158;
-        public override bool CanOffer()
-        {
-            return MondainsLegacy.Spellweaving;
-        }
 
         public override void Serialize(GenericWriter writer)
         {
@@ -196,10 +180,6 @@ namespace Server.Engines.Quests
         public override object Uncomplete => 1072778;
         /* I will take the ears you have collected now.  Hand them here. */
         public override object Complete => 1074160;
-        public override bool CanOffer()
-        {
-            return MondainsLegacy.Spellweaving;
-        }
 
         public override void GiveRewards()
         {

--- a/Scripts/Quests/Spellweaving.cs
+++ b/Scripts/Quests/Spellweaving.cs
@@ -32,10 +32,6 @@ namespace Server.Engines.Quests
         public override object Uncomplete => 1072774;
         /* Have you gathered the mushrooms? */
         public override object Complete => 1074166;
-        public override bool CanOffer()
-        {
-            return MondainsLegacy.Spellweaving;
-        }
 
         public override void Serialize(GenericWriter writer)
         {
@@ -74,10 +70,6 @@ namespace Server.Engines.Quests
         public override object Uncomplete => 1072775;
         /* Well, where are the cotton bales? */
         public override object Complete => 1074110;
-        public override bool CanOffer()
-        {
-            return MondainsLegacy.Spellweaving;
-        }
 
         public override void Serialize(GenericWriter writer)
         {
@@ -114,10 +106,6 @@ namespace Server.Engines.Quests
         public override object Uncomplete => 1072776;
         /* Well, where are the boards? */
         public override object Complete => 1074152;
-        public override bool CanOffer()
-        {
-            return MondainsLegacy.Spellweaving;
-        }
 
         public override void Serialize(GenericWriter writer)
         {
@@ -159,10 +147,6 @@ namespace Server.Engines.Quests
         public override object Uncomplete => 1072777;
         /* Ah good, you're back.  We're eager for the feast. */
         public override object Complete => 1074158;
-        public override bool CanOffer()
-        {
-            return MondainsLegacy.Spellweaving;
-        }
 
         public override void Serialize(GenericWriter writer)
         {
@@ -205,10 +189,6 @@ namespace Server.Engines.Quests
         public override object Uncomplete => 1072779;
         /* Well done!  Well done, indeed.  You are worthy to become an arcanist! */
         public override object Complete => 1074167;
-        public override bool CanOffer()
-        {
-            return MondainsLegacy.Spellweaving;
-        }
 
         public override void GiveRewards()
         {

--- a/Scripts/Quests/SummonFey.cs
+++ b/Scripts/Quests/SummonFey.cs
@@ -29,10 +29,6 @@ namespace Server.Engines.Quests
         public override object Uncomplete => 1074290;
         /* What have we here? Oh yes, gifts for a pixie. */
         public override object Complete => 1074292;
-        public override bool CanOffer()
-        {
-            return MondainsLegacy.Spellweaving;
-        }
 
         public override void Serialize(GenericWriter writer)
         {
@@ -70,10 +66,6 @@ namespace Server.Engines.Quests
         public override object Uncomplete => 1074315;
         /* *giggle*  Oooh!  For me? */
         public override object Complete => 1074319;
-        public override bool CanOffer()
-        {
-            return MondainsLegacy.Spellweaving;
-        }
 
         public override void Serialize(GenericWriter writer)
         {
@@ -110,10 +102,6 @@ namespace Server.Engines.Quests
         /* *giggle* Mean reapers got fixed!  Pixie friend now! *giggle* When mean 
         thingies bother you, a brave pixie will help. */
         public override object Complete => 1074320;
-        public override bool CanOffer()
-        {
-            return MondainsLegacy.Spellweaving;
-        }
 
         public override void GiveRewards()
         {

--- a/Scripts/Quests/SummonFiend.cs
+++ b/Scripts/Quests/SummonFiend.cs
@@ -25,10 +25,6 @@ namespace Server.Engines.Quests
         public override object Refuse => 1074287;
         /* Surely you're not having difficulties swatting down those annoying pests? */
         public override object Uncomplete => 1074289;
-        public override bool CanOffer()
-        {
-            return MondainsLegacy.Spellweaving;
-        }
 
         public override void Serialize(GenericWriter writer)
         {
@@ -65,10 +61,6 @@ namespace Server.Engines.Quests
         public override object Uncomplete => 1074317;
         /* That's a well-made whip.  No imp will ignore the sting of that lash. */
         public override object Complete => 1074321;
-        public override bool CanOffer()
-        {
-            return MondainsLegacy.Spellweaving;
-        }
 
         public override void Serialize(GenericWriter writer)
         {
@@ -103,10 +95,6 @@ namespace Server.Engines.Quests
         public override object Refuse => 1074314;
         /* You need to vanquish an arcane daemon before the imps will fear you properly. */
         public override object Uncomplete => 1074318;
-        public override bool CanOffer()
-        {
-            return MondainsLegacy.Spellweaving;
-        }
 
         public override void GiveRewards()
         {

--- a/Scripts/Services/MondainsLegacy.cs
+++ b/Scripts/Services/MondainsLegacy.cs
@@ -40,7 +40,6 @@ namespace Server
         private static bool m_Sanctuary;
         private static bool m_StygianDragonLair;
         private static bool m_MedusasLair;
-        private static bool m_Spellweaving;
         private static bool m_PublicDonations;
         public static bool PalaceOfParoxysmus
         {
@@ -163,17 +162,6 @@ namespace Server
                 m_MedusasLair = value;
             }
         }
-        public static bool Spellweaving
-        {
-            get
-            {
-                return m_Spellweaving;
-            }
-            set
-            {
-                m_Spellweaving = value;
-            }
-        }
         public static bool PublicDonations
         {
             get
@@ -254,7 +242,6 @@ namespace Server
                 ReadNode(root, "Sanctuary", ref m_Sanctuary);
                 ReadNode(root, "StygianDragonLair", ref m_StygianDragonLair);
                 ReadNode(root, "MedusasLair", ref m_MedusasLair);
-                ReadNode(root, "Spellweaving", ref m_Spellweaving);
                 ReadNode(root, "PublicDonations", ref m_PublicDonations);
             }
             catch (Exception e)
@@ -304,7 +291,6 @@ namespace Server
                 UpdateNode(root, "Sanctuary", m_Sanctuary);
                 UpdateNode(root, "StygianDragonLair", m_StygianDragonLair);
                 UpdateNode(root, "MedusasLair", m_MedusasLair);
-                UpdateNode(root, "Spellweaving", m_Spellweaving);
                 UpdateNode(root, "PublicDonations", m_PublicDonations);
 
                 doc.Save("Data/Mondain's Legacy/Settings.xml");
@@ -682,8 +668,7 @@ namespace Server
             AddButton(20, 260, MondainsLegacy.Sanctuary ? 0x939 : 0x938, MondainsLegacy.Sanctuary ? 0x939 : 0x938, 9, GumpButtonType.Reply, 0);
             AddButton(20, 285, MondainsLegacy.StygianDragonLair ? 0x939 : 0x938, MondainsLegacy.StygianDragonLair ? 0x939 : 0x938, 10, GumpButtonType.Reply, 0);
             AddButton(20, 310, MondainsLegacy.MedusasLair ? 0x939 : 0x938, MondainsLegacy.MedusasLair ? 0x939 : 0x938, 11, GumpButtonType.Reply, 0);
-            AddButton(20, 335, MondainsLegacy.Spellweaving ? 0x939 : 0x938, MondainsLegacy.Spellweaving ? 0x939 : 0x938, 12, GumpButtonType.Reply, 0);
-            AddButton(20, 360, MondainsLegacy.PublicDonations ? 0x939 : 0x938, MondainsLegacy.PublicDonations ? 0x939 : 0x938, 13, GumpButtonType.Reply, 0);
+            AddButton(20, 360, MondainsLegacy.PublicDonations ? 0x939 : 0x938, MondainsLegacy.PublicDonations ? 0x939 : 0x938, 12, GumpButtonType.Reply, 0);
 
             AddLabel(45, 56, 0x226, "Palace of Paroxysmus");
             AddLabel(45, 81, 0x226, "Twisted Weald");
@@ -696,7 +681,6 @@ namespace Server
             AddLabel(45, 256, 0x226, "Sanctuary");
             AddLabel(45, 281, 0x226, "StygianDragonLair");
             AddLabel(45, 306, 0x226, "MedusasLair");
-            AddLabel(45, 331, 0x226, "Spellweaving");
             AddLabel(45, 356, 0x226, "PublicDonations");
 
             // legend
@@ -749,9 +733,6 @@ namespace Server
                     MondainsLegacy.MedusasLair = !MondainsLegacy.MedusasLair;
                     break;
                 case 12:
-                    MondainsLegacy.Spellweaving = !MondainsLegacy.Spellweaving;
-                    break;
-                case 13:
                     MondainsLegacy.PublicDonations = !MondainsLegacy.PublicDonations;
                     break;
             }

--- a/Scripts/Spells/Spellweaving/ArcanistSpell.cs
+++ b/Scripts/Spells/Spellweaving/ArcanistSpell.cs
@@ -72,12 +72,6 @@ namespace Server.Spells.Spellweaving
                 return false;
             }
 
-            if (!MondainsLegacy.Spellweaving)
-            {
-                Caster.SendLocalizedMessage(1042753, "Spellweaving"); // ~1_SOMETHING~ has been temporarily disabled.
-                return false;
-            }
-
             if (Caster is PlayerMobile pm && !pm.Spellweaving)
             {
                 Caster.SendLocalizedMessage(1073220); // You must have completed the epic arcanist quest to use this ability.


### PR DESCRIPTION
- No need to have all these checks to the Spellweaving skill being active. No other spell casting spell acts that way.

(does not effect needing the skill to do it, just removes a useless bool