### PR TITLE
Pet Command balance and fixes

### DIFF
--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -295,6 +295,8 @@ namespace Server.Mobiles
         private bool m_bControlled; // Is controlled
         private Mobile m_ControlMaster; // My master
         private IDamageable m_ControlTarget; // My target mobile
+        private Mobile m_FollowTarget; // Who i'm following
+
         private Point3D m_ControlDest; // My target destination (patrol)
         private LastOrderType m_ControlOrder; // My order
         private PetActionType m_PetAction; // My control protector
@@ -3447,6 +3449,9 @@ namespace Server.Mobiles
 
         [CommandProperty(AccessLevel.GameMaster)]
         public IDamageable ControlTarget { get => m_ControlTarget; set => m_ControlTarget = value; }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public Mobile FollowTarget { get => m_FollowTarget; set => m_FollowTarget = value; }
 
         [CommandProperty(AccessLevel.GameMaster)]
         public Point3D ControlDest { get => m_ControlDest; set => m_ControlDest = value; }


### PR DESCRIPTION
* When a pet is following and guarding pets will not wander off the screen for a fight and keep fighting everything away from the player. Guarding the master is priority. This is based on the HearRange the command distance is based off.

* Pets and summons will no longer attack the Controller
 This was caused by the ControlTarget being set in Follow, but Guard keeps war active and the default attack logic was applying the ControlTarget as a default target to the pet. Adding the pet into the players Aggressors. This then causes other pets to attack the first pet and they all go grey. Now Follow has a new FollowTarget, so it doesnt interfere with attack logic.

* Follow will disable guard mode, so pets come back when asked
  So players can hunt with the standard Follow/Guard commands they are used to. (because OSI never invented "Stop Guarding"