### PR TITLE
CleanupAbilities

### DIFF
--- a/Scripts/Abilities/Dismount.cs
+++ b/Scripts/Abilities/Dismount.cs
@@ -110,7 +110,7 @@ namespace Server.Items
             }
         }
 
-        private bool CheckMountedNoLance(Mobile attacker, Mobile defender)
+        private static bool CheckMountedNoLance(Mobile attacker, Mobile defender)
         {
             if (!attacker.Mounted && !attacker.Flying)
                 return false;

--- a/Scripts/Abilities/Focus.cs
+++ b/Scripts/Abilities/Focus.cs
@@ -6,7 +6,7 @@ namespace Server.Items
     public class Focus
     {
         private static readonly Dictionary<Mobile, FocusInfo> m_Table = new Dictionary<Mobile, FocusInfo>();
-        private static readonly int DefaultDamageBonus = -40;
+        private const int DefaultDamageBonus = -40;
 
         public static void Initialize()
         {

--- a/Scripts/Abilities/MysticArc.cs
+++ b/Scripts/Abilities/MysticArc.cs
@@ -7,7 +7,7 @@ namespace Server.Items
     // This will only hit targets that are in combat with the user.
     public class MysticArc : WeaponAbility
     {
-        private readonly int m_Damage = 15;
+        private const int m_Damage = 15;
         private Mobile m_Target;
         private Mobile m_Mobile;
 

--- a/Scripts/Abilities/SAPropEffects.cs
+++ b/Scripts/Abilities/SAPropEffects.cs
@@ -142,9 +142,9 @@ namespace Server.Items
 
         public static IEnumerable<T> GetContextsForVictim<T>(Mobile victim) where T : PropertyEffect
         {
-            foreach (PropertyEffect effect in Effects.OfType<T>().Where(e => e.Victim == victim))
+            foreach (var effect in Effects.OfType<T>().Where(e => e.Victim == victim))
             {
-                yield return effect as T;
+                yield return effect;
             }
         }
     }
@@ -397,13 +397,15 @@ namespace Server.Items
             BuffInfo.RemoveBuff(Victim, BuffIcon.SplinteringEffect);
         }
 
-        public void StartForceWalk(Mobile m)
+        public static void StartForceWalk(Mobile m)
         {
             if (m.NetState != null && m.AccessLevel < AccessLevel.GameMaster)
+            {
                 m.SendSpeedControl(SpeedControlType.WalkSpeed);
+            }
         }
 
-        public void EndForceWalk(Mobile m)
+        public static void EndForceWalk(Mobile m)
         {
             m.SendSpeedControl(SpeedControlType.Disable);
         }
@@ -474,8 +476,9 @@ namespace Server.Items
     public class BoneBreakerContext : PropertyEffect
     {
         public static Dictionary<Mobile, DateTime> _Immunity;
-        private static TimeSpan _EffectsDuration = TimeSpan.FromSeconds(4);
-        private static TimeSpan _ImmunityDuration = TimeSpan.FromSeconds(60);
+
+        private static readonly TimeSpan _EffectsDuration = TimeSpan.FromSeconds(4);
+        private static readonly TimeSpan _ImmunityDuration = TimeSpan.FromSeconds(60);
 
         public BoneBreakerContext(Mobile attacker, Mobile defender, Item weapon)
             : base(attacker, defender, weapon, _EffectsDuration, TimeSpan.FromSeconds(1))

--- a/Scripts/Abilities/SlayerGroup.cs
+++ b/Scripts/Abilities/SlayerGroup.cs
@@ -1,6 +1,7 @@
 using Server.Engines.Shadowguard;
 using Server.Mobiles;
 using System;
+using System.Collections.Generic;
 
 namespace Server.Items
 {
@@ -648,11 +649,11 @@ namespace Server.Items
             return false;
         }
 
-        private static SlayerEntry[] CompileEntries(SlayerGroup[] groups)
+        private static SlayerEntry[] CompileEntries(IReadOnlyList<SlayerGroup> groups)
         {
             SlayerEntry[] entries = new SlayerEntry[32];
 
-            for (int i = 0; i < groups.Length; ++i)
+            for (int i = 0; i < groups.Count; ++i)
             {
                 SlayerGroup g = groups[i];
 

--- a/Scripts/Abilities/WeaponAbility.cs
+++ b/Scripts/Abilities/WeaponAbility.cs
@@ -155,7 +155,7 @@ namespace Server.Items
             return false;
         }
 
-        private int GetSkillLocalization(SkillName skill)
+        private static int GetSkillLocalization(SkillName skill)
         {
             switch (skill)
             {
@@ -420,27 +420,29 @@ namespace Server.Items
 
         private static readonly Hashtable m_PlayersTable = new Hashtable();
 
-        private static void AddContext(Mobile m, WeaponAbilityContext context)
+        private static void AddContext(IEntity m, WeaponAbilityContext context)
         {
             m_PlayersTable[m] = context;
         }
 
-        private static void RemoveContext(Mobile m)
+        private static void RemoveContext(IEntity m)
         {
             WeaponAbilityContext context = GetContext(m);
 
             if (context != null)
+            {
                 RemoveContext(m, context);
+            }
         }
 
-        private static void RemoveContext(Mobile m, WeaponAbilityContext context)
+        private static void RemoveContext(IEntity m, WeaponAbilityContext context)
         {
             m_PlayersTable.Remove(m);
 
             context.Timer.Stop();
         }
 
-        private static WeaponAbilityContext GetContext(Mobile m)
+        private static WeaponAbilityContext GetContext(IEntity m)
         {
             return m_PlayersTable[m] as WeaponAbilityContext;
         }


### PR DESCRIPTION
Should make members static when possible and does not affect anything else.

https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2015/code-quality/ca1822-mark-members-as-static?view=vs-2015&redirectedfrom=MSDN

- Members that do not access instance data or call instance methods can be marked as static (Shared in Visual Basic). After you mark the methods as static, the compiler will emit non-virtual call sites to these members. Emitting nonvirtual call sites will prevent a check at runtime for each call that makes sure that the current object pointer is non-null. This can achieve a measurable performance gain for performance-sensitive code. In some cases, the failure to access the current object instance represents a correctness issue.