### PR TITLE
Bag Of Sending

### DIFF
--- a/Scripts/Items/Consumables/PowderOfTranslocation.cs
+++ b/Scripts/Items/Consumables/PowderOfTranslocation.cs
@@ -9,7 +9,6 @@ namespace Server.Items
         int Recharges { get; set; }
         int MaxCharges { get; }
         int MaxRecharges { get; }
-        string TranslocationItemName { get; }
     }
 
     public class PowderOfTranslocation : Item, ICommodity
@@ -52,15 +51,13 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.WriteEncodedInt(0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
-            int version = reader.ReadEncodedInt();
+            reader.ReadEncodedInt();
         }
 
         private class InternalTarget : Target
@@ -110,8 +107,7 @@ namespace Server.Items
 
                         if (transItem is Item item)
                         {
-                            // The ~1_translocationItem~ glows with green energy and absorbs magical power from the powder.
-                            MessageHelper.SendLocalizedMessageTo(item, from, 1054139, transItem.TranslocationItemName, 0x43);
+                            MessageHelper.SendLocalizedMessageTo(item, from, 1054139, "item", 0x43); // The ~1_translocationItem~ glows with green energy and absorbs magical power from the powder.
                         }
                     }
                 }

--- a/Scripts/Items/Tools/BagOfSending.cs
+++ b/Scripts/Items/Tools/BagOfSending.cs
@@ -19,6 +19,7 @@ namespace Server.Items
         private int m_Charges;
         private int m_Recharges;
         private BagOfSendingHue m_BagOfSendingHue;
+
         [Constructable]
         public BagOfSending()
             : this(RandomHue())
@@ -57,6 +58,7 @@ namespace Server.Items
                 InvalidateProperties();
             }
         }
+
         [CommandProperty(AccessLevel.GameMaster)]
         public int Recharges
         {
@@ -73,12 +75,14 @@ namespace Server.Items
                 InvalidateProperties();
             }
         }
+
         [CommandProperty(AccessLevel.GameMaster)]
         public int MaxCharges => 30;
         [CommandProperty(AccessLevel.GameMaster)]
         public int MaxRecharges => 255;
-        public string TranslocationItemName => "bag of sending";
-        public override int LabelNumber => 1054104;// a bag of sending
+
+        public override int LabelNumber => 1054104; // a bag of sending
+
         [CommandProperty(AccessLevel.GameMaster)]
         public BagOfSendingHue BagOfSendingHue
         {
@@ -104,6 +108,7 @@ namespace Server.Items
                 }
             }
         }
+
         public static BagOfSendingHue RandomHue()
         {
             switch (Utility.Random(4))
@@ -131,25 +136,28 @@ namespace Server.Items
             base.GetContextMenuEntries(from, list);
 
             if (from.Alive)
+            {
                 list.Add(new UseBagEntry(this, Charges > 0 && IsChildOf(from.Backpack)));
+            }
         }
 
         public override void OnDoubleClick(Mobile from)
         {
             if (from.Region.IsPartOf<Regions.Jail>())
             {
-                from.SendMessage("You may not do that in jail.");
+                from.SendLocalizedMessage(1078497); // You cannot use that right now
             }
             else if (!IsChildOf(from.Backpack))
             {
-                MessageHelper.SendLocalizedMessageTo(this, from, 1062334, 0x59); // The bag of sending must be in your backpack.
+                from.SendLocalizedMessage(1054107); // This item must be in your backpack.
             }
             else if (Charges == 0)
             {
-                MessageHelper.SendLocalizedMessageTo(this, from, 1042544, 0x59); // This item is out of charges.
+                from.SendLocalizedMessage(1042544); // This item is out of charges.
             }
             else
             {
+                from.SendLocalizedMessage(1150597); // Select the item you wish to send to your bank box.
                 from.Target = new SendTarget(this);
             }
         }
@@ -157,11 +165,9 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.WriteEncodedInt(1); // version
 
             writer.WriteEncodedInt(m_Recharges);
-
             writer.WriteEncodedInt(m_Charges);
             writer.WriteEncodedInt((int)m_BagOfSendingHue);
         }
@@ -169,52 +175,48 @@ namespace Server.Items
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
+            reader.ReadEncodedInt();
 
