### PR TITLE
VendorSellBug

### DIFF
--- a/Scripts/Mobiles/NPCs/BaseVendor.cs
+++ b/Scripts/Mobiles/NPCs/BaseVendor.cs
@@ -1634,6 +1634,13 @@ namespace Server.Mobiles
                         if (ValidateBought(buyer, item))
                         {
                             totalCost += cost;
+
+                            DecayingItemSocket socket = item.GetSocket<DecayingItemSocket>();
+
+                            if (socket != null)
+                            {
+                                socket.Remove();
+                            }
                         }
                         else
                         {
@@ -2159,8 +2166,10 @@ namespace Server.Mobiles
                                 }
                                 else
                                 {
+                                    //Say("Item Added to BuyPack"); // Debug message
                                     resp.Item.SetLastMoved();
                                     cont.DropItem(resp.Item);
+                                    resp.Item.AttachSocket(new DecayingItemSocket(300, true));
                                 }
                             }
                         }


### PR DESCRIPTION
When selling items to an NPC they simply go into the BuyPack to allow them to be "re purchased" by other players. The problem is this BuyPack with items sold NEVER decay. They stay in that bag. If that bag becomes full of hundreds of items when players go to vendor buy it will freeze / cause a delay on their end while all those items are loaded.

On EA I noticed that when I sold a random item, about 10 minutes later that item was no longer there. I am guessing they do a sort of clean up.

Now there are still a few issues:

One if the item decays while waiting to be bought, the client will crash. Second is the displaying of time left.
![Sockets](https://user-images.githubusercontent.com/20760229/145473544-fdc8a5b4-a2cd-4ec3-8df6-7f15d0f55042.png)


Here I simply add a Decaying Item Socket to non-resource/stacking items when sold and another check to remove them when purchased. This is not intended for a production shard but more to showcase one way we could potentially fix this issue.