### PR TITLE
CannonBallFix1

### DIFF
--- a/Scripts/Multis/Boats/Cannons and Ammo/AmmoInfo.cs
+++ b/Scripts/Multis/Boats/Cannons and Ammo/AmmoInfo.cs
@@ -23,11 +23,11 @@ namespace Server.Items
 
         public static void Initialize()
         {
-            Infos[typeof(Cannonball)] = new AmmoInfo(typeof(HeavyCannonball), AmmunitionType.Cannonball, 1095804, 5000, 5000, 3);
+            Infos[typeof(Cannonball)] = new AmmoInfo(typeof(Cannonball), AmmunitionType.Cannonball, 1095804, 5000, 5000, 3);
             Infos[typeof(Grapeshot)] = new AmmoInfo(typeof(Grapeshot), AmmunitionType.Grapeshot, 1095741, 100, 150, 3);
 
-            Infos[typeof(FlameCannonball)] = new AmmoInfo(typeof(HeavyFlameCannonball), AmmunitionType.FlameCannonball, 1149633, 5000, 5000, 3, true, 50, 50, 0, 0, 0, false);
-            Infos[typeof(FrostCannonball)] = new AmmoInfo(typeof(HeavyFrostCannonball), AmmunitionType.FrostCannonball, 1149634, 30, 50, 3, true, 50, 0, 50, 0, 0, false);
+            Infos[typeof(FlameCannonball)] = new AmmoInfo(typeof(FlameCannonball), AmmunitionType.FlameCannonball, 1149633, 5000, 5000, 3, true, 50, 50, 0, 0, 0, false);
+            Infos[typeof(FrostCannonball)] = new AmmoInfo(typeof(FrostCannonball), AmmunitionType.FrostCannonball, 1149634, 30, 50, 3, true, 50, 0, 50, 0, 0, false);
         }
 
         public Type Type { get; }

--- a/Scripts/Multis/Boats/Cannons and Ammo/CannonBall.cs
+++ b/Scripts/Multis/Boats/Cannons and Ammo/CannonBall.cs
@@ -1,6 +1,6 @@
 namespace Server.Items
 {
-    public class Cannonball : Item, ICommodity, ICannonAmmo
+    public class BaseCannonball : Item, ICommodity, ICannonAmmo
     {
         public override int LabelNumber => 1116266; // cannonball
         public override double DefaultWeight => 1.0;
@@ -9,6 +9,40 @@ namespace Server.Items
         bool ICommodity.IsDeedable => true;
 
         public virtual AmmunitionType AmmoType => AmmunitionType.Cannonball;
+
+        [Constructable]
+        public BaseCannonball(int itemID)
+            : this(1, itemID)
+        {
+        }
+
+        [Constructable]
+        public BaseCannonball(int amount, int itemid)
+            : base(itemid)
+        {
+            Stackable = true;
+            Amount = amount;
+        }
+
+        public BaseCannonball(Serial serial) : base(serial) { }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+        }
+    }
+
+    public class Cannonball : BaseCannonball, ICommodity
+    {
+        TextDefinition ICommodity.Description => LabelNumber;
+        bool ICommodity.IsDeedable => true;
 
         [Constructable]
         public Cannonball() : this(1)
@@ -43,7 +77,7 @@ namespace Server.Items
         }
     }
 
-    public class FrostCannonball : Cannonball, ICommodity
+    public class FrostCannonball : BaseCannonball, ICommodity
     {
         public override int LabelNumber => 1116762; // frost cannonball
 
@@ -85,7 +119,7 @@ namespace Server.Items
         }
     }
 
