### PR TITLE
Fishing Fix

### DIFF
--- a/Scripts/Misc/BuffIcons.cs
+++ b/Scripts/Misc/BuffIcons.cs
@@ -29,6 +29,9 @@ namespace Server
         private readonly int m_SecondaryCliloc;
         public int SecondaryCliloc => m_SecondaryCliloc;
 
+        private readonly int m_ThirdCliloc;
+        public int ThirdCliloc => m_ThirdCliloc;
+
         private readonly bool m_NoTimer;
         public bool NoTimer => m_NoTimer;
 
@@ -44,8 +47,14 @@ namespace Server
         private readonly bool m_RetainThroughDeath;
         public bool RetainThroughDeath => m_RetainThroughDeath;
 
-        private readonly TextDefinition m_Args;
-        public TextDefinition Args => m_Args;
+        private readonly TextDefinition m_TitleArguments;
+        public TextDefinition TitleArguments => m_TitleArguments;
+
+        private readonly TextDefinition m_SecondaryArguments;
+        public TextDefinition SecondaryArguments => m_SecondaryArguments;
+
+        private readonly TextDefinition m_ThirdArguments;
+        public TextDefinition ThirdArguments => m_ThirdArguments;
 
         #endregion
 
@@ -56,10 +65,16 @@ namespace Server
         }
 
         public BuffInfo(BuffIcon iconID, int titleCliloc, int secondaryCliloc)
+            : this(iconID, titleCliloc, secondaryCliloc, 0)
+        {
+        }
+
+        public BuffInfo(BuffIcon iconID, int titleCliloc, int secondaryCliloc, int thirdCliloc)
         {
             m_ID = iconID;
             m_TitleCliloc = titleCliloc;
             m_SecondaryCliloc = secondaryCliloc;
+            m_ThirdCliloc = thirdCliloc;
         }
 
         public BuffInfo(BuffIcon iconID, int titleCliloc, TimeSpan length, Mobile m)
@@ -67,9 +82,14 @@ namespace Server
         {
         }
 
-        //Only the timed one needs to Mobile to know when to automagically remove it.
         public BuffInfo(BuffIcon iconID, int titleCliloc, int secondaryCliloc, TimeSpan length, Mobile m)
-            : this(iconID, titleCliloc, secondaryCliloc)
+            : this(iconID, titleCliloc, secondaryCliloc, 0, length, m)
+        {
+        }
+
+        //Only the timed one needs to Mobile to know when to automagically remove it.
+        public BuffInfo(BuffIcon iconID, int titleCliloc, int secondaryCliloc, int thirdCliloc, TimeSpan length, Mobile m)
+            : this(iconID, titleCliloc, secondaryCliloc, thirdCliloc)
         {
             m_TimeLength = length;
             m_TimeStart = DateTime.UtcNow;
@@ -91,15 +111,15 @@ namespace Server
             m_NoTimer = notimer;
         }
 
-        public BuffInfo(BuffIcon iconID, int titleCliloc, TextDefinition args)
-            : this(iconID, titleCliloc, titleCliloc + 1, args)
+        public BuffInfo(BuffIcon iconID, int titleCliloc, TextDefinition secargs)
+            : this(iconID, titleCliloc, titleCliloc + 1, secargs)
         {
         }
 
-        public BuffInfo(BuffIcon iconID, int titleCliloc, int secondaryCliloc, TextDefinition args)
+        public BuffInfo(BuffIcon iconID, int titleCliloc, int secondaryCliloc, TextDefinition secargs)
             : this(iconID, titleCliloc, secondaryCliloc)
         {
-            m_Args = args;
+            m_SecondaryArguments = secargs;
         }
 
         public BuffInfo(BuffIcon iconID, int titleCliloc, bool retainThroughDeath)
@@ -113,37 +133,52 @@ namespace Server
             m_RetainThroughDeath = retainThroughDeath;
         }
 
-        public BuffInfo(BuffIcon iconID, int titleCliloc, TextDefinition args, bool retainThroughDeath)
-            : this(iconID, titleCliloc, titleCliloc + 1, args, retainThroughDeath)
+        public BuffInfo(BuffIcon iconID, int titleCliloc, TextDefinition secargs, bool retainThroughDeath)
+            : this(iconID, titleCliloc, titleCliloc + 1, secargs, retainThroughDeath)
         {
         }
 
-        public BuffInfo(BuffIcon iconID, int titleCliloc, int secondaryCliloc, TextDefinition args, bool retainThroughDeath)
-            : this(iconID, titleCliloc, secondaryCliloc, args)
+        public BuffInfo(BuffIcon iconID, int titleCliloc, int secondaryCliloc, TextDefinition secargs, bool retainThroughDeath)
+            : this(iconID, titleCliloc, secondaryCliloc, secargs)
         {
             m_RetainThroughDeath = retainThroughDeath;
         }
 
-        public BuffInfo(BuffIcon iconID, int titleCliloc, TimeSpan length, Mobile m, TextDefinition args)
-            : this(iconID, titleCliloc, titleCliloc + 1, length, m, args)
+        public BuffInfo(BuffIcon iconID, int titleCliloc, TimeSpan length, Mobile m, TextDefinition secargs)
+            : this(iconID, titleCliloc, titleCliloc + 1, length, m, secargs)
         {
         }
 
-        public BuffInfo(BuffIcon iconID, int titleCliloc, int secondaryCliloc, TimeSpan length, Mobile m, TextDefinition args)
+        public BuffInfo(BuffIcon iconID, int titleCliloc, int secondaryCliloc, TimeSpan length, Mobile m, TextDefinition secargs)
             : this(iconID, titleCliloc, secondaryCliloc, length, m)
         {
-            m_Args = args;
+            m_SecondaryArguments = secargs;
         }
 
-        public BuffInfo(BuffIcon iconID, int titleCliloc, TimeSpan length, Mobile m, TextDefinition args, bool retainThroughDeath)
-            : this(iconID, titleCliloc, titleCliloc + 1, length, m, args, retainThroughDeath)
-        {
-        }
-
-        public BuffInfo(BuffIcon iconID, int titleCliloc, int secondaryCliloc, TimeSpan length, Mobile m, TextDefinition args, bool retainThroughDeath)
+        public BuffInfo(BuffIcon iconID, int titleCliloc, TextDefinition titleargs, int secondaryCliloc, TextDefinition secargs, TimeSpan length, Mobile m)
             : this(iconID, titleCliloc, secondaryCliloc, length, m)
         {
-            m_Args = args;
+            m_TitleArguments = titleargs;
+            m_SecondaryArguments = secargs;
+        }
+
+        public BuffInfo(BuffIcon iconID, int titleCliloc, TextDefinition titleargs, int secondaryCliloc, TextDefinition secargs, int thirdCliloc, TextDefinition thirdargs, TimeSpan length, Mobile m)
+            : this(iconID, titleCliloc, secondaryCliloc, thirdCliloc, length, m)
+        {
+            m_TitleArguments = titleargs;
+            m_SecondaryArguments = secargs;
+            m_ThirdArguments = thirdargs;
+        }
+
+        public BuffInfo(BuffIcon iconID, int titleCliloc, TimeSpan length, Mobile m, TextDefinition secargs, bool retainThroughDeath)
+            : this(iconID, titleCliloc, titleCliloc + 1, length, m, secargs, retainThroughDeath)
+        {
+        }
+
+        public BuffInfo(BuffIcon iconID, int titleCliloc, int secondaryCliloc, TimeSpan length, Mobile m, TextDefinition secargs, bool retainThroughDeath)
+            : this(iconID, titleCliloc, secondaryCliloc, length, m)
+        {
+            m_SecondaryArguments = secargs;
             m_RetainThroughDeath = retainThroughDeath;
         }
 
