### PR TITLE
Loot

### DIFF
--- a/Scripts/Misc/Loot.cs
+++ b/Scripts/Misc/Loot.cs
@@ -433,26 +433,6 @@ namespace Server
             return Construct(m_WeaponTypes) as BaseWeapon;
         }
 
-        public static Item RandomWeaponOrJewelry(bool inTokuno = false, bool isMondain = false, bool isStygian = false)
-        {
-            if (isStygian)
-            {
-                return Construct(m_SAWeaponTypes, m_WeaponTypes, m_JewelryTypes, m_SAJewelryTypes);
-            }
-
-            if (isMondain)
-            {
-                return Construct(m_MLWeaponTypes, m_WeaponTypes, m_JewelryTypes);
-            }
-
-            if (inTokuno)
-            {
-                return Construct(m_SEWeaponTypes, m_WeaponTypes, m_JewelryTypes);
-            }
-
-            return Construct(m_WeaponTypes, m_JewelryTypes);
-        }
-
         public static BaseJewel RandomJewelry(bool isStygian = false)
         {
             if (isStygian)
@@ -491,26 +471,6 @@ namespace Server
             }
 
             return Construct(m_HatTypes) as BaseHat;
-        }
-
-        public static Item RandomArmorOrHat(bool inTokuno = false, bool isMondain = false, bool isStygian = false)
-        {
-            if (isStygian)
-            {
-                return Construct(m_SAArmorTypes, m_ArmorTypes, m_HatTypes);
-            }
-
-            if (isMondain)
-            {
-                return Construct(m_MLArmorTypes, m_ArmorTypes, m_HatTypes);
-            }
-
-            if (inTokuno)
-            {
-                return Construct(m_SEArmorTypes, m_ArmorTypes, m_SEHatTypes, m_HatTypes);
-            }
-
-            return Construct(m_ArmorTypes, m_HatTypes);
         }
 
         public static BaseShield RandomShield(bool isStygian = false)

--- a/Scripts/Misc/LootPack.cs
+++ b/Scripts/Misc/LootPack.cs
@@ -972,7 +972,14 @@ namespace Server
                 }
                 else if (Type == typeof(BaseArmor))
                 {
-                    item = Loot.RandomArmorOrHat(inTokuno, isMondain, isStygian);
+                    if (0.80 > Utility.RandomDouble())
+                    {
+                        item = Loot.RandomArmor(inTokuno, isMondain, isStygian);
+                    }
+                    else
+                    {
+                        item = Loot.RandomHat(inTokuno);
+                    }
                 }
                 else if (Type == typeof(BaseShield))
                 {


### PR DESCRIPTION
- The way it was coded before - when a call for BaseArmor was called it would then simply choose between ALL ARMOR types and hats. 50/50

This led to situations where loot packs were sometimes dominated by hates.

This new way simply spaces it out a little better.