### PR TITLE
Bug Fix

### DIFF
--- a/Scripts/Mobiles/NPCs/Mannequin/Mannequin.cs
+++ b/Scripts/Mobiles/NPCs/Mannequin/Mannequin.cs
@@ -517,7 +517,14 @@ namespace Server.Mobiles
 
             public override void OnClick()
             {
-                _Mannequin.SwitchClothes(_From, _Mannequin);
+                if (!_From.HasTrade)
+                {
+                    _Mannequin.SwitchClothes(_From, _Mannequin);
+                }
+                else
+                {
+                    _From.SendLocalizedMessage(1004041); // You can't do that while you have a trade pending.
+                }
             }
         }
 

--- a/Scripts/Services/CleanUpBritannia/Items/Steward.cs
+++ b/Scripts/Services/CleanUpBritannia/Items/Steward.cs
@@ -374,7 +374,14 @@ namespace Server.Mobiles
 
             public override void OnClick()
             {
-                _Mannequin.SwitchClothes(_From, _Mannequin);
+                if (!_From.HasTrade)
+                {
+                    _Mannequin.SwitchClothes(_From, _Mannequin);
+                }
+                else
+                {
+                    _From.SendLocalizedMessage(1004041); // You can't do that while you have a trade pending.
+                }
             }
         }
 


### PR DESCRIPTION
- Swapping clothes on a mannequin or steward with a trade window open results in deletion of items.
- Coded in a block to prevent this option from being selected if a trade window is open.