-            int version = reader.ReadEncodedInt();
-
-            switch (version)
-            {
-                case 1:
-                    {
-                        m_Recharges = reader.ReadEncodedInt();
-                        goto case 0;
-                    }
-                case 0:
-                    {
-                        m_Charges = Math.Min(reader.ReadEncodedInt(), MaxCharges);
-                        m_BagOfSendingHue = (BagOfSendingHue)reader.ReadEncodedInt();
-                        break;
-                    }
-            }
+            m_Recharges = reader.ReadEncodedInt();
+            m_Charges = Math.Min(reader.ReadEncodedInt(), MaxCharges);
+            m_BagOfSendingHue = (BagOfSendingHue)reader.ReadEncodedInt();
         }
 
         private class UseBagEntry : ContextMenuEntry
         {
             private readonly BagOfSending m_Bag;
+
             public UseBagEntry(BagOfSending bag, bool enabled)
                 : base(6189)
             {
                 m_Bag = bag;
 
                 if (!enabled)
+                {
                     Flags |= CMEFlags.Disabled;
+                }
             }
 
             public override void OnClick()
             {
                 if (m_Bag.Deleted)
+                {
                     return;
+                }
 
                 Mobile from = Owner.From;
 
                 if (from.CheckAlive())
+                {
                     m_Bag.OnDoubleClick(from);
+                }
             }
         }
 
         private class SendTarget : Target
         {
             private readonly BagOfSending m_Bag;
+
             public SendTarget(BagOfSending bag)
                 : base(-1, false, TargetFlags.None)
             {
@@ -228,36 +230,31 @@ namespace Server.Items
 
                 if (from.Region.IsPartOf<Regions.Jail>())
                 {
-                    from.SendMessage("You may not do that in jail.");
+                    from.SendLocalizedMessage(1078497); // You cannot use that right now
                 }
                 else if (!m_Bag.IsChildOf(from.Backpack))
                 {
-                    MessageHelper.SendLocalizedMessageTo(m_Bag, from, 1062334, 0x59); // The bag of sending must be in your backpack. 1054107 is gone from client, using generic response
+                    from.SendLocalizedMessage(1054107); // This item must be in your backpack.
                 }
                 else if (m_Bag.Charges == 0)
                 {
-                    MessageHelper.SendLocalizedMessageTo(m_Bag, from, 1042544, 0x59); // This item is out of charges.
+                    from.SendLocalizedMessage(1042544); // This item is out of charges.
                 }
                 else if (targeted is Item item)
                 {
-                    int reqCharges = 1; // (int)Math.Max(1, Math.Ceiling(item.TotalWeight / 10.0));
-                                        // change was ML, however reverted during ML period so we can put it at 1
+                    int reqCharges = 1; 
 
                     if (!item.IsChildOf(from.Backpack))
                     {
-                        MessageHelper.SendLocalizedMessageTo(m_Bag, from, 1054152, 0x59); // You may only send items from your backpack to your bank box.
+                        from.SendLocalizedMessage(1054152); // You may only send items from your backpack to your bank box.
                     }
                     else if (item is BagOfSending || item is Container)
                     {
-                        from.Send(new AsciiMessage(m_Bag.Serial, m_Bag.ItemID, MessageType.Regular, 0x3B2, 3, "", "You cannot send a container through the bag of sending."));
+                        from.SendLocalizedMessage(1079428); // You cannot send a container through the bag of sending
                     }
-                    else if (item.LootType == LootType.Cursed)
+                    else if (!item.VerifyMove(from) || item.LootType == LootType.Cursed || item is Engines.Quests.QuestItem || item.QuestItem || item is ArcaneFocus)
                     {
-                        MessageHelper.SendLocalizedMessageTo(m_Bag, from, 1054108, 0x59); // The bag of sending rejects the cursed item.
-                    }
-                    else if (!item.VerifyMove(from) || item is Engines.Quests.QuestItem || item.QuestItem)
-                    {
-                        MessageHelper.SendLocalizedMessageTo(m_Bag, from, 1054109, 0x59); // The bag of sending rejects that item.
+                        from.SendLocalizedMessage(1054109); // The bag of sending rejects that item.
                     }
                     else if (Spells.SpellHelper.IsDoomGauntlet(from.Map, from.Location))
                     {
@@ -265,16 +262,16 @@ namespace Server.Items
                     }
                     else if (!from.BankBox.TryDropItem(from, item, false))
                     {
-                        MessageHelper.SendLocalizedMessageTo(m_Bag, from, 1054110, 0x59); // Your bank box is full.
+                        from.SendLocalizedMessage(1054110); // Your bank box is full.
                     }
                     else if (reqCharges > m_Bag.Charges)
                     {
-                        from.SendLocalizedMessage(1079932); //You don't have enough charges to send that much weight
+                        from.SendLocalizedMessage(1042544); // This item is out of charges.
                     }
                     else
                     {
                         m_Bag.Charges -= reqCharges;
-                        MessageHelper.SendLocalizedMessageTo(m_Bag, from, 1054150, 0x59); // The item was placed in your bank box.
+                        from.SendLocalizedMessage(1054150); // The item was placed in your bank box.
                     }
                 }
             }

--- a/Scripts/Items/Tools/BallOfSummoning.cs
+++ b/Scripts/Items/Tools/BallOfSummoning.cs
@@ -66,11 +66,12 @@ namespace Server.Items
                 InvalidateProperties();
             }
         }