@@ -370,53 +405,64 @@ namespace Server
     public sealed class AddBuffPacket : Packet
     {
         public AddBuffPacket(Mobile m, BuffInfo info)
-            : this(m, info.ID, info.TitleCliloc, info.SecondaryCliloc, info.Args, info.NoTimer ? TimeSpan.Zero : (info.TimeStart != DateTime.MinValue) ? ((info.TimeStart + info.TimeLength) - DateTime.UtcNow) : TimeSpan.Zero)
+            : this(m, info.ID, info.TitleCliloc, info.TitleArguments, info.SecondaryCliloc, info.SecondaryArguments, info.ThirdCliloc, info.ThirdArguments, info.NoTimer ? TimeSpan.Zero : (info.TimeStart != DateTime.MinValue) ? ((info.TimeStart + info.TimeLength) - DateTime.UtcNow) : TimeSpan.Zero)
         {
         }
 
-        public AddBuffPacket(Mobile mob, BuffIcon iconID, int titleCliloc, int secondaryCliloc, TextDefinition args, TimeSpan length)
+        public AddBuffPacket(Mobile mob, BuffIcon iconID, int titleCliloc, TextDefinition titleargs, int secondaryCliloc, TextDefinition secargs, int thirdCliloc, TextDefinition thirdargs, TimeSpan length)
             : base(0xDF)
         {
-            bool hasArgs = (args != null);
+            bool args = titleargs != null || secargs != null || thirdargs != null;
 
-            EnsureCapacity((hasArgs ? (48 + args.ToString().Length * 2) : 44));
-            m_Stream.Write(mob.Serial);
+            string title = string.Format("{0}{1}", titleargs ?? "", args ? "\0" : "");
+            string secondary = string.Format("{0}{1}", secargs ?? "", args ? "\0" : "");
+            string third = string.Format("{0}{1}", thirdargs ?? "", args ? "\0" : "");
 
-            m_Stream.Write((short)iconID);	//ID
-            m_Stream.Write((short)0x1);	//Type 0 for removal. 1 for add 2 for Data
+            EnsureCapacity(46 + (title.Length * 2) + (secondary.Length * 2) + (third.Length * 2));
 
-            m_Stream.Fill(4);
+            m_Stream.Write(mob.Serial); // Serial
 
-            m_Stream.Write((short)iconID);	//ID
-            m_Stream.Write((short)0x01);	//Type 0 for removal. 1 for add 2 for Data
+            m_Stream.Write((short)iconID);	// BuffIconType
+            m_Stream.Write((short)0x1); // Buffs Count
 
-            m_Stream.Fill(4);
+            m_Stream.Write((short)0x0); // Source Type
+            m_Stream.Write((short)0x0);
+
+            m_Stream.Write((short)iconID); // Buff Icon ID
+            m_Stream.Write((short)0x1); // Buff Queue Index
+
+            m_Stream.Write(0x0);
 
             if (length < TimeSpan.Zero)
                 length = TimeSpan.Zero;
 
-            m_Stream.Write((short)length.TotalSeconds);	//Time in seconds
+            m_Stream.Write((short)length.TotalSeconds);	// Buff Duration in seconds
 
-            m_Stream.Fill(3);
-            m_Stream.Write(titleCliloc);
-            m_Stream.Write(secondaryCliloc);
+            m_Stream.Fill(3); // byte[3] 0x00
 
-            if (!hasArgs)
-            {
-                //m_Stream.Fill( 2 );
-                m_Stream.Fill(10);
+            m_Stream.Write(titleCliloc); // Buff Title Cliloc
+            m_Stream.Write(secondaryCliloc); // Buff Secondary Cliloc
+            m_Stream.Write(thirdCliloc); // Buff Third Cliloc
+
+            m_Stream.Write((short)(title.Length)); // Primary Cliloc Arguments Length
+
+            if (title.Length > 0)
+            {                
+                m_Stream.WriteLittleUniFixed(title, title.Length); // Primary Cliloc Arguments
             }
-            else
-            {
-                m_Stream.Fill(4);
-                m_Stream.Write((short)0x1);	//Unknown -> Possibly something saying 'hey, I have more data!'?
-                m_Stream.Fill(2);
 
-                //m_Stream.WriteLittleUniNull( "\t#1018280" );
-                m_Stream.WriteLittleUniNull(string.Format("\t{0}", args));
+            m_Stream.Write((short)(secondary.Length)); // Secondary Cliloc Arguments
 
-                m_Stream.Write((short)0x1);	//Even more Unknown -> Possibly something saying 'hey, I have more data!'?
-                m_Stream.Fill(2);
+            if (secondary.Length > 0)
+            {                
+                m_Stream.WriteLittleUniFixed(secondary, secondary.Length); // Secondary Cliloc Arguments
+            }
+
+            m_Stream.Write((short)(third.Length)); // Third Cliloc Arguments Length
+
+            if (third.Length > 0)
+            {                
+                m_Stream.WriteLittleUniFixed(third, third.Length); // Third Cliloc Arguments
             }
         }
     }

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -3678,6 +3678,8 @@ namespace Server.Mobiles
             StrangleSpell.RemoveCurse(this);
             Spells.Second.ProtectionSpell.EndProtection(this);
 
+            BaseFishPie.RemoveEffects(this);
+
             EndAction(typeof(PolymorphSpell));
             EndAction(typeof(IncognitoSpell));
 

--- a/Scripts/Services/Craft/DefCooking.cs
+++ b/Scripts/Services/Craft/DefCooking.cs
@@ -537,13 +537,7 @@ namespace Server.Engines.Craft
 
         private Item CraftCharydbisBait(Mobile m, CraftItem craftItem, ITool tool)
         {
-            var bait = new Bait
-            {
-                Index = 35,
-                UsesRemaining = 5
-            };
-
-            return bait;
+            return new Bait(35, 5);
         }
     }
 }

--- a/Scripts/Services/Harvest/Fishing/Bait.cs
+++ b/Scripts/Services/Harvest/Fishing/Bait.cs
@@ -133,7 +133,7 @@ namespace Server.Items
                 {
                     if (bait.IsChildOf(from.Backpack))
                     {
-                        if (bait.BaitType == m_Bait.BaitType)
+                        if (bait.BaitType == m_Bait.BaitType && bait.Enhanced == m_Bait.Enhanced)
                         {
                             m_Bait.UsesRemaining += bait.UsesRemaining;
                             bait.Delete();

--- a/Scripts/Services/Harvest/Fishing/Bait.cs
+++ b/Scripts/Services/Harvest/Fishing/Bait.cs
@@ -1,4 +1,3 @@
-using Server.Prompts;
 using Server.Targeting;
 using System;
 
@@ -6,10 +5,7 @@ namespace Server.Items
 {
     public class Bait : Item
     {
-        public static readonly bool UsePrompt = true;
-
         private Type m_BaitType;
-        private object m_Label;
         private int m_UsesRemaining;
         private int m_Index;
         private bool m_Enhanced;
@@ -18,8 +14,7 @@ namespace Server.Items
         public Type BaitType => m_BaitType;
 
         [CommandProperty(AccessLevel.GameMaster)]
-        public int UsesRemaining { get => m_UsesRemaining;
-            set { m_UsesRemaining = value; InvalidateProperties(); } }
+        public int UsesRemaining { get => m_UsesRemaining; set { m_UsesRemaining = value; InvalidateProperties(); } }
 
         [CommandProperty(AccessLevel.GameMaster)]
         public int Index
@@ -36,7 +31,6 @@ namespace Server.Items
 
                 m_BaitType = FishInfo.GetTypeFromIndex(m_Index);
                 Hue = FishInfo.GetFishHue(m_Index);
-                m_Label = FishInfo.GetFishLabel(m_Index);
                 InvalidateProperties();
             }
         }
@@ -45,42 +39,22 @@ namespace Server.Items
         public bool Enhanced { get => m_Enhanced; set { m_Enhanced = value; InvalidateProperties(); } }
 
         [Constructable]
-        public Bait(int index) : base(2454)
+        public Bait()
+            : this(Utility.RandomMinMax(0, 34), 1)
         {
-            Index = index;
-            m_UsesRemaining = 1;
         }
 
         [Constructable]
-        public Bait() : base(2454)
+        public Bait(int index, int remaining)
+            : base(0x996)
         {
-            m_UsesRemaining = 1;
-        }
+            Index = index;
+            m_UsesRemaining = remaining;
+        }        
 
         public override void OnDoubleClick(Mobile from)
         {
-            if (IsChildOf(from.Backpack))
-            {
-                if (UsePrompt && m_UsesRemaining > 1)
-                {
-                    from.SendMessage("How much bait would you like to use?");
-                    from.Prompt = new InternalPrompt(this);
-                }
-                else
-                {
-                    from.Target = new InternalTarget(this, 1);
-                    from.SendMessage("Target the fishing pole or lobster trap that you would like to apply the bait to.");
-                }
-            }
-        }
-
-        public void TryBeginTarget(Mobile from, int amount)
-        {
-            if (amount < 0) amount = 1;
-            if (amount > m_UsesRemaining) amount = m_UsesRemaining;
-
-            from.Target = new InternalTarget(this, amount);
-            from.SendMessage("Target the fishing pole or lobster trap that you would like to apply the bait to.");
+            from.Target = new InternalTarget(this);
         }
 
         public override void AddNameProperty(ObjectPropertyList list)
@@ -96,7 +70,7 @@ namespace Server.Items
                     list.Add(1116464, "#{0}\t{1}", 1116470, s);
             }
             else if (label is int i)
-                list.Add(1116465, string.Format("#{0}", i)); //~1_token~ bait
+                list.Add(1116465, string.Format("#{0}", i)); // ~1_token~ bait
             else if (label is string s)
                 list.Add(1116465, s);
         }
