### PR TITLE
Pet Change Fixes

### DIFF
--- a/Scripts/Items/Addons/DungeonHitchingPost.cs
+++ b/Scripts/Items/Addons/DungeonHitchingPost.cs
@@ -223,7 +223,7 @@ namespace Server.Items
                         if (pet.Summoned)
                             pet.SummonMaster = from;
 
-                        pet.ControlTarget = from;
+                        pet.FollowTarget = from;
                         pet.ControlOrder = LastOrderType.Follow;
 
                         pet.MoveToWorld(from.Location, from.Map);
@@ -297,7 +297,7 @@ namespace Server.Items
                 if (pet.Summoned)
                     pet.SummonMaster = from;
 
-                pet.ControlTarget = from;
+                pet.FollowTarget = from;
                 pet.ControlOrder = LastOrderType.Follow;
 
                 pet.MoveToWorld(from.Location, from.Map);

--- a/Scripts/Items/Addons/HitchingPost.cs
+++ b/Scripts/Items/Addons/HitchingPost.cs
@@ -241,7 +241,7 @@ namespace Server.Items
                 if (pet.Summoned)
                     pet.SummonMaster = from;
 
-                pet.ControlTarget = from;
+                pet.FollowTarget = from;
                 pet.ControlOrder = LastOrderType.Follow;
 
                 pet.MoveToWorld(from.Location, from.Map);
@@ -406,7 +406,7 @@ namespace Server.Items
                         if (pet.Summoned)
                             pet.SummonMaster = from;
 
-                        pet.ControlTarget = from;
+                        pet.FollowTarget = from;
                         pet.ControlOrder = LastOrderType.Follow;
 
                         pet.MoveToWorld(from.Location, from.Map);

--- a/Scripts/Items/Consumables/PersonalAttendantDeed.cs
+++ b/Scripts/Items/Consumables/PersonalAttendantDeed.cs
@@ -164,7 +164,7 @@ namespace Server.Items
                     attendant.BindedToPlayer = m_Deed.Owner != null;
                     attendant.SetControlMaster(m);
                     attendant.ControlOrder = LastOrderType.Follow;
-                    attendant.ControlTarget = m;
+                    attendant.FollowTarget = m;
                     attendant.MoveToWorld(m.Location, m.Map);
 
                     m_Deed.Delete();

--- a/Scripts/Items/Functional/ChickenCoop.cs
+++ b/Scripts/Items/Functional/ChickenCoop.cs
@@ -202,7 +202,7 @@ namespace Server.Items
                 if (pet.Summoned)
                     pet.SummonMaster = from;
 
-                pet.ControlTarget = from;
+                pet.FollowTarget = from;
                 pet.ControlOrder = LastOrderType.Follow;
 
                 pet.MoveToWorld(from.Location, from.Map);

--- a/Scripts/Items/Quest/WispOrb.cs
+++ b/Scripts/Items/Quest/WispOrb.cs
@@ -366,7 +366,7 @@ namespace Server.Engines.Despise
                             creature.Link(m_Orb);
 
                             m_Orb.Pet.SetControlMaster(from);
-                            m_Orb.Pet.ControlTarget = from;
+                            m_Orb.Pet.FollowTarget = from;
                             m_Orb.Pet.ControlOrder = LastOrderType.Follow;
 
                             from.SendLocalizedMessage(1153276); // Your Wisp Orb takes control of the creature!
@@ -440,7 +440,7 @@ namespace Server.Engines.Despise
                 Anchor = m;
                 from.SendLocalizedMessage(1153280, m == m_Owner ? "You!" : m.Name + ".");
 
-                m_Pet.ControlTarget = m;
+                m_Pet.FollowTarget = m;
                 m_Pet.ControlOrder = LastOrderType.Follow;
             }
 
@@ -455,7 +455,7 @@ namespace Server.Engines.Despise
                 else if (name is string stringName)
                     from.SendLocalizedMessage(1153280, stringName);
 
-                m_Pet.ControlTarget = m_Pet.ControlMaster;
+                m_Pet.FollowTarget = m_Pet.ControlMaster;
                 m_Pet.ControlOrder = LastOrderType.Follow;
             }
         }

