### PR TITLE
VendorSearchFix

### DIFF
--- a/Scripts/Services/Vendor Searching/VendorSearch.cs
+++ b/Scripts/Services/Vendor Searching/VendorSearch.cs
@@ -1354,6 +1354,7 @@ namespace Server.Engines.VendorSearching
         {
             if (VendorSearch.CanSearch(Player))
             {
+                Player.CloseGump(typeof(VendorSearchGump));
                 BaseGump.SendGump(new VendorSearchGump(Player));
             }
         }


### PR DESCRIPTION
- only one instance of the main menu should be open at any time.