+
         [CommandProperty(AccessLevel.GameMaster)]
         public int MaxCharges => 20;
         [CommandProperty(AccessLevel.GameMaster)]
         public int MaxRecharges => 255;
-        public string TranslocationItemName => "crystal ball of pet summoning";
+
         [CommandProperty(AccessLevel.GameMaster)]
         public BaseCreature Pet
         {

--- a/Scripts/Items/Tools/BraceletOfBinding.cs
+++ b/Scripts/Items/Tools/BraceletOfBinding.cs
@@ -34,6 +34,7 @@ namespace Server.Items
         }
 
         private delegate void BraceletCallback(Mobile from);
+
         [CommandProperty(AccessLevel.GameMaster)]
         public int Charges
         {
@@ -50,6 +51,7 @@ namespace Server.Items
                 InvalidateProperties();
             }
         }
+
         [CommandProperty(AccessLevel.GameMaster)]
         public int Recharges
         {
@@ -73,8 +75,6 @@ namespace Server.Items
         [CommandProperty(AccessLevel.GameMaster)]
         public virtual int MaxRecharges => -1;
 
-        public virtual string TranslocationItemName => "bracelet of binding";
-
         [CommandProperty(AccessLevel.GameMaster)]
         public string Inscription
         {
@@ -85,6 +85,7 @@ namespace Server.Items
                 InvalidateProperties();
             }
         }
+
         [CommandProperty(AccessLevel.GameMaster)]
         public BraceletOfBinding Bound
         {

--- a/Scripts/Items/Tools/GreaterBraceletOfBinding.cs
+++ b/Scripts/Items/Tools/GreaterBraceletOfBinding.cs
@@ -31,9 +31,6 @@ namespace Server.Items
         {
         }
 
-
-        public override string TranslocationItemName => "greater bracelet of binding";
-
         public override void AddNameProperty(ObjectPropertyList list)
         {
             list.Add(1151769); // Greater Bracelet of Binding

--- a/Scripts/Items/Tools/InteriorDecorator.cs
+++ b/Scripts/Items/Tools/InteriorDecorator.cs
@@ -92,21 +92,21 @@ namespace Server.Items
 
                 if (!InHouse(from))
                 {
-                    AddButton(40, 36, (decorator.Command == DecorateCommand.GetHue ? 2154 : 2152), 2154, 4, GumpButtonType.Reply, 0);
+                    AddButton(40, 36, decorator.Command == DecorateCommand.GetHue ? 2154 : 2152, 2154, 4, GumpButtonType.Reply, 0);
                     AddHtmlLocalized(80, 41, 100, 20, 1158863, false, false); // Get Hue   
                 }
                 else
                 {
-                    AddButton(40, 36, (decorator.Command == DecorateCommand.Turn ? 2154 : 2152), 2154, 1, GumpButtonType.Reply, 0);
+                    AddButton(40, 36, decorator.Command == DecorateCommand.Turn ? 2154 : 2152, 2154, 1, GumpButtonType.Reply, 0);
                     AddHtmlLocalized(80, 41, 100, 20, 1018323, false, false); // Turn
 
-                    AddButton(40, 86, (decorator.Command == DecorateCommand.Up ? 2154 : 2152), 2154, 2, GumpButtonType.Reply, 0);
+                    AddButton(40, 86, decorator.Command == DecorateCommand.Up ? 2154 : 2152, 2154, 2, GumpButtonType.Reply, 0);
                     AddHtmlLocalized(80, 91, 100, 20, 1018324, false, false); // Up
 
-                    AddButton(40, 136, (decorator.Command == DecorateCommand.Down ? 2154 : 2152), 2154, 3, GumpButtonType.Reply, 0);
+                    AddButton(40, 136, decorator.Command == DecorateCommand.Down ? 2154 : 2152, 2154, 3, GumpButtonType.Reply, 0);
                     AddHtmlLocalized(80, 141, 100, 20, 1018325, false, false); // Down
 
-                    AddButton(40, 186, (decorator.Command == DecorateCommand.GetHue ? 2154 : 2152), 2154, 4, GumpButtonType.Reply, 0);
+                    AddButton(40, 186, decorator.Command == DecorateCommand.GetHue ? 2154 : 2152, 2154, 4, GumpButtonType.Reply, 0);
                     AddHtmlLocalized(80, 191, 100, 20, 1158863, false, false); // Get Hue                    
                 }
 
@@ -189,7 +189,7 @@ namespace Server.Items
             {
                 if (m_Decorator.Command == DecorateCommand.GetHue)
                 {
-                    int hue = 0;
+                    int hue;
 
                     if (targeted is Item item)
                         hue = item.Hue;
@@ -201,7 +201,7 @@ namespace Server.Items
                         return;
                     }
 
-                    from.SendLocalizedMessage(1158862, string.Format("{0}", hue)); // That object is hue ~1_HUE~
+                    from.SendLocalizedMessage(1158862, $"{hue}"); // That object is hue ~1_HUE~
                 }
                 else if (targeted is Item item && CheckUse(from))
                 {
@@ -254,7 +254,7 @@ namespace Server.Items
                             }
                         }
                     }
