### PR TITLE
ChampionCleanup

### DIFF
--- a/Scripts/Mobiles/Bosses/BaseChampion.cs
+++ b/Scripts/Mobiles/Bosses/BaseChampion.cs
@@ -32,7 +32,7 @@ namespace Server.Mobiles
         public abstract MonsterStatuetteType[] StatueTypes { get; }
 
         public virtual bool DoesGoldShower => true;
-        public virtual bool CanGivePowerscrolls => true;
+        public virtual bool CanGivePowerscrolls => Map.Rules == MapRules.FeluccaRules;
 
         public virtual int PowerScrollAmount => ChampionSystem.PowerScrollAmount;
 
@@ -287,9 +287,12 @@ namespace Server.Mobiles
 
         public override bool OnBeforeDeath()
         {
-            if (CanGivePowerscrolls && !NoKillAwards)
+            if (!NoKillAwards)
             {
-                GivePowerScrolls();
+                if (CanGivePowerscrolls)
+                {
+                    GivePowerScrolls();
+                }
 
                 if (DoesGoldShower)
                 {

--- a/Scripts/Mobiles/Bosses/BaseChampion.cs
+++ b/Scripts/Mobiles/Bosses/BaseChampion.cs
@@ -24,15 +24,16 @@ namespace Server.Mobiles
         }
 
         public override bool CanBeParagon => false;
+
         public abstract ChampionSkullType SkullType { get; }
         public abstract Type[] UniqueList { get; }
         public abstract Type[] SharedList { get; }
         public abstract Type[] DecorativeList { get; }
         public abstract MonsterStatuetteType[] StatueTypes { get; }
-        public virtual bool NoGoodies => false;
+
         public virtual bool DoesGoldShower => true;
         public virtual bool CanGivePowerscrolls => true;
-        public virtual bool RestrictedToFelucca => true;
+
         public virtual int PowerScrollAmount => ChampionSystem.PowerScrollAmount;
 
         public override void Serialize(GenericWriter writer)
@@ -91,8 +92,10 @@ namespace Server.Mobiles
 
         public virtual void GivePowerScrolls()
         {
-            if (Map == null || RestrictedToFelucca && Map.Rules != MapRules.FeluccaRules)
+            if (Map == null || Map.Rules != MapRules.FeluccaRules)
+            {
                 return;
+            }
 
             List<Mobile> toGive = new List<Mobile>();
             List<DamageStore> rights = GetLootingRights();
@@ -287,11 +290,6 @@ namespace Server.Mobiles
             if (CanGivePowerscrolls && !NoKillAwards)
             {
                 GivePowerScrolls();
-
-                if (NoGoodies)
-                {
-                    return base.OnBeforeDeath();
-                }
 
                 if (DoesGoldShower)
                 {

--- a/Scripts/Mobiles/Bosses/BaseSeaChampion.cs
+++ b/Scripts/Mobiles/Bosses/BaseSeaChampion.cs
@@ -8,11 +8,13 @@ namespace Server.Mobiles
 {
     public class BaseSeaChampion : BaseChampion
     {
+        public override bool DoesGoldShower => false;
+        public override bool CanGivePowerscrolls => false;
+
         public override Type[] UniqueList => new Type[] { };
         public override Type[] SharedList => new Type[] { };
         public override Type[] DecorativeList => new Type[] { };
         public override MonsterStatuetteType[] StatueTypes => new MonsterStatuetteType[] { };
-
         public override ChampionSkullType SkullType => ChampionSkullType.None;
 
         private DateTime m_NextBoatDamage;

--- a/Scripts/Mobiles/Bosses/Charybdis/Charybdis.cs
+++ b/Scripts/Mobiles/Bosses/Charybdis/Charybdis.cs
@@ -35,9 +35,6 @@ namespace Server.Mobiles
         public override Type[] SharedList => new Type[] { };
         public override Type[] DecorativeList => new[] { typeof(EnchantedBladeDeed), typeof(EnchantedVortexDeed) };
 
-        public override bool DoesGoldShower => false;
-        public override bool CanGivePowerscrolls => false;
-
         [CommandProperty(AccessLevel.GameMaster)]
         public int Tentacles => m_Tentacles.Count;
 

--- a/Scripts/Mobiles/Bosses/Corgul/CorgulTheSoulbinder.cs
+++ b/Scripts/Mobiles/Bosses/Corgul/CorgulTheSoulbinder.cs
@@ -32,9 +32,6 @@ namespace Server.Mobiles
         public override Type[] SharedList => new[] { typeof(HelmOfVengence), typeof(RingOfTheSoulbinder), typeof(RuneEngravedPegLeg), typeof(CullingBlade) };
         public override Type[] DecorativeList => new[] { typeof(EnchantedBladeDeed), typeof(EnchantedVortexDeed) };
 
-        public override bool NoGoodies => true;
-        public override bool RestrictedToFelucca => false;
-
         private readonly int _SpawnPerLoc = 15;
 
         private readonly Point3D[] _SpawnLocs =

--- a/Scripts/Mobiles/Bosses/OsiredonTheScalisEnforcer.cs
+++ b/Scripts/Mobiles/Bosses/OsiredonTheScalisEnforcer.cs
@@ -34,8 +34,6 @@ namespace Server.Mobiles
         public override Type[] SharedList => new[] { typeof(MiniSoulForgeDeed) };
         public override Type[] DecorativeList => new[] { typeof(EnchantedBladeDeed), typeof(EnchantedVortexDeed) };
 
-        public override bool NoGoodies => true;
-
         [Constructable]
         public Osiredon()
             : this(null)


### PR DESCRIPTION
- RestirctedToFelucca and NoGoodies were only used for a few mobiles that probably never should have inherited from BaseChampion.cs
- Cleaned those up - Sea mobs do not act like champions.