@@ -105,116 +79,71 @@ namespace Server.Items
         {
             base.GetProperties(list);
 
-            list.Add(1116466, m_UsesRemaining.ToString());  //amount: ~1_val~
-        }
-
-        private class InternalPrompt : Prompt
-        {
-            private readonly Bait m_Bait;
-
-            public InternalPrompt(Bait bait)
-            {
-                m_Bait = bait;
-            }
-
-            public override void OnResponse(Mobile from, string text)
-            {
-                int amount = Utility.ToInt32(text);
-                m_Bait.TryBeginTarget(from, amount);
-            }
-
-            public override void OnCancel(Mobile from)
-            {
-                from.SendMessage("Not applying bait...");
-            }
+            list.Add(1116466, m_UsesRemaining.ToString()); // amount: ~1_val~
         }
 
         private class InternalTarget : Target
         {
             private readonly Bait m_Bait;
-            private readonly int m_Amount;
 
-            public InternalTarget(Bait bait, int amount)
+            public InternalTarget(Bait bait)
                 : base(0, false, TargetFlags.None)
             {
                 m_Bait = bait;
-                m_Amount = amount;
             }
 
             protected override void OnTarget(Mobile from, object targeted)
             {
-                if (targeted == m_Bait)
+                if (targeted == m_Bait || m_Bait.UsesRemaining <= 0)
                     return;
 
                 if (targeted is FishingPole pole)
                 {
-                    if (!m_Bait.IsFishBait())
-                    {
-                        from.SendMessage("Think again before applying lobster or crab bait to a fishing pole!");
+                    if (pole.BaitType != null)
                         return;
-                    }
 
-                    bool hasBait = pole.BaitType != null;
-
-                    if (hasBait && pole.BaitType != m_Bait.BaitType)
-                        from.SendMessage("You swap out the old bait for new.");
-
-                    if (pole.BaitType == m_Bait.BaitType)
-                        pole.BaitUses += m_Amount;
-                    else
-                    {
-                        pole.BaitType = m_Bait.BaitType;
-                        pole.BaitUses += m_Amount;
-                    }
+                    pole.BaitType = m_Bait.BaitType;
 
                     if (m_Bait.Enhanced)
                         pole.EnhancedBait = true;
 
-                    from.SendLocalizedMessage(1149759);  //You bait the hook.
-                    m_Bait.UsesRemaining -= m_Amount;
+                    from.SendLocalizedMessage(1149759); // You bait the hook.
+
+                    m_Bait.UsesRemaining--;
                 }
                 else if (targeted is LobsterTrap trap)
                 {
-                    if (m_Bait.IsFishBait())
+                    if (trap.BaitType != null)
+                        return;                   
+
+                    if (trap.Amount > m_Bait.UsesRemaining)
                     {
-                        from.SendMessage("Think again before applying fish bait to a lobster trap!");
+                        from.SendLocalizedMessage(1149758); // There is not enough to bait the whole stack.
                         return;
                     }
 
-                    bool hasBait = trap.BaitType != null;
-
                     trap.BaitType = m_Bait.BaitType;
-                    //trap.Hue = m_Bait.Hue;
+                    trap.EnhancedBait = m_Bait.Enhanced;
 
-                    if (hasBait && trap.BaitType != m_Bait.BaitType)
-                        from.SendMessage("You swap out the old bait for new.");
+                    m_Bait.UsesRemaining -= trap.Amount;
 
-                    if (trap.BaitType == m_Bait.BaitType)
-                        trap.BaitUses += m_Amount;
-                    else
-                    {
-                        trap.BaitType = m_Bait.BaitType;
-                        trap.BaitUses += m_Amount;
-                    }
-
-                    if (m_Bait.Enhanced)
-                        trap.EnhancedBait = true;
-
-                    from.SendLocalizedMessage(1149760); //You bait the trap.
-                    m_Bait.UsesRemaining -= m_Amount;
+                    from.SendLocalizedMessage(1149760); // You bait the trap.
                 }
-                else if (targeted is Bait bait && bait.IsChildOf(from.Backpack) && bait.BaitType == m_Bait.BaitType)
+                else if (targeted is Bait bait)
                 {
-                    bait.UsesRemaining += m_Amount;
-                    m_Bait.UsesRemaining -= m_Amount;
-
-                    if (m_Bait.UsesRemaining <= 0)
+                    if (bait.IsChildOf(from.Backpack))
                     {
-                        m_Bait.Delete();
-                        from.SendLocalizedMessage(1116469); //You combine these baits into one cup and destroy the other cup.
+                        if (bait.BaitType == m_Bait.BaitType)
+                        {
+                            m_Bait.UsesRemaining += bait.UsesRemaining;
+                            bait.Delete();
+                            from.SendLocalizedMessage(1116469); // You combine these baits into one cup and destroy the other cup.
+                        }
                     }
                     else
-                        from.SendMessage("You combine these baits into one cup.");
+                    {
+                        from.SendLocalizedMessage(1154125); // You must be carrying that in order to combine them.
+                    }
 
                     return;
                 }
@@ -222,22 +151,15 @@ namespace Server.Items
                 if (m_Bait.UsesRemaining <= 0)
                 {
                     m_Bait.Delete();
-                    from.SendLocalizedMessage(1116467); //Your bait is used up so you destroy the container.
+                    from.SendLocalizedMessage(1116467); // Your bait is used up so you destroy the container.
                 }
             }
         }
 
-        public bool IsFishBait()
+        public Bait(Serial serial)
+            : base(serial)
         {
-            if (m_BaitType == null)
-            {
-                Index = Utility.RandomMinMax(0, 34);
-            }
-
-            return !(m_BaitType is null) && !m_BaitType.IsSubclassOf(typeof(BaseCrabAndLobster));
         }
-
-        public Bait(Serial serial) : base(serial) { }
 
         public override void Serialize(GenericWriter writer)
         {
@@ -264,7 +186,6 @@ namespace Server.Items
                 m_Index = FishInfo.FishInfos.Count - 1;
 
             m_BaitType = FishInfo.FishInfos[m_Index].Type;
-            m_Label = FishInfo.GetFishLabel(m_Index);
         }
     }
 }

--- a/Scripts/Services/Harvest/Fishing/Bait.cs
+++ b/Scripts/Services/Harvest/Fishing/Bait.cs
@@ -50,7 +50,12 @@ namespace Server.Items
         {
             Index = index;
             m_UsesRemaining = remaining;
-        }        
+        }
+
+        public Bait(Serial serial)
+            : base(serial)
+        {
+        }
 
         public override void OnDoubleClick(Mobile from)
         {
@@ -154,11 +159,6 @@ namespace Server.Items
                     from.SendLocalizedMessage(1116467); // Your bait is used up so you destroy the container.
                 }
             }
