### PR TITLE
Tracking Fixes

### DIFF
--- a/Scripts/Skills/Tracking.cs
+++ b/Scripts/Skills/Tracking.cs
@@ -201,8 +201,8 @@ namespace Server.SkillHandlers
 
             foreach (Mobile m in eable)
             {
-                // Ghosts can no longer be tracked 
-                if (m != from && m.Alive && (!m.Hidden || m.IsPlayer() || from.AccessLevel > m.AccessLevel) && check(m) && CheckDifficulty(from, m))
+                // Ghosts can't be tracked and region must be same as target. Region is unique emulation fix due to no "server lines"
+                if (m != from && m.Alive && from.Region == m.Region && (!m.Hidden || m.IsPlayer() || from.AccessLevel > m.AccessLevel) && check(m) && CheckDifficulty(from, m))
                 {
                     list.Add(m);
                 }


### PR DESCRIPTION
- Draft only for now.
- EA has no distance limit. However they do have server lines and tracking does not persist over them. Could be one tile away on the same map, in a field, and it will fail.
- To open up distances we can do a check for regions. Works but one issue is houses. If in a house you can't detect. However once tracking has begun if they go into a house can still be tracked to that location.
![Region](https://user-images.githubusercontent.com/20760229/126372986-096dbf77-c016-423c-a86e-f493edf97334.png)
