### PR TITLE
Movement targetting

### DIFF
--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -4533,7 +4533,12 @@ namespace Server.Mobiles
                     }
                 }
             }
-            else if (ReacquireOnMovement)
+            else if (ReacquireOnMovement &&
+                Combatant == null
+                && !m.Hidden
+                && m.Alive
+                && (m is PlayerMobile || (m is BaseCreature bc && (bc.Controlled || bc.Summoned)))
+                && InLOS(m))
             {
                 ForceReacquire();
             }

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -4537,7 +4537,7 @@ namespace Server.Mobiles
                 Combatant == null
                 && !m.Hidden
                 && m.Alive
-                && (m is PlayerMobile || (m is BaseCreature bc && (bc.Controlled || bc.Summoned)))
+                && (m.IsPlayer() || (m is BaseCreature bc && (bc.Controlled || bc.Summoned)))
                 && InLOS(m))
             {
                 ForceReacquire();

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -4537,7 +4537,7 @@ namespace Server.Mobiles
                 Combatant == null
                 && !m.Hidden
                 && m.Alive
-                && (m.IsPlayer() || (m is BaseCreature bc && (bc.Controlled || bc.Summoned)))
+                && ((m.IsPlayer() && m is PlayerMobile) || (m is BaseCreature bc && (bc.Controlled || bc.Summoned)))
                 && InLOS(m))
             {
                 ForceReacquire();

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -4537,10 +4537,16 @@ namespace Server.Mobiles
                 Combatant == null
                 && !m.Hidden
                 && m.Alive
-                && ((m.IsPlayer() && m is PlayerMobile) || (m is BaseCreature bc && (bc.Controlled || bc.Summoned)))
+               && ((m.IsPlayer() && m is PlayerMobile) || (m is BaseCreature bc && (bc.Controlled || bc.Summoned)))
                 && InLOS(m))
             {
-                ForceReacquire();
+                Direction targetDirection = this.GetDirectionTo(m);
+
+                if ((this.Direction & targetDirection) == targetDirection && m.InRange(this.Location, 4))
+                {
+                    ForceReacquire();
+                }
+
             }
 
             SpecialAbility.CheckApproachTrigger(this, m, oldLocation);


### PR DESCRIPTION
Started looking at how dragons target after taking my bard to Belfly. They all seem too aggressive, so I put display messages in BaseCreature and discovered this:
* As its always been dragons should target a creature when they see it move. But in the OnMovementMethod no checks are made against the mobile type or details. It just forces a ForceReaquire() on the dragon every time a mobile moves near it. This function then checks if the dragon can target anything in the area and resets its target timer.
If there are 2 dragons and 1 player, and dragon 1 moves then dragon 2 will instantly target the player because there was movement. It will then target and attack every time one of the mobiles takes a step.
If you are at Belfry and have 8 dragons then every dragon will try to target you every time one of the dragons steps.

Solution: 
* If a dragon has a target then it doesn't need to check for a target every time something moves
* If a mobile is Dead and moves, then a dragon shouldn't be trying to target everything
* If a mobile is Hiding/Stealth, then a dragon shouldn't be trying to target everything
* A dragon should only be trying to attack a Player or a Player controlled creature when they move
* The target should be in LOS of the dragon for it to see it move

When testing this against 50 dragons, every time one of the dragons took a step all the dragons would look for a target. If they all targeted a Player at once, they would all travel to the player triggering another 50 checks for each movement the creatures made. If they all move 10 spaces then its 550 calls in total.
When retesting with the fix of this change the initial movement of the player triggers the target check, down to 50 calls only. CPU usage in VS went down from 25% across all 4 cores to between 10-15% during the dragons existence (similar to standard CPU when the server is running for me).
![image](https://user-images.githubusercontent.com/37800482/154166351-284222a7-3a25-4a68-b7c9-4ec51a081aec.png)

More importantly, now if a bard is hidden and reveals himself to provoke 2 dragons he doesn't have every other dragon on the screen instantly target him when he hasn't actually taken a step. I still need to check how dragon targeting works on OSI and will update.

__________________________

Update:
Dragons on OSI do no longer target based on movement. I've kept some functionality, so it will now only attack if you are within 4 tiles of the direction it is facing.