### PR TITLE
CrashFix

### DIFF
--- a/Scripts/Skills/Tracking.cs
+++ b/Scripts/Skills/Tracking.cs
@@ -267,7 +267,8 @@ namespace Server.SkillHandlers
             {
                 if (type == 3)
                 {
-                    list = NetState.Instances.AsParallel().Select(m => m.Mobile).Where(m => m != from
+                    list = NetState.Instances.AsParallel().Select(m => m.Mobile).Where(m => m != null
+                            && m != from
                             && m.Alive
                             && (!m.Hidden || m.IsPlayer() || from.AccessLevel > m.AccessLevel)
                             && check(m)
@@ -279,11 +280,11 @@ namespace Server.SkillHandlers
                 {
                     IEnumerable<Mobile> mobiles = FilterRegionMobs(from, range);
 
-                    list = mobiles.AsParallel().Where(m => m != from
+                    list = mobiles.AsParallel().Where(m => m != null
+                            && m != from
                             && m.Alive
                             && (!m.Hidden || m.IsPlayer() || from.AccessLevel > m.AccessLevel)
-                            && check(m)
-                            && CheckDifficulty(from, m)
+                            && check(m) && CheckDifficulty(from, m)
                             && ReachableTarget(from, m, range))
                         .OrderBy(x => x.GetDistanceToSqrt(from)).Select(x => x).Take(12).ToList();
                 }


### PR DESCRIPTION
`System.AggregateException: One or more errors occurred. ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at Server.SkillHandlers.TrackWhoGump.<>c__DisplayClass13_0.<DisplayTo>b__1(Mobile m) in C:\Users\danrk\Desktop\Heritage\Scripts\Skills\Tracking.cs:line 270
   at System.Linq.Parallel.WhereQueryOperator`1.WhereQueryOperatorEnumerator`1.MoveNext(TInputOutput& currentElement, TKey& currentKey)
   at System.Linq.Parallel.SortQueryOperatorEnumerator`3.MoveNext(TInputOutput& currentElement, TSortKey& currentKey)
   at System.Linq.Parallel.SelectQueryOperator`2.SelectQueryOperatorEnumerator`1.MoveNext(TOutput& currentElement, TKey& currentKey)
   at System.Linq.Parallel.SortHelper`2.BuildKeysFromSource(GrowingArray`1& keys, List`1& values)
   at System.Linq.Parallel.SortHelper`2.Sort()
   at System.Linq.Parallel.OrderPreservingSpoolingTask`2.SpoolingWork()
   at System.Linq.Parallel.SpoolingTaskBase.Work()
   at System.Linq.Parallel.QueryTask.BaseWork(Object unused)
   at System.Threading.Tasks.Task.Execute()
   --- End of inner exception stack trace ---`