### PR TITLE
Bug Fix

### DIFF
--- a/Scripts/Services/New Magincia/MaginciaPlants/GardeningContract.cs
+++ b/Scripts/Services/New Magincia/MaginciaPlants/GardeningContract.cs
@@ -51,7 +51,7 @@ namespace Server.Items
 
                     if (!plant.IsContract)
                     {
-                        if (plant.ContractTime.Month == DateTime.UtcNow.Month)
+                        if (plant.ContractTime.Month == DateTime.UtcNow.Month && plant.ContractTime.Year == DateTime.UtcNow.Year)
                         {
                             from.SendLocalizedMessage(1155760); // You may do this once every other month.
                             return;


### PR DESCRIPTION
- Fixes an obscure bug with the Magincia Garden contract. The default value the system checks for is 1/1/0001. Since it before was only looking for the month, gardenining contracts were not working during the month of July. Simply changed it to check both month and year.
- 
![Flowers](https://user-images.githubusercontent.com/20760229/104858498-b9a4a280-58ed-11eb-85cd-a657e13c4d42.png)
