### PR TITLE
Barding distances and timeouts

### DIFF
--- a/Scripts/Mobiles/AI/BaseAI.cs
+++ b/Scripts/Mobiles/AI/BaseAI.cs
@@ -2146,7 +2146,7 @@ namespace Server.Mobiles
         {
             if (DateTime.UtcNow >= m_Mobile.BardEndTime && (m_Mobile.BardMaster == null || m_Mobile.BardMaster.Deleted ||
                                                             m_Mobile.BardMaster.Map != m_Mobile.Map ||
-                                                            m_Mobile.GetDistanceToSqrt(m_Mobile.BardMaster) > m_Mobile.RangePerception))
+                                                            !m_Mobile.InRange((IPoint3D)m_Mobile.BardMaster, m_Mobile.RangePerception)))
             {
                 m_Mobile.DebugSay("I have lost my provoker");
                 m_Mobile.BardProvoked = false;
@@ -2158,8 +2158,9 @@ namespace Server.Mobiles
             }
             else
             {
-                if (m_Mobile.BardTarget == null || m_Mobile.BardTarget.Deleted || m_Mobile.BardTarget.Map != m_Mobile.Map ||
-                    m_Mobile.GetDistanceToSqrt(m_Mobile.BardTarget) > m_Mobile.RangePerception)
+                m_Mobile.BardEndTime = DateTime.UtcNow + TimeSpan.FromSeconds(30.0);
+
+                if (m_Mobile.BardTarget == null || m_Mobile.BardTarget.Deleted || m_Mobile.BardTarget.Map != m_Mobile.Map || !m_Mobile.InRange((IPoint3D)m_Mobile.BardTarget, m_Mobile.RangePerception))
                 {
                     m_Mobile.DebugSay("I have lost my provoke target");
                     m_Mobile.BardProvoked = false;

--- a/Scripts/Skills/Discordance.cs
+++ b/Scripts/Skills/Discordance.cs
@@ -93,19 +93,20 @@ namespace Server.SkillHandlers
                 }
                 else
                 {
-                    int range = (int)targ.GetDistanceToSqrt(from);
                     int maxRange = BaseInstrument.GetBardRange(from, SkillName.Discordance);
+                    bool inRange = targ.InRange((IPoint3D)targ, maxRange);
+
                     Map targetMap = targ.Map;
 
                     if (targ is BaseMount mount && mount.Rider != null)
                     {
                         Mobile rider = mount.Rider;
 
-                        range = (int)rider.GetDistanceToSqrt(from);
+                        inRange = rider.InRange((IPoint3D)targ, maxRange);
                         targetMap = rider.Map;
                     }
 
-                    if (from.Map != targetMap || range > maxRange)
+                    if (from.Map != targetMap || !inRange)
                     {
                         ends = true;
                     }


### PR DESCRIPTION
#766 
- Provocation and Discord is now checked to be active by the BardingRange in tiles, not circular (as per OSI)
- Provocation now updates the endTime every time you are detected in the barding area, instead of just the initial provoke (as per OSI)