-    public class FlameCannonball : Cannonball, ICommodity
+    public class FlameCannonball : BaseCannonball, ICommodity
     {
         public override int LabelNumber => 1116759; // flame cannonball
 

--- a/Scripts/Multis/Boats/Cannons and Ammo/CannonBall.cs
+++ b/Scripts/Multis/Boats/Cannons and Ammo/CannonBall.cs
@@ -2,7 +2,7 @@ namespace Server.Items
 {
     public class Cannonball : Item, ICommodity, ICannonAmmo
     {
-        public override int LabelNumber => 1116266;
+        public override int LabelNumber => 1116266; // cannonball
         public override double DefaultWeight => 1.0;
 
         TextDefinition ICommodity.Description => LabelNumber;
@@ -45,7 +45,7 @@ namespace Server.Items
 
     public class FrostCannonball : Cannonball, ICommodity
     {
-        public override int LabelNumber => 1116267;
+        public override int LabelNumber => 1116762; // frost cannonball
 
         TextDefinition ICommodity.Description => LabelNumber;
         bool ICommodity.IsDeedable => true;
@@ -87,7 +87,7 @@ namespace Server.Items
 
     public class FlameCannonball : Cannonball, ICommodity
     {
-        public override int LabelNumber => 1116759;
+        public override int LabelNumber => 1116759; // flame cannonball
 
         TextDefinition ICommodity.Description => LabelNumber;
         bool ICommodity.IsDeedable => true;
@@ -124,244 +124,6 @@ namespace Server.Items
         {
             base.Deserialize(reader);
             reader.ReadInt();
-        }
-    }
-
-    public class LightCannonball : Item, ICommodity, ICannonAmmo
-    {
-        public override int LabelNumber => 1116266;
-        public override double DefaultWeight => 1.0;
-
-        TextDefinition ICommodity.Description => LabelNumber;
-        bool ICommodity.IsDeedable => true;
-
-        public virtual AmmunitionType AmmoType => AmmunitionType.Cannonball;
-
-        [Constructable]
-        public LightCannonball() : this(1)
-        {
-        }
-
-        [Constructable]
-        public LightCannonball(int amount) : this(amount, 16932)
-        {
-        }
-
-        [Constructable]
-        public LightCannonball(int amount, int itemid)
-            : base(itemid)
-        {
-            Stackable = true;
-            Amount = amount;
-        }
-
-        public LightCannonball(Serial serial) : base(serial) { }
-
-        public override void Serialize(GenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(GenericReader reader)
-        {
-            base.Deserialize(reader);
-            reader.ReadInt();
-
-            Replacer.Replace(this, new Cannonball());
-        }
-    }
-
-    public class HeavyCannonball : Item, ICommodity, ICannonAmmo
-    {
-        public override int LabelNumber => 1116267;
-        public override double DefaultWeight => 1.0;
-
-        TextDefinition ICommodity.Description => LabelNumber;
-        bool ICommodity.IsDeedable => true;
-
-        public virtual AmmunitionType AmmoType => AmmunitionType.Cannonball;
-
-        [Constructable]
-        public HeavyCannonball() : this(1)
-        {
-        }
-
-        [Constructable]
-        public HeavyCannonball(int amount) : this(amount, 16932)
-        {
-        }
-
-        public HeavyCannonball(int amount, int itemID) : base(itemID)
-        {
-            Stackable = true;
-            Amount = amount;
-        }
-
-        public HeavyCannonball(Serial serial) : base(serial) { }
-
-        public override void Serialize(GenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(GenericReader reader)
-        {
-            base.Deserialize(reader);
-            reader.ReadInt();
-
-            Replacer.Replace(this, new Cannonball());
-        }
-    }
-
-    public class LightFlameCannonball : Cannonball, ICommodity
-    {
-        public override int LabelNumber => 1116759;
-
-        TextDefinition ICommodity.Description => LabelNumber;
-        bool ICommodity.IsDeedable => true;
-
-        public override AmmunitionType AmmoType => AmmunitionType.FlameCannonball;
-
-        [Constructable]
-        public LightFlameCannonball() : this(1)
-        {
-        }
-
-        [Constructable]
-        public LightFlameCannonball(int amount) : base(amount, 17601)
-        {
-        }
-
-        public LightFlameCannonball(Serial serial) : base(serial) { }
-
-        public override void Serialize(GenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(GenericReader reader)
-        {
-            base.Deserialize(reader);
-            reader.ReadInt();
-
-            Replacer.Replace(this, new FlameCannonball());
-        }
-    }
-
-    public class HeavyFlameCannonball : Cannonball, ICommodity
-    {
-        public override int LabelNumber => 1116267;
-
-        TextDefinition ICommodity.Description => LabelNumber;
-        bool ICommodity.IsDeedable => true;
-
-        public override AmmunitionType AmmoType => AmmunitionType.FlameCannonball;
-
-        [Constructable]
-        public HeavyFlameCannonball()
-            : this(1)
-        {
-        }
-
-        [Constructable]
-        public HeavyFlameCannonball(int amount)
-            : base(amount, 17601)
-        {
-        }
-
-        public HeavyFlameCannonball(Serial serial) : base(serial) { }
-
-        public override void Serialize(GenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(GenericReader reader)
-        {
-            base.Deserialize(reader);
-            reader.ReadInt();
-
-            Replacer.Replace(this, new FlameCannonball());
-        }
-    }
-
-    public class LightFrostCannonball : Cannonball, ICommodity
-    {
-        public override int LabelNumber => 1116759;
-
-        TextDefinition ICommodity.Description => LabelNumber;
-        bool ICommodity.IsDeedable => true;
-
-        public override AmmunitionType AmmoType => AmmunitionType.FrostCannonball;
-
-        [Constructable]
-        public LightFrostCannonball()
-            : this(1)
-        {
-        }
-
-        [Constructable]
-        public LightFrostCannonball(int amount)
-            : base(amount, 16939)
-        {
-        }
-
-        public LightFrostCannonball(Serial serial) : base(serial) { }
-
-        public override void Serialize(GenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(GenericReader reader)
-        {
-            base.Deserialize(reader);
-            reader.ReadInt();
-
-            Replacer.Replace(this, new FrostCannonball());
-        }
-    }
-
-    public class HeavyFrostCannonball : Cannonball, ICommodity
-    {
-        public override int LabelNumber => 1116267;
-
-        TextDefinition ICommodity.Description => LabelNumber;
-        bool ICommodity.IsDeedable => true;
-
-        public override AmmunitionType AmmoType => AmmunitionType.FrostCannonball;
-
-        [Constructable]
-        public HeavyFrostCannonball()
-            : this(1)
-        {
-        }
-
-        [Constructable]
-        public HeavyFrostCannonball(int amount)
-            : base(amount, 16939)
-        {
-        }
-
-        public HeavyFrostCannonball(Serial serial) : base(serial) { }
-
-        public override void Serialize(GenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(GenericReader reader)
-        {
-            base.Deserialize(reader);
-            reader.ReadInt();
-
-            Replacer.Replace(this, new FrostCannonball());
         }
     }
 }

--- a/Scripts/Multis/Boats/Cannons and Ammo/ShipCannon.cs
+++ b/Scripts/Multis/Boats/Cannons and Ammo/ShipCannon.cs
@@ -197,8 +197,8 @@ namespace Server.Items
             {
                 ICannonAmmo ammo = null;
 
-                Cannonball cannon = FindItemByType<Cannonball>();
-                Grapeshot grapeshot = FindItemByType<Grapeshot>();
+                var cannon = FindItemByType<BaseCannonball>();
+                var grapeshot = FindItemByType<Grapeshot>();
 
                 if (cannon != null)
                 {
@@ -210,7 +210,7 @@ namespace Server.Items
                 }
                 else
                 {
-                    cannon = m.Backpack.FindItemByType<Cannonball>();
+                    cannon = m.Backpack.FindItemByType<BaseCannonball>();
                     grapeshot = m.Backpack.FindItemByType<Grapeshot>();
 
                     if (cannon != null)
@@ -328,7 +328,7 @@ namespace Server.Items
                 switch (AmmoType)
                 {
                     default: item = null; break;
-                    case AmmunitionType.Grapeshot: item = new Cannonball(); break;
+                    case AmmunitionType.Grapeshot: item = new Grapeshot(); break;
                     case AmmunitionType.Cannonball: item = new Cannonball(); break;
                     case AmmunitionType.FrostCannonball: item = new FrostCannonball(); break;
                     case AmmunitionType.FlameCannonball: item = new FlameCannonball(); break;
@@ -404,7 +404,7 @@ namespace Server.Items
 
         private readonly Type[] _Types =
         {
-            typeof(Cannonball), typeof(Grapeshot), typeof(PowderCharge), typeof(FuseCord)
+            typeof(BaseCannonball), typeof(Grapeshot), typeof(PowderCharge), typeof(FuseCord)
         };
 
         public override void OnDoubleClickDead(Mobile m)

--- a/Scripts/Quests/ProfessionalBountyQuest/ProfessionalBountyQuest.cs
+++ b/Scripts/Quests/ProfessionalBountyQuest/ProfessionalBountyQuest.cs
@@ -221,7 +221,7 @@ namespace Server.Engines.Quests
                                 mob.SendLocalizedMessage(1149840); //Here is some special cannon ammunition.  It's imported!
                             }
 
-                            if (reward is HeavyFlameCannonball || reward is LightFlameCannonball || reward is HeavyFrostCannonball || reward is LightFrostCannonball)
+                            if (reward is FlameCannonball || reward is FrostCannonball)
                             {
                                 reward.Amount = Utility.RandomMinMax(5, 10);
                             }
@@ -285,11 +285,11 @@ namespace Server.Engines.Quests
 
         private readonly Type[] m_CapturedRewards =
         {
-           typeof(RuinedShipPlans),      typeof(RuinedShipPlans),
-           typeof(LightFlameCannonball), typeof(HeavyFlameCannonball),
-           typeof(LightFrostCannonball), typeof(HeavyFrostCannonball),
-           typeof(LightFlameCannonball), typeof(HeavyFlameCannonball),
-           typeof(LightFrostCannonball), typeof(HeavyFrostCannonball)
+           typeof(RuinedShipPlans), typeof(RuinedShipPlans),
+           typeof(FlameCannonball), typeof(FlameCannonball),
+           typeof(FrostCannonball), typeof(FrostCannonball),
+           typeof(FlameCannonball), typeof(FlameCannonball),
+           typeof(FrostCannonball), typeof(FrostCannonball)
         };
 
         public override void Serialize(GenericWriter writer)


### PR DESCRIPTION
1. Frost and Flame cannonballs revert to normal types on restart.
2. There were multiple types (light and heavy) from when the cannon process was more intense. They needed to be consolidated/removed.
3. Existing cannonballs will be deleted on restart as I had to re-code them to get them to work properly. Sorry about that.