--- a/Scripts/Items/StoreBought/PetCastle.cs
+++ b/Scripts/Items/StoreBought/PetCastle.cs
@@ -349,7 +349,7 @@ namespace Server.Items
                         if (pet.Summoned)
                             pet.SummonMaster = from;
 
-                        pet.ControlTarget = from;
+                        pet.FollowTarget = from;
                         pet.ControlOrder = LastOrderType.Follow;
 
                         pet.MoveToWorld(from.Location, from.Map);
@@ -425,7 +425,7 @@ namespace Server.Items
                 if (pet.Summoned)
                     pet.SummonMaster = from;
 
-                pet.ControlTarget = from;
+                pet.FollowTarget = from;
                 pet.ControlOrder = LastOrderType.Follow;
 
                 pet.MoveToWorld(from.Location, from.Map);

--- a/Scripts/Items/Tools/BallOfSummoning.cs
+++ b/Scripts/Items/Tools/BallOfSummoning.cs
@@ -211,7 +211,7 @@ namespace Server.Items
                 if (pet.Summoned)
                     pet.SummonMaster = from;
 
-                pet.ControlTarget = from;
+                pet.FollowTarget = from;
                 pet.ControlOrder = LastOrderType.Follow;
 
                 pet.IsStabled = false;

--- a/Scripts/Mobiles/NPCs/AnimalTrainer.cs
+++ b/Scripts/Mobiles/NPCs/AnimalTrainer.cs
@@ -430,7 +430,7 @@ namespace Server.Mobiles
                 pet.SummonMaster = from;
             }
 
-            pet.ControlTarget = from;
+            pet.FollowTarget = from;
             pet.ControlOrder = LastOrderType.Follow;
 
             pet.MoveToWorld(from.Location, from.Map);

--- a/Scripts/Mobiles/NPCs/PersonalAttendant/AttendantHerald.cs
+++ b/Scripts/Mobiles/NPCs/PersonalAttendant/AttendantHerald.cs
@@ -452,7 +452,7 @@ namespace Server.Mobiles
                             if (m_Herald.MovementMode == MovementType.Stay)
                             {
                                 m_Herald.ControlOrder = LastOrderType.Follow;
-                                m_Herald.ControlTarget = m;
+                                m_Herald.FollowTarget = m;
                             }
 
                             break;

--- a/Scripts/Mobiles/NPCs/PersonalAttendant/PersonalAttendant.cs
+++ b/Scripts/Mobiles/NPCs/PersonalAttendant/PersonalAttendant.cs
@@ -73,7 +73,7 @@ namespace Server.Mobiles
         public virtual void CommandFollow(Mobile by)
         {
             ControlOrder = LastOrderType.Follow;
-            ControlTarget = by;
+            FollowTarget = by;
 
             if (m_Timer != null)
             {
@@ -199,7 +199,7 @@ namespace Server.Mobiles
                 if (m_Attendant != null && !m_Attendant.Deleted)
                 {
                     m_Attendant.ControlOrder = LastOrderType.Follow;
-                    m_Attendant.ControlTarget = m_Attendant.ControlMaster;
+                    m_Attendant.FollowTarget = m_Attendant.ControlMaster;
 
                     if (obj is Point3D point3D && m_Attendant.ControlMaster != null)
                     {

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -5698,9 +5698,11 @@ namespace Server.Mobiles
                 Mana = 0;
 
                 IsDeadPet = true;
-                ControlTarget = ControlMaster;
+                ControlTarget = null;
+                FollowTarget = ControlMaster;
                 ControlOrder = LastOrderType.Follow;
                 GuardMode = GuardType.Passive;
+                PetAction = PetActionType.NoAction;
 
                 ProcessDeltaQueue();
                 SendIncomingPacket();

--- a/Scripts/Services/City Loyalty System/Mobiles/Raider.cs
+++ b/Scripts/Services/City Loyalty System/Mobiles/Raider.cs
@@ -101,7 +101,7 @@ namespace Server.Mobiles
 
                 SetControlMaster(m);
                 IsBonded = false;
-                ControlTarget = m;
+                FollowTarget = m;
                 ControlOrder = LastOrderType.Follow;
 
                 m.SendLocalizedMessage(1152236, Name); // You arrest the ~1_name~. Take the criminal to the guard captain.

--- a/Scripts/Services/Dungeons/DespiseRevamped/AI.cs
+++ b/Scripts/Services/Dungeons/DespiseRevamped/AI.cs
@@ -119,7 +119,7 @@ namespace Server.Engines.Despise
                     m_Creature.ControlOrder = LastOrderType.Follow;
                 }
 
-                m_Creature.ControlTarget = m_Creature.ControlMaster;
+                m_Creature.FollowTarget = m_Creature.ControlMaster;
                 Action = ActionType.Guard;
                 DoOrderFollow();
             }
@@ -349,7 +349,7 @@ namespace Server.Engines.Despise
                     m_Creature.ControlOrder = LastOrderType.Follow;
                 }
 
-                m_Creature.ControlTarget = m_Creature.ControlMaster;
+                m_Creature.FollowTarget = m_Creature.ControlMaster;
                 Action = ActionType.Guard;
                 DoOrderFollow();
             }

