### PR TITLE
Mail box crash fix.

### DIFF
--- a/Scripts/Services/CleanUpBritannia/Items/Mailbox.cs
+++ b/Scripts/Services/CleanUpBritannia/Items/Mailbox.cs
@@ -151,9 +151,9 @@ namespace Server.Items
         public override void OnDoubleClick(Mobile from)
         {
             BaseHouse house = BaseHouse.FindHouseAt(this);
-            SecureInfo secure = house.GetSecureInfoFor(this);
+            SecureInfo secure = house?.GetSecureInfoFor(this);
 
-            if (!house.HasSecureAccess(from, secure))
+            if (house != null && !house.HasSecureAccess(from, secure))
             {
                 if (IsSecure)
                 {


### PR DESCRIPTION
`System.NullReferenceException: Object reference not set to an instance of an object.

   at Server.Items.Mailbox.OnDoubleClick(Mobile from) in 

C:\Users\danrk\Desktop\Heritage\Scripts\Services\CleanUpBritannia\Items\Mailbox.cs:line 153`