-        }
-
-        public Bait(Serial serial)
-            : base(serial)
-        {
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Services/Harvest/Fishing/CrabsAndLobsters.cs
+++ b/Scripts/Services/Harvest/Fishing/CrabsAndLobsters.cs
@@ -43,6 +43,11 @@ namespace Server.Items
         {
         }
 
+        public RareCrabAndLobster(Serial serial)
+            : base(serial)
+        {
+        }
+
         public override void GetProperties(ObjectPropertyList list)
         {
             base.GetProperties(list);
@@ -51,11 +56,6 @@ namespace Server.Items
 
             if (m_DateCaught != DateTime.MinValue)
                 list.Add("[{0}]", m_DateCaught.ToShortDateString());
-        }
-
-        public RareCrabAndLobster(Serial serial)
-            : base(serial)
-        {
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Services/Harvest/Fishing/CrabsAndLobsters.cs
+++ b/Scripts/Services/Harvest/Fishing/CrabsAndLobsters.cs
@@ -43,7 +43,20 @@ namespace Server.Items
         {
         }
 
-        public RareCrabAndLobster(Serial serial) : base(serial) { }
+        public override void GetProperties(ObjectPropertyList list)
+        {
+            base.GetProperties(list);
+
+            list.Add(1070857, m_CaughtBy != null ? m_CaughtBy.Name : "An Unknown Fisher"); // Caught by ~1_fisherman~
+
+            if (m_DateCaught != DateTime.MinValue)
+                list.Add("[{0}]", m_DateCaught.ToShortDateString());
+        }
+
+        public RareCrabAndLobster(Serial serial)
+            : base(serial)
+        {
+        }
 
         public override void Serialize(GenericWriter writer)
         {

--- a/Scripts/Services/Harvest/Fishing/FishInfo.cs
+++ b/Scripts/Services/Harvest/Fishing/FishInfo.cs
@@ -20,10 +20,10 @@ namespace Server.Items
             m_FishInfos.Add(new FishInfo(2578, typeof(FairySalmon), 1116089, "TerMur", false, RareChance, 85.8)); //Confirmed
             m_FishInfos.Add(new FishInfo(1461, typeof(FireFish), 1116093, "Shame", false, RareChance, 95.8)); //Confirmed
             m_FishInfos.Add(new FishInfo(1257, typeof(GiantKoi), 1116088, "Tokuno", true, RareChance, 95.8)); //Confirmed
-            m_FishInfos.Add(new FishInfo(2579/*1287*/, typeof(GreatBarracuda), 1116100, "Felucca", true, RareChance, 89.0)); //Confirmed
+            m_FishInfos.Add(new FishInfo(2579, typeof(GreatBarracuda), 1116100, "Felucca", true, RareChance, 89.0)); //Confirmed
             m_FishInfos.Add(new FishInfo(2959, typeof(HolyMackerel), 1116087, "Gravewater Lake", false, RareChance, 102.9)); //Confirmed
             m_FishInfos.Add(new FishInfo(2075, typeof(LavaFish), 1116096, "Abyss", false, RareChance, 110.0)); //Confirmed
-            m_FishInfos.Add(new FishInfo(2075/*1152*/, typeof(ReaperFish), 1116094, "Doom", false, RareChance, 98.1));  //Confirmed
+            m_FishInfos.Add(new FishInfo(2075, typeof(ReaperFish), 1116094, "Doom", false, RareChance, 98.1));  //Confirmed
             m_FishInfos.Add(new FishInfo(2539, typeof(SpiderCrab), 1116367, "Terathan Keep", false, RareChance, 103.1)); //Confirmed
             m_FishInfos.Add(new FishInfo(2558, typeof(StoneCrab), 1116365, "T2A", true, RareChance, 103.1)); //Confirmed
             m_FishInfos.Add(new FishInfo(43, typeof(SummerDragonfish), 1116091, "Destard", false, RareChance, 105.2));  //Confirmed

--- a/Scripts/Services/Harvest/Fishing/FishInfo.cs
+++ b/Scripts/Services/Harvest/Fishing/FishInfo.cs
@@ -373,7 +373,7 @@ namespace Server.Items
             return item;
         }
 
-        public static List<FishInfo> GetInfoFor(IEntity fisher, bool fishing, double skill, bool deep)
+        public static List<FishInfo> GetInfoFor(IEntity fisher, bool isfishingpole, double skill, bool deepwater)
         {
             var list = new List<FishInfo>();
             var fisherMap = fisher.Map;
@@ -383,8 +383,8 @@ namespace Server.Items
             {
                 var info = m_FishInfos[i];
 
-                if ((fishing && info.Type.IsSubclassOf(typeof(RareFish)) || !fishing && !info.Type.IsSubclassOf(typeof(RareFish))) &&
-                    skill >= info.MinSkill && (info.RequiresDeepWater == deep || !info.RequiresDeepWater == deep))
+                if ((isfishingpole && info.Type.IsSubclassOf(typeof(RareFish)) || !isfishingpole && info.Type.IsSubclassOf(typeof(RareCrabAndLobster))) &&
+                    skill >= info.MinSkill && (info.RequiresDeepWater == deepwater || !info.RequiresDeepWater == deepwater))
                 {
                     if (info.Location is string stringLoc)
                     {

--- a/Scripts/Services/Harvest/Fishing/FishPies.cs
+++ b/Scripts/Services/Harvest/Fishing/FishPies.cs
@@ -156,7 +156,8 @@ namespace Server.Items
 
             if (Effect != FishPieEffect.None)
             {
-                new InternalTimer(Duration, from);
+                Timer t = new InternalTimer(Duration, from);
+                t.Start();
 
                 BuffInfo.AddBuff(from, new BuffInfo(BuffIcon.FishPie, 1116559, string.Format("#{0}", Buff), 1116560, string.Format("+{0}\t#{1}", BuffAmount, BuffDescription), Duration, from)); // Magic Fish Buff<br>~1_val~
             }
@@ -170,7 +171,6 @@ namespace Server.Items
                 : base(duration)
             {
                 m_From = from;
-                Start();
             }
 
             protected override void OnTick()

--- a/Scripts/Services/Harvest/Fishing/FishPies.cs
+++ b/Scripts/Services/Harvest/Fishing/FishPies.cs
@@ -42,7 +42,7 @@ namespace Server.Items
         public virtual int BuffDescription => 0;
         public virtual FishPieEffect Effect => FishPieEffect.None;
 
-        public static Dictionary<Mobile, FishPieEffect> m_EffectsList = new Dictionary<Mobile, FishPieEffect>();
+        private static readonly Dictionary<Mobile, FishPieEffect> m_EffectsList = new Dictionary<Mobile, FishPieEffect>();
 
         public BaseFishPie() : base(4161)
         {

--- a/Scripts/Services/Harvest/Fishing/Fishing.cs
+++ b/Scripts/Services/Harvest/Fishing/Fishing.cs
@@ -803,6 +803,7 @@ namespace Server.Engines.Harvest
             return true;
         }
 
+        public static int[] WaterTiles => m_WaterTiles;
         private static readonly int[] m_WaterTiles =
         {
             0x00A8, 0x00AB,

--- a/Scripts/Services/Harvest/Fishing/Hooks.cs
+++ b/Scripts/Services/Harvest/Fishing/Hooks.cs
@@ -67,7 +67,6 @@ namespace Server.Items
             if (IsChildOf(from.Backpack))
             {
                 from.Target = new InternalTarget(this);
-                //TODO: Message?
             }
         }
 
@@ -119,8 +118,12 @@ namespace Server.Items
                     pole.HookUses = m_Hook.Uses;
                     pole.OriginalHue = pole.Hue;
                     pole.Hue = m_Hook.Hue;
-                    from.SendLocalizedMessage(1150884); //You tie the hook to the fishing line.
+                    from.SendLocalizedMessage(1150884); // You tie the hook to the fishing line.
                     m_Hook.Delete();
+                }
+                else
+                {
+                    from.SendLocalizedMessage(1046439); // That is not a valid target.
                 }
             }
         }
@@ -154,13 +157,13 @@ namespace Server.Items
         [Constructable]
         public LavaHook(int uses) : base(uses)
         {
-            Hue = 2075;
+            Hue = 2515;
         }
 
         [Constructable]
         public LavaHook()
         {
-            Hue = 2075;
+            Hue = 2515;
         }
 
         public LavaHook(Serial serial) : base(serial) { }

--- a/Scripts/Services/Harvest/Fishing/LavaLobsterTrap.cs
+++ b/Scripts/Services/Harvest/Fishing/LavaLobsterTrap.cs
@@ -2,19 +2,18 @@ namespace Server.Items
 {
     public class LavaLobsterTrap : LobsterTrap
     {
+        public override int LabelNumber => 1116474; // lava lobster trap
+
         [Constructable]
         public LavaLobsterTrap()
         {
+            Hue = 2515;
         }
 
-        public override int[] UseableTiles => Engines.Harvest.Fishing.LavaTiles;
-
-        public override void AddNameProperty(ObjectPropertyList list)
+        public LavaLobsterTrap(Serial serial)
+            : base(serial)
         {
-            list.Add(1116474); //lava lobster trap
         }
-
-        public LavaLobsterTrap(Serial serial) : base(serial) { }
 
         public override void Serialize(GenericWriter writer)
         {

--- a/Scripts/Services/Harvest/Fishing/LobsterTrap.cs
+++ b/Scripts/Services/Harvest/Fishing/LobsterTrap.cs
@@ -242,15 +242,10 @@ namespace Server.Items
                 return false;
             }
 
-            if (!iswater && !lava || !islava && lava)
+            if (!iswater && !lava || !islava && lava || lava && !from.Region.IsPartOf("Abyss"))
             {
                 from.SendLocalizedMessage(1116695); // The water there is too shallow for the trap.
                 return false;
-            }
-
-            if (lava && !from.Region.IsPartOf("Abyss"))
-            {
-                islava = false;
             }
 
             return true;

--- a/Scripts/Services/Harvest/Fishing/LobsterTrap.cs
+++ b/Scripts/Services/Harvest/Fishing/LobsterTrap.cs
@@ -486,7 +486,7 @@ namespace Server.Items
 
             InUse = true;
 
-            m_Timer = Timer.DelayCall(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(3), OnTick);            
+            m_Timer = Timer.DelayCall(TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1), OnTick);            
         }
 
         public void EndTimer(Mobile from)

--- a/Scripts/Services/Harvest/Fishing/LobsterTrap.cs
+++ b/Scripts/Services/Harvest/Fishing/LobsterTrap.cs
@@ -55,6 +55,11 @@ namespace Server.Items
             Amount = amount;
         }
 
+        public LobsterTrap(Serial serial)
+            : base(serial)
+        {
+        }
+
         public override void OnAfterDuped(Item newItem)
         {
             if (!(newItem is LobsterTrap trap))
@@ -351,11 +356,6 @@ namespace Server.Items
             eable.Free();
 
             return true;
-        }        
-
-        public LobsterTrap(Serial serial)
-            : base(serial)
-        {
         }
 
         public override void Serialize(GenericWriter writer)
@@ -437,6 +437,11 @@ namespace Server.Items
             Caught = new List<Type>();
 
             StartTimer();
+        }
+
+        public LobsterTrapMechanism(Serial serial)
+            : base(serial)
+        {
         }
 
         public override void AddNameProperty(ObjectPropertyList list)
@@ -630,11 +635,6 @@ namespace Server.Items
 
             from.SendLocalizedMessage(1116391); //You realize that the trap isn't yours so you leave it alone.
             return false;
-        }
-
-        public LobsterTrapMechanism(Serial serial)
-            : base(serial)
-        {
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Services/Harvest/Fishing/LobsterTrap.cs
+++ b/Scripts/Services/Harvest/Fishing/LobsterTrap.cs
@@ -543,10 +543,7 @@ namespace Server.Items
                 case 5:
                 case 8:
                     {
-                        if (!IsLava)
-                        {
-                            OnTrapLost();
-                        }
+                        OnTrapLost();
 
                         break;
                     }

--- a/Scripts/Services/Harvest/Fishing/LobsterTrap.cs
+++ b/Scripts/Services/Harvest/Fishing/LobsterTrap.cs
@@ -253,8 +253,6 @@ namespace Server.Items
 
         public static bool IsNotShallowWaterStaticTile(Map map, IPoint3D pnt)
         {
-            var tiles = Engines.Harvest.Fishing.WaterTiles;
-
             bool water = true;
 
             Misc.Geometry.Circle2D(new Point3D(pnt.X, pnt.Y, pnt.Z), map, 5, (p, m) =>
@@ -289,8 +287,6 @@ namespace Server.Items
 
         public static bool IsNotShallowWaterLand(Map map, IPoint3D pnt)
         {
-            var tiles = Engines.Harvest.Fishing.WaterTiles;
-
             bool water = true;
 
             Misc.Geometry.Circle2D(new Point3D(pnt.X, pnt.Y, pnt.Z), map, 5, (p, m) =>
@@ -507,7 +503,7 @@ namespace Server.Items
             {
                 trap.Caught = Caught;
                 trap.CheckTrap();
-            };
+            }
 
             if (from.Backpack == null || !from.Backpack.TryDropItem(from, trap, false))
                 trap.MoveToWorld(from.Location, from.Map);

--- a/Scripts/Services/Harvest/Fishing/LobsterTrap.cs
+++ b/Scripts/Services/Harvest/Fishing/LobsterTrap.cs
@@ -7,20 +7,10 @@ using System.Collections.Generic;
 
 namespace Server.Items
 {
-    [Flipable(17615, 17616)]
-    public class LobsterTrap : Container, ITelekinesisable, IBaitable
+    [Flipable(0x44CF, 0x44D0)]
+    public class LobsterTrap : Item, IBaitable
     {
-        public static readonly int TrapID = Utility.RandomMinMax(17615, 17616);
-        public static readonly int BuoyID = 17611;
-        public static readonly int MaxCatch = 5;
-
         private Type m_BaitType;
-        private bool m_EnhancedBait;
-        private int m_BaitUses;
-        private bool m_InUse;
-        private Timer m_Timer;
-        private Mobile m_Owner;
-        private int m_Bobs;
 
         [CommandProperty(AccessLevel.GameMaster)]
         public Type BaitType
@@ -33,71 +23,68 @@ namespace Server.Items
                 if (m_BaitType == null)
                 {
                     m_EnhancedBait = false;
-                    m_BaitUses = 0;
                 }
 
                 InvalidateProperties();
             }
         }
 
+        private bool m_EnhancedBait;
+
         [CommandProperty(AccessLevel.GameMaster)]
         public bool EnhancedBait { get => m_EnhancedBait; set { m_EnhancedBait = value; InvalidateProperties(); } }
 
-        [CommandProperty(AccessLevel.GameMaster)]
-        public int BaitUses { get => m_BaitUses; set { m_BaitUses = value; InvalidateProperties(); } }
+        public List<Type> Caught;
 
-        [CommandProperty(AccessLevel.GameMaster)]
-        public bool InUse { get => m_InUse; set { m_InUse = value; InvalidateProperties(); } }
+        public override int LabelNumber => IsFull ? 1149599 : 1116389; // full lobster trap || empty lobster trap
 
-        [CommandProperty(AccessLevel.GameMaster)]
-        public Mobile Owner { get => m_Owner; set { m_Owner = value; InvalidateProperties(); } }
-
-        public override int LabelNumber { get { if (m_Owner == null) return 1096487; return 0; } }
-        public override bool DisplaysContent => false;
+        public bool IsFull => Caught != null && Caught.Count > 0;
 
         [Constructable]
-        public LobsterTrap() : base(17615)
+        public LobsterTrap()
+            : this(1)
         {
         }
 
-        public void OnTelekinesis(Mobile from)
+        [Constructable]
+        public LobsterTrap(int amount)
+            : base(0x44CF)
         {
-            if (m_InUse && ItemID == BuoyID && CanUseTrap(from))
-                EndTimer(from);
+            Weight = 5.0;
+            Stackable = true;
+            Amount = amount;
         }
 
-        public override bool OnDragDropInto(Mobile from, Item item, Point3D p)
+        public override void OnAfterDuped(Item newItem)
         {
-            return false;
+            if (!(newItem is LobsterTrap trap))
+                return;
+
+            trap.BaitType = m_BaitType;
+            trap.EnhancedBait = m_EnhancedBait;
+
+            base.OnAfterDuped(newItem);
         }
 
-        public override bool OnDragDrop(Mobile from, Item dropped)
+        public override bool WillStack(Mobile from, Item item)
         {
-            return false;
-        }
-
-        public override bool TryDropItem(Mobile from, Item dropped, bool sendFullMessage)
-        {
-            return false;
-        }
-
-        public override void AddNameProperty(ObjectPropertyList list)
-        {
-            if (ItemID == TrapID)
+            if (IsFull || item is LobsterTrap trap && (trap.BaitType != BaitType || trap.EnhancedBait != EnhancedBait))
             {
-                if (Items.Count == 0)
-                    list.Add(1116389); //empty lobster trap
-                else if (Items.Count >= MaxCatch)
-                    list.Add(1149599); //full lobster trap
-                else
-                    list.Add(1096487); //lobster trap
+                return false;
+            }
+
+            return base.WillStack(from, item);
+        }
+
+        public void CheckTrap()
+        {
+            if (IsFull)
+            {
+                ItemID = 0x44D0;
             }
             else
             {
-                if (m_Owner == null)
-                    list.Add(1096487); //lobster trap
-                else
-                    list.Add(1116390, m_Owner.Name);
+                ItemID = 0x44CF;
             }
         }
 
@@ -105,81 +92,79 @@ namespace Server.Items
         {
             base.GetProperties(list);
 
-            if (m_BaitType != null)
+            if (!IsFull && m_BaitType != null)
             {
                 object label = FishInfo.GetFishLabel(m_BaitType);
+
                 if (label is int i)
-                    list.Add(1116468, string.Format("#{0}", i)); //baited to attract: ~1_val~
+                    list.Add(1116468, string.Format("#{0}", i)); // baited to attract: ~1_val~
                 else if (label is string s)
                     list.Add(1116468, s);
-
-                list.Add(1116466, m_BaitUses.ToString());
             }
         }
 
         public override void OnDoubleClick(Mobile from)
         {
-            if (IsChildOf(from.Backpack))
+            if (Caught != null && Caught.Count > 0)
             {
-                if (ItemID == BuoyID)
-                    ItemID = TrapID;
+                DumpContents(from);
+                return;
+            }
 
-                if (Items.Count > 0)
+            if (from.Mounted || from.Flying)
+            {
+                if (IsChildOf(from.Backpack))
                 {
-                    DumpContents(from);
-                    from.SendMessage("You dump the contents of the lobster trap into your pack.");
+                    from.SendLocalizedMessage(500971); // You can't fish while riding!
                 }
                 else
                 {
-                    from.SendLocalizedMessage(500974); //What water do you want to fish in?
-                    from.BeginTarget(-1, true, TargetFlags.None, OnTarget);
+                    PrivateOverheadMessage(MessageType.Regular, 0x3B2, 500971, from.NetState); // You can't fish while riding!
                 }
-            }
-            else if (ItemID == BuoyID)
-            {
-                if (RootParent != null)
-                    ItemID = TrapID;
 
-                InvalidateProperties();
-
-                if (CanUseTrap(from))
-                    EndTimer(from);
-
-                InvalidateProperties();
+                return;
             }
-            else
-            {
-                from.SendLocalizedMessage(1042001); // That must be in your pack for you to use it.
-            }
+
+            from.SendLocalizedMessage(500974); // What water do you want to fish in?
+            from.BeginTarget(-1, true, TargetFlags.None, OnTarget);
         }
 
         private void DumpContents(Mobile from)
         {
+            ItemID = 0x44CF;
+
             Container pack = from.Backpack;
 
-            var list = new List<Item>(Items);
-
-            for (var index = 0; index < list.Count; index++)
+            foreach(var t in Caught)
             {
-                Item item = list[index];
+                Item item = Loot.Construct(t);
 
-                if (item == null)
+                if (item is RareCrabAndLobster fish)
                 {
-                    continue;
+                    fish.Fisher = from;
+                    fish.DateCaught = DateTime.UtcNow;
+                    fish.Weight = Utility.RandomMinMax(10, 200);
+                    fish.Stackable = false;
                 }
 
-                if (!pack.TryDropItem(from, item, false))
+                if (item != null)
                 {
-                    item.MoveToWorld(from.Location, from.Map);
-                }
+                    if (!pack.TryDropItem(from, item, false))
+                    {
+                        item.MoveToWorld(from.Location, from.Map);
+                    }
 
-                from.SendLocalizedMessage(1116386, string.Format("#{0}", item.LabelNumber));
+                    from.SendLocalizedMessage(1116386, string.Format("#{0}", item.LabelNumber)); // You remove ~1_ITEM~from the trap and put it in your pack.
+                }
             }
+
+            Caught = null;
+            CheckTrap();
         }
 
         public void OnTarget(Mobile from, object targeted)
         {
-            if (Deleted || m_InUse)
+            if (Deleted)
                 return;
 
             IPoint3D pnt = (IPoint3D)targeted;
@@ -188,215 +173,174 @@ namespace Server.Items
             if (map == null || map == Map.Internal)
                 return;
 
-            int x = pnt.X; int y = pnt.Y; int z = pnt.Z;
-
-            if (!from.InRange(pnt, 6))
+            if (!from.InLOS(targeted))
+            {
+                from.SendLocalizedMessage(500979); // You cannot see that location.
+            }
+            else if (!from.InRange(pnt, 6))
             {
                 from.SendLocalizedMessage(1116388); // The trap is too cumbersome to deploy that far away.
             }
-            else if (!IsValidTile(targeted))
-                from.SendMessage("You cannot deploy a trap there!"); //TODO: Get Cliloc
-            else if (!IsValidLocation(x, y, z, map))
-                from.SendLocalizedMessage(1116393); //The location is too close to another trap.
+            else if (!IsValidLocation(pnt.X, pnt.Y, pnt.Z, map))
+            {
+                from.SendLocalizedMessage(1116393); // The location is too close to another trap.
+            }
             else
             {
-                m_Owner = from;
-                ItemID = BuoyID;
-                InvalidateProperties();
-                Movable = false;
-                MoveToWorld(new Point3D(x, y, z), map);
-                m_Bobs = 0;
-                m_InUse = true;
-                StartTimer();
+                var lava = this is LavaLobsterTrap;
 
-                Effects.PlaySound(this, map, Utility.Random(0x025, 3));
-                Effects.SendMovingEffect(from, this, TrapID, 7, 0, false, false);
-            }
-        }
-
-        public void StartTimer()
-        {
-            if (m_Timer != null)
-                m_Timer.Stop();
-
-            m_Timer = Timer.DelayCall(TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1), OnTick);
-        }
-
-        public void EndTimer(Mobile from)
-        {
-            if (m_Timer != null)
-            {
-                m_Timer.Stop();
-                m_Timer = null;
-            }
-
-            if (from == null) from = m_Owner;
-            if (from == null)
-                return;
-
-            Movable = true;
-            ItemID = TrapID;
-            InvalidateProperties();
-            m_InUse = false;
-
-            if (RootParent == null)
-            {
-                if (from.Backpack == null || !from.Backpack.TryDropItem(from, this, false))
-                    MoveToWorld(from.Location, from.Map);
-            }
-        }
-
-        public void OnTick()
-        {
-            m_Bobs++;
-
-            PublicOverheadMessage(MessageType.Regular, 0, 1116364); //**bob**
-
-            if (m_Owner != null && (!SpecialFishingNet.ValidateDeepWater(Map, X, Y) || m_Owner.Skills[SkillName.Fishing].Base >= 75.0))
-            {
-                m_Owner.CheckSkill(SkillName.Fishing, 0, m_Owner.Skills[SkillName.Fishing].Cap);
-            }
-
-            if (!m_InUse)
-            {
-                EndTimer(null);
-                return;
-            }
-
-            if (m_Bobs * 5 > Utility.Random(100))
-            {
-                OnTrapLost();
-                return;
-            }
-
-            double bump = m_Bobs / 100.0;
-
-            Type type = FishInfo.GetSpecialItem(m_Owner, this, Location, bump, this is LavaLobsterTrap);
-
-            if (type != null)
-            {
-                Item item = Loot.Construct(type);
-                DropItem(item);
-
-                if (item is RareCrabAndLobster fish)
+                if (IsValidTile(from, targeted, lava))
                 {
-                    fish.Fisher = m_Owner;
-                    fish.DateCaught = DateTime.UtcNow;
-                    fish.Weight = Utility.RandomMinMax(10, 200);
-                    fish.Stackable = false;
-                }
+                    from.RevealingAction();
 
-                if (m_Owner != null)
-                    m_Owner.SendMessage("It looks like you caught something!");
+                    var mechanism = new LobsterTrapMechanism(from, BaitType, EnhancedBait);
 
-                CheckBait();
+                    if (lava)
+                    {
+                        mechanism.Hue = 2515;
+                    }
+
+                    mechanism.MoveToWorld(new Point3D(pnt.X, pnt.Y, pnt.Z), map);
+
+                    Consume();
+                }               
             }
-            else if (Utility.RandomBool())
-            {
-                Item item;
+        }        
 
-                if (Utility.RandomBool())
-                    item = new Crab();
-                else
-                    item = new Lobster();
-
-                if (m_Owner != null)
-                    m_Owner.SendMessage("It looks like you caught something!");
-
-                DropItem(item);
-                CheckBait();
-            }
-        }
-
-        private void CheckBait()
+        public virtual bool IsValidTile(Mobile from, object targeted, bool lava)
         {
-            if (m_BaitType != null)
-            {
-                BaitUses--;
+            bool iswater = false;
+            bool islava = false;
 
-                if (m_BaitUses == 0)
-                {
-                    BaitType = null;
-                    EnhancedBait = false;
-
-                    if (m_Owner != null)
-                        m_Owner.SendMessage("You have used up the bait on your lobster trap.");
-                }
-            }
-        }
-
-        public void OnTrapLost()
-        {
-            if (m_Timer != null)
-                m_Timer.Stop();
-
-            Effects.PlaySound(this, Map, Utility.Random(0x025, 3));
-
-            IPooledEnumerable eable = GetMobilesInRange(12);
-            foreach (Mobile mob in eable)
-            {
-                if (mob is PlayerMobile && m_Owner != null)
-                    mob.SendLocalizedMessage(1116385, m_Owner.Name); //~1_NAME~'s trap bouy is pulled beneath the waves.
-            }
-            eable.Free();
-
-            Delete();
-        }
-
-        private bool CanUseTrap(Mobile from)
-        {
-            if (m_Owner == null || RootParent != null)
-                return false;
-
-            if (!from.InRange(Location, 6))
-            {
-                from.SendLocalizedMessage(500295); //You are too far away to do that.
-                return false;
-            }
-
-            //is owner, or in same guild
-            if (m_Owner == from || from.Guild != null && from.Guild == m_Owner.Guild)
-                return true;
-
-            //partied
-            if (Party.Get(from) == Party.Get(m_Owner))
-                return true;
-
-            //fel rules
-            if (from.Map != null && from.Map.Rules == MapRules.FeluccaRules)
-            {
-                from.CriminalAction(true);
-                from.SendLocalizedMessage(1149823); //The owner of the lobster trap notices you committing a criminal act!
-
-                if (m_Owner != null)
-                    m_Owner.SendMessage("You notice {0} taking your lobster trap out of the water!", from.Name);
-
-                return true;
-            }
-
-            from.SendLocalizedMessage(1116391); //You realize that the trap isn't yours so you leave it alone.
-            return false;
-        }
-
-        public virtual bool IsValidTile(object targeted)
-        {
-            int tileID = 0;
+            IPoint3D pnt = (IPoint3D)targeted;
 
             if (targeted is LandTarget landTarget)
             {
-                tileID = landTarget.TileID;
+                iswater = IsNotShallowWaterLand(from.Map, pnt);
+                islava = LaveTileValidate(landTarget.TileID);
             }
-
             else if (targeted is StaticTarget staticTarget)
             {
-                tileID = staticTarget.ItemID;
+                islava = LaveTileValidate(staticTarget.ItemID);
+                iswater = IsNotShallowWaterStaticTile(from.Map, pnt);
+            }
+            else
+            {
+                from.SendLocalizedMessage(500977); // You can't reach the water there.
+                return false;
+            }            
+
+            if (!islava && iswater && lava)
+            {
+                from.SendLocalizedMessage(1149622); // You need lava to fish in!
+                return false;
             }
 
-            for (int i = 0; i < UseableTiles.Length; i++)
+            if (!iswater && islava && !lava)
             {
-                if (UseableTiles[i] == tileID)
-                    return true;
+                from.SendLocalizedMessage(500978); // You need water to fish in!
+                return false;
             }
+
+            if (!iswater && !lava || !islava && lava)
+            {
+                from.SendLocalizedMessage(1116695); // The water there is too shallow for the trap.
+                return false;
+            }
+
+            if (lava && !from.Region.IsPartOf("Abyss"))
+            {
+                islava = false;
+            }
+
+            return true;
+        }
+
+        public static bool IsNotShallowWaterStaticTile(Map map, IPoint3D pnt)
+        {
+            var tiles = Engines.Harvest.Fishing.WaterTiles;
+
+            bool water = true;
+
+            Misc.Geometry.Circle2D(new Point3D(pnt.X, pnt.Y, pnt.Z), map, 5, (p, m) =>
+            {
+                StaticTile[] stile = map.Tiles.GetStaticTiles(p.X, p.Y, false);
+
+                if (stile.Length > 0)
+                {
+                    for (var index = 0; index < stile.Length; index++)
+                    {
+                        StaticTile st = stile[index];
+
+                        if (st.Z == pnt.Z)
+                        {
+                            int id = (st.ID & 0x3FFF) | 0x4000;
+
+                            if (WaterTileValidate(id) && water)
+                            {
+                                water = true;
+                            }
+                            else
+                            {
+                                water = false;
+                            }
+                        }
+                    }
+                }
+            });
+
+            return water;
+        }
+
+        public static bool IsNotShallowWaterLand(Map map, IPoint3D pnt)
+        {
+            var tiles = Engines.Harvest.Fishing.WaterTiles;
+
+            bool water = true;
+
+            Misc.Geometry.Circle2D(new Point3D(pnt.X, pnt.Y, pnt.Z), map, 5, (p, m) =>
+            {               
+               LandTile ltile = map.Tiles.GetLandTile(p.X, p.Y);
+
+                if (WaterTileValidate(ltile.ID) && water)
+                {
+                    water = true;
+                }
+                else
+                {
+                    water = false;
+                }
+            });
+
+            return water;
+        }
+
+        public static bool WaterTileValidate(int tileID)
+        {
+            var tiles = Engines.Harvest.Fishing.WaterTiles;
+
+            bool contains = false;
+
+            for (int i = 0; !contains && i < tiles.Length; i += 2)
+                contains = tileID >= tiles[i] && tileID <= tiles[i + 1];
+
+            return contains;
+        }
+
+        public bool LaveTileValidate(int tileID)
+        {
+            var tiles = Engines.Harvest.Fishing.LavaTiles;
+
+            for (var index = 0; index < tiles.Length; index++)
+            {
+                int id = tiles[index];
+
+                if (tileID == id)
+                {
+                    return true;
+                }
+            }
+
             return false;
         }
 