-                    else if (item is Banner && m_Decorator.Command != DecorateCommand.Turn)
+                    else if ((item is Banner || item is DecorativeShardShield) && m_Decorator.Command != DecorateCommand.Turn)
                     {
                         isDecorableComponent = true;
                     }
@@ -359,7 +359,7 @@ namespace Server.Items
             {
                 int floorZ = GetFloorZ(item);
 
-                if (floorZ > int.MinValue && item.Z < (floorZ + 15)) // Confirmed : no height checks here
+                if (floorZ > int.MinValue && item.Z < floorZ + 15) // Confirmed : no height checks here
                     item.Location = new Point3D(item.Location, item.Z + 1);
                 else
                     from.SendLocalizedMessage(1042274); // You cannot raise it up any higher.

--- a/Scripts/Mobiles/NPCs/Necromancer.cs
+++ b/Scripts/Mobiles/NPCs/Necromancer.cs
@@ -5,6 +5,7 @@ namespace Server.Mobiles
     public class Necromancer : BaseVendor
     {
         private readonly List<SBInfo> m_SBInfos = new List<SBInfo>();
+
         [Constructable]
         public Necromancer()
             : base("the Necromancer")
@@ -30,27 +31,14 @@ namespace Server.Mobiles
             m_SBInfos.Add(new SBNecromancer());
         }
 
-
         public override void InitOutfit()
         {
             base.InitOutfit();
-            AddItem(new Items.Shoes(0x151));
+
             AddItem(new Items.Robe(0x455));
-            AddItem(new Items.FancyShirt(0x455));
 
-            Item hair = new Item(Utility.RandomList(0x203B, 0x2049, 0x2048, 0x204A))
-            {
-                Hue = 0x3c6,
-                Layer = Layer.Hair,
-                Movable = false
-            };
-            AddItem(hair);
-
-            Item beard = new Item(0x0)
-            {
-                Layer = Layer.FacialHair
-            };
-            AddItem(beard);
+            HairHue = 0;
+            FacialHairHue = 0;
         }
 
         public override void Serialize(GenericWriter writer)


### PR DESCRIPTION
- All of its messages are private side messages now. Confirmed on EA.
- TranslocationItemName no longer needed. The message simply returns the string "item". See picture.
- Cursed Items simply return the same message as everything else. Invalid.
- Should not be able to send ArcaneFocus to the bank.
- Necromancer NPC LayerConflicts.


![hhh](https://user-images.githubusercontent.com/20760229/109390507-0b265100-78e0-11eb-9b89-68d90e5bed05.png)
