### PR TITLE
Additional pet control fixes

### DIFF
--- a/Scripts/Mobiles/AI/BaseAI.cs
+++ b/Scripts/Mobiles/AI/BaseAI.cs
@@ -1890,7 +1890,7 @@ namespace Server.Mobiles
             m_Mobile.DebugSay("My master told me to stop.");
 
             //Stay for 30 seconds
-            if (m_Mobile.StopDuration == null || DateTime.Now > m_Mobile.StopDuration)
+            if (DateTime.Now > m_Mobile.StopDuration)
             {
                 m_Mobile.PetAction = PetActionType.NoAction;
                 m_Mobile.MovementMode = MovementType.Roam;

--- a/Scripts/Mobiles/AI/BaseAI.cs
+++ b/Scripts/Mobiles/AI/BaseAI.cs
@@ -1614,7 +1614,7 @@ namespace Server.Mobiles
 
         public virtual bool DoOrderGuard()
         {
-            if (m_Mobile.GuardMode != GuardType.Active || m_Mobile.IsDeadPet)
+            if (m_Mobile.GuardMode != GuardType.Active || m_Mobile.IsDeadPet || m_Mobile.PetAction == PetActionType.Come)
             {
                 return false;
             }

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -257,6 +257,8 @@ namespace Server.Mobiles
             }
         }
 
+        public override int HearRange => 24;
+
         [CommandProperty(AccessLevel.GameMaster)]
         public bool CanMove { get; set; }
 
@@ -3219,6 +3221,8 @@ namespace Server.Mobiles
                 }
             }
         }
+        [CommandProperty(AccessLevel.GameMaster)]
+        public DateTime StopDuration{ get; set; }
 
         [CommandProperty(AccessLevel.GameMaster)]
         public Point3D Home { get => m_pHome; set => m_pHome = value; }
@@ -4377,18 +4381,19 @@ namespace Server.Mobiles
                 return true;
             }
 
-            return m_AI != null && m_AI.HandlesOnSpeech(from) && from.InRange(this, m_iRangePerception);
+            return m_AI != null && m_AI.HandlesOnSpeech(from);
         }
 
         public override void OnSpeech(SpeechEventArgs e)
         {
             InhumanSpeech speechType = SpeechType;
 
+            int speechRange = ControlMaster == e.Mobile || IsPetFriend(e.Mobile) ? HearRange : m_iRangePerception;
             if (speechType != null && speechType.OnSpeech(this, e.Mobile, e.Speech))
             {
                 e.Handled = true;
             }
-            else if (!e.Handled && m_AI != null && e.Mobile.InRange(this, m_iRangePerception))
+            else if (!e.Handled && m_AI != null && e.Mobile.InRange(this, speechRange))
             {
                 m_AI.OnSpeech(e);
             }

--- a/Server/Mobile.cs
+++ b/Server/Mobile.cs
@@ -4774,7 +4774,7 @@ namespace Server
 
 				foreach (IEntity o in eable)
 				{
-					if (o is Mobile heard && heard.InRange(this, heard.HearRange))
+					if (o is Mobile heard && heard.InRange(this, Math.Max(heard.HearRange, range)))
                     {
                         if (heard.CanSee(this) && (m_NoSpeechLOS || !heard.Player || heard.InLOS(this)))
 						{

--- a/Server/Mobile.cs
+++ b/Server/Mobile.cs
@@ -1434,6 +1434,8 @@ namespace Server
         [CommandProperty(AccessLevel.Decorator)]
         public int BAC { get => m_BAC; set => m_BAC = value; }
 
+        public virtual int HearRange => 15;
+
         public virtual int DefaultBloodHue => 0;
 
         public virtual bool HasBlood => Alive && BloodHue >= 0 && !Body.IsGhost && !Body.IsEquipment;
@@ -4768,15 +4770,15 @@ namespace Server
 
 			if (m_Map != null)
 			{
-				IPooledEnumerable<IEntity> eable = m_Map.GetObjectsInRange(m_Location, range);
+				IPooledEnumerable<IEntity> eable = m_Map.GetObjectsInRange(m_Location, 24);
 
 				foreach (IEntity o in eable)
 				{
-					if (o is Mobile heard)
-					{
+					if (o is Mobile heard && heard.InRange(this, heard.HearRange))
+                    {
                         if (heard.CanSee(this) && (m_NoSpeechLOS || !heard.Player || heard.InLOS(this)))
 						{
-							if (heard.m_NetState != null)
+							if (heard.m_NetState != null && heard.InRange(this, range))
 							{
 								hears.Add(heard);
 							}


### PR DESCRIPTION
All changes have been tested and compared against against the OSI server
* Pets home location is now set to the Control masters location when using Come command
* Using the Stop command will make the pet stand still for 30 seconds before roaming
* Pets can accept spoken commands upto 24 tiles 
* Speech types whisper (1) /normal(15)/yell(18) distances should only affect players for ingame chat and not commands.
 (Whisper will now work at more than 1 tile distance for pets, but players cant hear the commands unless they are within 1 tile from the speaking player)