@@ -412,30 +356,16 @@ namespace Server.Items
                     return false;
                 }
             }
+
             eable.Free();
+
             return true;
-        }
+        }        
 
-        public virtual int[] UseableTiles => m_WaterTiles;
-        private readonly int[] m_WaterTiles =
+        public LobsterTrap(Serial serial)
+            : base(serial)
         {
-            //Deep Water
-            0x00AA, 0x00A9,
-            0x00A8, 0x00AB,
-            0x0136, 0x0137,
-            //Shallow Water
-            0x5797, 0x579C,
-            0x746E, 0x7485,
-            0x7490, 0x74AB,
-            0x74B5, 0x75D5,
-            //Static tiles
-            0x1797, 0x1798,
-            0x1799, 0x179A,
-            0x179B, 0x179C
-
-        };
-
-        public LobsterTrap(Serial serial) : base(serial) { }
+        }
 
         public override void Serialize(GenericWriter writer)
         {
@@ -444,11 +374,17 @@ namespace Server.Items
 
             int index = FishInfo.GetIndexFromType(m_BaitType);
             writer.Write(index);
-            writer.Write(m_Bobs);
-            writer.Write(m_InUse);
-            writer.Write(m_Owner);
-            writer.Write(m_BaitUses);
             writer.Write(m_EnhancedBait);
+            writer.Write(Caught == null ? 0 : Caught.Count);
+
+            if (Caught != null)
+            {
+                for (var i = 0; i < Caught.Count; i++)
+                {
+                    var b = Caught[index];
+                    writer.Write(b.Name);
+                }
+            }
         }
 
         public override void Deserialize(GenericReader reader)
