### PR TITLE
BugFixes

### DIFF
--- a/Scripts/Items/Addons/TheKingsCollection/FirePainting.cs
+++ b/Scripts/Items/Addons/TheKingsCollection/FirePainting.cs
@@ -65,7 +65,7 @@ namespace Server.Items
             }
         }
 
-        public override BaseAddonDeed Deed => new FirePaintingDeed();
+        public override BaseAddonDeed Deed => new FirePaintingDeed(m_ResourceCount);
 
         public override void GetProperties(ObjectPropertyList list, AddonComponent c)
         {
@@ -97,7 +97,7 @@ namespace Server.Items
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-            int version = reader.ReadInt();
+            reader.ReadInt();
 
             m_ResourceCount = reader.ReadInt();
             NextResourceCount = reader.ReadDateTime();
@@ -106,19 +106,47 @@ namespace Server.Items
 
     public class FirePaintingDeed : BaseAddonDeed, IRewardOption
     {
+        private int m_ResourceCount;
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public int ResourceCount
+        {
+            get => m_ResourceCount;
+            set
+            {
+                m_ResourceCount = value;
+                InvalidateProperties();
+            }
+        }
+
         public override int LabelNumber => 1154182;  // Fire Painting
 
         private DirectionType _Direction;
 
         [Constructable]
         public FirePaintingDeed()
+            : this(0)
+        {
+        }
+
+        [Constructable]
+        public FirePaintingDeed(int resCount)
         {
             LootType = LootType.Blessed;
+
+            ResourceCount = resCount;
         }
 
         public FirePaintingDeed(Serial serial)
             : base(serial)
         {
+        }
+
+        public override void GetProperties(ObjectPropertyList list)
+        {
+            base.GetProperties(list);
+
+            list.Add(1154179, ResourceCount.ToString()); // Scrolls of Transcendence: ~1_COUNT~
         }
 
         public override void OnDoubleClick(Mobile from)
@@ -145,21 +173,35 @@ namespace Server.Items
             _Direction = (DirectionType)choice;
 
             if (!Deleted)
+            {
                 base.OnDoubleClick(from);
+            }
         }
 
-        public override BaseAddon Addon => new FirePaintingAddon(_Direction);
+        public override BaseAddon Addon =>
+            new FirePaintingAddon(_Direction, m_ResourceCount, DateTime.UtcNow + TimeSpan.FromDays(7));
 
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-            writer.Write(0);
+            writer.Write(1);
+
+            writer.Write(m_ResourceCount);
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
             int version = reader.ReadInt();
+
+            switch (version)
+            {
+                case 1:
+                    m_ResourceCount = reader.ReadInt();
+                    break;
+                case 0:
+                    break;
+            }
         }
     }
 }

--- a/Scripts/Items/Addons/TheKingsCollection/ShipPainting.cs
+++ b/Scripts/Items/Addons/TheKingsCollection/ShipPainting.cs
@@ -97,7 +97,7 @@ namespace Server.Items
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-            int version = reader.ReadInt();
+            reader.ReadInt();
 
             m_ResourceCount = reader.ReadInt();
             NextResourceCount = reader.ReadDateTime();
@@ -173,18 +173,13 @@ namespace Server.Items
             _Direction = (DirectionType)choice;
 
             if (!Deleted)
-                base.OnDoubleClick(from);
-        }
-
-        public override BaseAddon Addon
-        {
-            get
             {
-                ShipPaintingAddon addon = new ShipPaintingAddon(_Direction, m_ResourceCount, DateTime.UtcNow + TimeSpan.FromDays(7));
-
-                return addon;
+                base.OnDoubleClick(from);
             }
         }
+
+        public override BaseAddon Addon =>
+            new ShipPaintingAddon(_Direction, m_ResourceCount, DateTime.UtcNow + TimeSpan.FromDays(7));
 
         public override void Serialize(GenericWriter writer)
         {

--- a/Scripts/Services/Plants/Raised Garden Beds/RaisedGarden.cs
+++ b/Scripts/Services/Plants/Raised Garden Beds/RaisedGarden.cs
@@ -85,6 +85,21 @@ namespace Server.Items
             base.OnChop(from);
         }
 
+        public override void OnDelete() // Used when a house with an active GardenBed decays orphaning the PlantItem(s).
+        {
+            for (var index = 0; index < Components.Count; index++)
+            {
+                AddonComponent comp = Components[index];
+
+                if (comp is GardenAddonComponent component && component.Plant != null)
+                {
+                    component.Plant.Delete();
+                }
+            }
+
+            base.OnDelete();
+        }
+
         public RaisedGardenAddon(Serial serial)
             : base(serial)
         {

--- a/Scripts/Services/Seasonal Events/ArtisanFestival/Items/SpecialGift.cs
+++ b/Scripts/Services/Seasonal Events/ArtisanFestival/Items/SpecialGift.cs
@@ -27,21 +27,6 @@ namespace Server.Engines.ArtisanFestival
             list.Add(1157163, _Owner != null ? _Owner.Name : "Somebody"); // A Special Gift for ~1_NAME~ 
         }
 
-        public override void OnDoubleClick(Mobile from)
-        {
-            if (from is PlayerMobile pm && from.InRange(GetWorldLocation(), 3))
-            {
-                if (_Owner == null || pm == _Owner)
-                {
-                    base.OnDoubleClick(pm);
-                }
-                else
-                {
-                    pm.SendLocalizedMessage(1157162); // That's not your gift!
-                }
-            }
-        }
-
         private Item RandomGift(Mobile m)
         {
             switch (Utility.Random(4))

--- a/Scripts/Spells/Spellweaving/ArcaneCircle.cs
+++ b/Scripts/Spells/Spellweaving/ArcaneCircle.cs
@@ -34,7 +34,7 @@ namespace Server.Spells.Spellweaving
                 return false;
             }
 
-            if (GetArcanists().Count < 2)
+            if (GetArcanists().Count < 2 || Caster.Skills.CurrentMastery == SkillName.Spellweaving)
             {
                 Caster.SendLocalizedMessage(1080452); //There are not enough spellweavers present to create an Arcane Focus.
                 return false;

--- a/Scripts/Spells/Spellweaving/ArcaneCircle.cs
+++ b/Scripts/Spells/Spellweaving/ArcaneCircle.cs
@@ -34,7 +34,7 @@ namespace Server.Spells.Spellweaving
                 return false;
             }
 
-            if (GetArcanists().Count < 2 || Caster.Skills.CurrentMastery == SkillName.Spellweaving)
+            if (GetArcanists().Count < 2 || Caster.Skills.CurrentMastery != SkillName.Spellweaving)
             {
                 Caster.SendLocalizedMessage(1080452); //There are not enough spellweavers present to create an Arcane Focus.
                 return false;


### PR DESCRIPTION
- If a Garden Bed with plants in an IDOC house re-deeds the PlantItems are orphaned and unmovable. This ensures they delete when the GardenBedAddon is deleted on house decay.

- Should now be able to cast arcane circle by yourself if your current skill mastery is set to Spellweaving.

- Ship Paintings will now keep their charges when deeded.