### PR TITLE
Lobster Trap Minor Edits

### DIFF
--- a/Scripts/Services/Harvest/Fishing/LobsterTrap.cs
+++ b/Scripts/Services/Harvest/Fishing/LobsterTrap.cs
@@ -113,6 +113,7 @@ namespace Server.Items
             if (Caught != null && Caught.Count > 0)
             {
                 DumpContents(from);
+                InvalidateProperties();
                 return;
             }
 
@@ -214,20 +215,20 @@ namespace Server.Items
 
         public virtual bool IsValidTile(Mobile from, object targeted, bool lava)
         {
-            bool iswater = false;
-            bool islava = false;
+            bool isWater = false;
+            bool isLava = false;
 
             IPoint3D pnt = (IPoint3D)targeted;
 
             if (targeted is LandTarget landTarget)
             {
-                iswater = IsNotShallowWaterLand(from.Map, pnt);
-                islava = LaveTileValidate(landTarget.TileID);
+                isWater = IsNotShallowWaterLand(from.Map, pnt);
+                isLava = LaveTileValidate(landTarget.TileID);
             }
             else if (targeted is StaticTarget staticTarget)
             {
-                islava = LaveTileValidate(staticTarget.ItemID);
-                iswater = IsNotShallowWaterStaticTile(from.Map, pnt);
+                isLava = LaveTileValidate(staticTarget.ItemID);
+                isWater = IsNotShallowWaterStaticTile(from.Map, pnt);
             }
             else
             {
@@ -235,19 +236,19 @@ namespace Server.Items
                 return false;
             }            
 
-            if (!islava && iswater && lava)
+            if (!isLava && isWater && lava)
             {
                 from.SendLocalizedMessage(1149622); // You need lava to fish in!
                 return false;
             }
 
-            if (!iswater && islava && !lava)
+            if (!isWater && isLava && !lava)
             {
                 from.SendLocalizedMessage(500978); // You need water to fish in!
                 return false;
             }
 
-            if (!iswater && !lava || !islava && lava || lava && !from.Region.IsPartOf("Abyss"))
+            if (!isWater && !lava || !isLava && lava || lava && !from.Region.IsPartOf("Abyss"))
             {
                 from.SendLocalizedMessage(1116695); // The water there is too shallow for the trap.
                 return false;
@@ -425,7 +426,7 @@ namespace Server.Items
 
         [Constructable]
         public LobsterTrapMechanism(Mobile owner, Type bait, bool enhanced)
-            : base(0x44CD)
+            : base(0x44CC)
         {
             Owner = owner;
             BaitType = bait;


### PR DESCRIPTION
- InvalidateProperties on Emptying of trap to force the name returning to "Empty trap"
- Correct ItemID for buoy while waiting.
- Better naming of isLava and isWater.