@@ -458,17 +394,307 @@ namespace Server.Items
 
             int index = reader.ReadInt();
             m_BaitType = FishInfo.GetTypeFromIndex(index);
+            m_EnhancedBait = reader.ReadBool();            
 
-            m_Bobs = reader.ReadInt();
-            m_InUse = reader.ReadBool();
-            m_Owner = reader.ReadMobile();
-            m_BaitUses = reader.ReadInt();
-            m_EnhancedBait = reader.ReadBool();
+            int count = reader.ReadInt();
 
-            if (m_BaitType != null && m_BaitUses <= 0)
-                BaitType = null;
+            if (count > 0)
+            {
+                Caught = new List<Type>();
+            }
 
-            if (m_InUse)
+            for (int i = 0; i < count; i++)
+            {
+                Type t = ScriptCompiler.FindTypeByName(reader.ReadString());
+
+                if (t != null)
+                    Caught.Add(t);
+            }
+        }
+    }
+
+    public class LobsterTrapMechanism : Item, IBaitable
+    {
+        [CommandProperty(AccessLevel.GameMaster)]
+        public Type BaitType { get; set; }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public bool EnhancedBait { get; set; }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public Mobile Owner { get; set; }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public bool InUse { get; set; }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public bool IsLava => Hue == 2515;
+
+        private List<Type> Caught;
+
+        [Constructable]
+        public LobsterTrapMechanism(Mobile owner, Type bait, bool enhanced)
+            : base(0x44CD)
+        {
+            Owner = owner;
+            BaitType = bait;
+            EnhancedBait = enhanced;
+
+            Weight = 0.0;
+            Movable = false;
+
+            Caught = new List<Type>();
+
+            StartTimer();
+        }
+
+        public override void AddNameProperty(ObjectPropertyList list)
+        {
+            if (Owner == null)
+                list.Add(1096487); // lobster trap
+            else
+                list.Add(1116390, Owner.Name);
+        }
+
+        public override void GetProperties(ObjectPropertyList list)
+        {
+            base.GetProperties(list);
+
+            if (BaitType != null)
+            {
+                object label = FishInfo.GetFishLabel(BaitType);
+
+                if (label is int i)
+                    list.Add(1116468, string.Format("#{0}", i)); // baited to attract: ~1_val~
+                else if (label is string s)
+                    list.Add(1116468, s);
+            }
+        }
+
+        public override void OnDoubleClick(Mobile from)
+        {
+            if (CanUseTrap(from))
+                EndTimer(from);
+        }
+
+        private Timer m_Timer;
+
+        public void StartTimer()
+        {
+            if (m_Timer != null)
+                m_Timer.Stop();
+
+            InUse = true;
+
+            m_Timer = Timer.DelayCall(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(3), OnTick);            
+        }
+
+        public void EndTimer(Mobile from)
+        {
+            if (m_Timer != null)
+            {
+                m_Timer.Stop();
+                m_Timer = null;
+            }
+
+            LobsterTrap trap;
+
+            if (IsLava)
+            {
+                trap = new LavaLobsterTrap();
+            }
+            else
+            {
+                trap = new LobsterTrap();
+            }             
+
+            if (Caught.Count > 0)
+            {
+                trap.Caught = Caught;
+                trap.CheckTrap();
+            };
+
+            if (from.Backpack == null || !from.Backpack.TryDropItem(from, trap, false))
+                trap.MoveToWorld(from.Location, from.Map);
+
+            Delete();
+        }
+
+        public void OnTick()
+        {
+            int random = Utility.Random(10);
+
+            switch (random)
+            {
+                default:
+                case 0: { break; }
+                case 1:
+                case 2:
+                case 4:
+                case 9:
+                    {
+                        if (Caught.Count <= 5)
+                        {
+                            GetReward(random);
+                        }
+
+                        break;
+                    }
+                case 5:
+                case 8:
+                    {
+                        if (!IsLava)
+                        {
+                            OnTrapLost();
+                        }
+
+                        break;
+                    }
+            }
+        }
+
+        public void GetReward(int value)
+        {
+            double bump = value / 100.0;
+
+            Type type = FishInfo.GetSpecialItem(Owner, this, Location, bump, IsLava);
+
+            if (type == null)
+            {
+                if (IsLava)
+                {
+                    if (Owner != null)
+                    {
+                        Owner.PrivateOverheadMessage(MessageType.Regular, 0x3B2, 503168, Owner.NetState); // The fish don't seem to be biting here.
+                    }
+                }
+                else
+                {
+                    if (Utility.RandomBool())
+                        type = typeof(Crab);
+                    else
+                        type = typeof(Lobster);
+                }
+            }
+
+            if (type != null)
+            {
+                if (Owner != null)
+                {
+                    Owner.CheckSkill(SkillName.Fishing, 0, Owner.Skills[SkillName.Fishing].Cap);
+                }
+
+                PublicOverheadMessage(MessageType.Regular, 0, 1116364); // **bob**
+
+                ItemID = 0x44CB;
+                Timer.DelayCall(TimeSpan.FromSeconds(5), () => ItemID = 0x44CC);
+
+                Caught.Add(type);
+            }
+        }
+
+        public void OnTrapLost()
+        {
+            if (m_Timer != null)
+                m_Timer.Stop();
+
+            Effects.SendPacket(Location, Map, new GraphicalEffect(EffectType.FixedXYZ, Serial.Zero, Serial.Zero, 0x352D, Location, Location, 4, 16, true, true));
+
+            IPooledEnumerable eable = GetMobilesInRange(12);
+
+            foreach (Mobile mob in eable)
+            {
+                if (mob is PlayerMobile && Owner != null)
+                    mob.SendLocalizedMessage(1116385, Owner.Name); //~1_NAME~'s trap bouy is pulled beneath the waves.
+            }
+            eable.Free();
+
+            Delete();
+        }
+
+        private bool CanUseTrap(Mobile from)
+        {
+            if (Owner == null || RootParent != null)
+                return false;
+
+            if (!from.InRange(Location, 6))
+            {
+                from.SendLocalizedMessage(500295); //You are too far away to do that.
+                return false;
+            }
+
+            //is owner, or in same guild
+            if (Owner == from || from.Guild != null && from.Guild == Owner.Guild)
+                return true;
+
+            //partied
+            if (Party.Get(from) == Party.Get(Owner))
+                return true;
+
+            //fel rules
+            if (from.Map != null && from.Map.Rules == MapRules.FeluccaRules)
+            {
+                from.CriminalAction(true);
+                from.SendLocalizedMessage(1149823); //The owner of the lobster trap notices you committing a criminal act!
+
+                return true;
+            }
+
+            from.SendLocalizedMessage(1116391); //You realize that the trap isn't yours so you leave it alone.
+            return false;
+        }
+
+        public LobsterTrapMechanism(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+
+            int index = FishInfo.GetIndexFromType(BaitType);
+            writer.Write(index);
+            writer.Write(EnhancedBait);
+            writer.Write(Owner);
+            writer.Write(InUse);
+            writer.Write(Caught == null ? 0 : Caught.Count);
+
+            if (Caught != null)
+            {
+                for (var i = 0; i < Caught.Count; i++)
+                {
+                    var b = Caught[index];
+                    writer.Write(b.Name);
+                }
+            }
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+
+            int index = reader.ReadInt();
+            BaitType = FishInfo.GetTypeFromIndex(index);
+            EnhancedBait = reader.ReadBool();
+            Owner = reader.ReadMobile();
+            InUse = reader.ReadBool();
+
+            Caught = new List<Type>();
+
+            int count = reader.ReadInt();
+
+            for (int i = 0; i < count; i++)
+            {
+                Type t = ScriptCompiler.FindTypeByName(reader.ReadString());
+
+                if (t != null)
+                    Caught.Add(t);
+            }
+
+            if (InUse)
                 StartTimer();
         }
     }


### PR DESCRIPTION
Note: The Lobster Trap has been redeveloped. Old items in saves will be deleted.

- Bait fix 
The bait can only be used once in tools.

- LobsterTrap Fix.
Lobster Trap is now more EA like - https://www.uoguide.com/Lobster_Trap
No trap is set within 5 squares of the nearest shore.
LobsterTrap is stackable

- Rare Fish, Crabs and Lobsters harvest criteria fix
- RareCrabAndLobster added information about who was caught and when.
- LavaHook Hue fix
- LavaLobsterTrap Hue fix

- Fish Pies fix like EA
- If you try to eat another pie it will replace the current pie. You cannot eat a pie if you are "full."
- Fish Pies fix.
- Fish Pies hue fix
- The effect disappears when you die.
- 0xDF Buff - Debuff package has been fixed.