--- a/Scripts/Services/Dungeons/DespiseRevamped/DespiseController.cs
+++ b/Scripts/Services/Dungeons/DespiseRevamped/DespiseController.cs
@@ -510,7 +510,7 @@ namespace Server.Engines.Despise
 
                             m.SendLocalizedMessage(1153280, "You!");
                             orb.Anchor = m;
-                            orb.Pet.ControlTarget = m;
+                            orb.Pet.FollowTarget = m;
                             orb.Pet.ControlOrder = LastOrderType.Follow;
                         }
                     }

--- a/Scripts/Services/MondainsLegacyQuests/BaseEscort.cs
+++ b/Scripts/Services/MondainsLegacyQuests/BaseEscort.cs
@@ -143,7 +143,7 @@ namespace Server.Engines.Quests
             PassiveSpeed = 0.2;
 
             ControlOrder = LastOrderType.Follow;
-            ControlTarget = escorter;
+            FollowTarget = escorter;
 
             CurrentSpeed = 0.1;
         }
@@ -154,7 +154,7 @@ namespace Server.Engines.Quests
             PassiveSpeed = 1.0;
 
             ControlOrder = LastOrderType.None;
-            ControlTarget = null;
+            FollowTarget = null;
 
             CurrentSpeed = 1.0;
 

--- a/Scripts/Services/New Magincia/Magincia Bazaar/Gumps/PetBrokerGumps.cs
+++ b/Scripts/Services/New Magincia/Magincia Bazaar/Gumps/PetBrokerGumps.cs
@@ -592,7 +592,7 @@ namespace Server.Engines.NewMagincia
 
                         pet.Blessed = true;
                         pet.SetControlMaster(m_Broker);
-                        pet.ControlTarget = m_Broker;
+                        pet.FollowTarget = m_Broker;
                         pet.ControlOrder = LastOrderType.None;
                         pet.MoveToWorld(m_Broker.Location, m_Broker.Map);
                         pet.IsStabled = false;

--- a/Scripts/Spells/Ninjitsu/MirrorImage.cs
+++ b/Scripts/Spells/Ninjitsu/MirrorImage.cs
@@ -195,7 +195,7 @@ namespace Server.Mobiles
             SummonMaster = caster;
 
             ControlOrder = LastOrderType.Follow;
-            ControlTarget = caster;
+            FollowTarget = caster;
 
             TimeSpan duration = TimeSpan.FromSeconds(30 + caster.Skills.Ninjitsu.Fixed / 40);
 

--- a/Scripts/Spells/Spellweaving/DryadAllure.cs
+++ b/Scripts/Spells/Spellweaving/DryadAllure.cs
@@ -101,7 +101,7 @@ namespace Server.Spells.Spellweaving
                 else
                 {
                     bc.PlaySound(0x5C5);
-                    bc.ControlTarget = Caster;
+                    bc.FollowTarget = Caster;
                     bc.ControlOrder = LastOrderType.Attack;
                     bc.Combatant = Caster;
 


### PR DESCRIPTION
* Using Pet Attack on a target, then Guarding and targetting a distant mob caused pets to go grey. This is because of the ControlTarget is set to master after battle in DoOrderAttack, and the AquireTarget method assigns ControlTarget to the focused mob.

* Fix various follow commands to use FollowTarget instead of ControlTarget
* Pets will set a new Home location if the current home is more than 2 screens away