### PR TITLE
SendGump change

### DIFF
--- a/Scripts/Commands/CreateWorld.cs
+++ b/Scripts/Commands/CreateWorld.cs
@@ -96,7 +96,7 @@ namespace Server.Commands
             if (string.IsNullOrEmpty(e.ArgString))
             {
                 if (e.Mobile is PlayerMobile mobile)
-                    BaseGump.SendGump(new NewCreateWorldGump(mobile, GumpType.Create));
+                    BaseGump.SendGump(new NewCreateWorldGump(mobile, GumpType.Create), true);
                 else
                     e.Mobile.SendGump(new CreateWorldGump(e, GumpType.Create));
             }
@@ -118,7 +118,7 @@ namespace Server.Commands
             if (string.IsNullOrEmpty(e.ArgString))
             {
                 if (e.Mobile is PlayerMobile mobile)
-                    BaseGump.SendGump(new NewCreateWorldGump(mobile, GumpType.Delete));
+                    BaseGump.SendGump(new NewCreateWorldGump(mobile, GumpType.Delete), true);
                 else
                     e.Mobile.SendGump(new CreateWorldGump(e, GumpType.Delete));
             }

--- a/Scripts/Gumps/AddCustomizableMessageGump.cs
+++ b/Scripts/Gumps/AddCustomizableMessageGump.cs
@@ -128,7 +128,7 @@ namespace Server.Items
             {
                 if (item is BaseAddon || item.IsChildOf(_From.Backpack))
                 {
-                    BaseGump.SendGump(new AddCustomizableMessageGump(_From, _MessageItem));
+                    BaseGump.SendGump(new AddCustomizableMessageGump(_From, _MessageItem), true);
                 }
                 else
                 {

--- a/Scripts/Gumps/ApplySkillBonusGump.cs
+++ b/Scripts/Gumps/ApplySkillBonusGump.cs
@@ -64,7 +64,7 @@ namespace Server.Gumps
                     (m, gump) =>
                     {
                         gump.Refresh();
-                    }));
+                    }), true);
                 }
             }
         }

--- a/Scripts/Gumps/BaseGump.cs
+++ b/Scripts/Gumps/BaseGump.cs
@@ -62,12 +62,15 @@ namespace Server.Gumps
             Dispose();
         }
 
-        public static BaseGump SendGump(BaseGump gump)
+        public static BaseGump SendGump(BaseGump gump, bool closeOtherInstances)
         {
             if (gump == null)
                 return null;
 
             BaseGump g = gump.User.FindGump(gump.GetType()) as BaseGump;
+
+            if (closeOtherInstances)
+                gump.Close();
 
             if (g == gump)
                 gump.Refresh();

--- a/Scripts/Gumps/Traps/CircuitTrap.cs
+++ b/Scripts/Gumps/Traps/CircuitTrap.cs
@@ -43,7 +43,6 @@ namespace Server.Gumps
             : base(from, 5, 30)
         {
             Trap = item;
-            from.CloseGump(GetType());
         }
 
         public override void AddGumpLayout()

--- a/Scripts/Items/Addons/Craft Addons/AnvilofArtifacts.cs
+++ b/Scripts/Items/Addons/Craft Addons/AnvilofArtifacts.cs
@@ -166,8 +166,7 @@ namespace Server.Items
             {
                 if (from is PlayerMobile pm && UsesRemaining > 0)
                 {
-                    from.CloseGump(typeof(AnvilofArtifactsGump));
-                    BaseGump.SendGump(new AnvilofArtifactsGump(pm, this));
+                    BaseGump.SendGump(new AnvilofArtifactsGump(pm, this), true);
                 }
             }
             else

--- a/Scripts/Items/Books/RunicAtlas.cs
+++ b/Scripts/Items/Books/RunicAtlas.cs
@@ -34,8 +34,7 @@ namespace Server.Items
                         return;
                     }
 
-                    mobile.CloseGump(typeof(RunicAtlasGump));
-                    BaseGump.SendGump(new RunicAtlasGump(mobile, this));
+                    BaseGump.SendGump(new RunicAtlasGump(mobile, this), true);
                     Openers.Add(mobile);
                 }
                 else
@@ -78,14 +77,11 @@ namespace Server.Items
                 }
                 else
                 {
-                    if (g != null)
-                        mobile.CloseGump(typeof(RunicAtlasGump));
-
                     g = new RunicAtlasGump(mobile, this)
                     {
                         Page = newPage
                     };
-                    BaseGump.SendGump(g);
+                    BaseGump.SendGump(g, true);
                 }
             }
 
@@ -543,8 +539,8 @@ namespace Server.Items
                 {
                     Atlas.Description = Utility.FixHtml(text.Trim());
 
-                    from.CloseGump(typeof(RunicAtlasGump));
-                    SendGump(new RunicAtlasGump((PlayerMobile)from, Atlas));
+                    SendGump(new RunicAtlasGump((PlayerMobile)from, Atlas), true);
+
                     from.SendLocalizedMessage(1041531); // You have changed the title of the rune book.
                 }
                 else
@@ -560,8 +556,7 @@ namespace Server.Items
 
                 if (from is PlayerMobile mobile && !Atlas.Deleted && mobile.InRange(Atlas.GetWorldLocation(), 3))
                 {
-                    mobile.CloseGump(typeof(RunicAtlasGump));
-                    SendGump(new RunicAtlasGump(mobile, Atlas));
+                    SendGump(new RunicAtlasGump(mobile, Atlas), true);
                 }
             }
         }

--- a/Scripts/Items/Books/SpecialScrollBooks/BaseSpecialScrollBook.cs
+++ b/Scripts/Items/Books/SpecialScrollBooks/BaseSpecialScrollBook.cs
@@ -61,7 +61,7 @@ namespace Server.Items
             }
             else if (m is PlayerMobile mobile && mobile.InRange(GetWorldLocation(), 2))
             {
-                BaseGump.SendGump(new SpecialScrollBookGump(mobile, this));
+                BaseGump.SendGump(new SpecialScrollBookGump(mobile, this), true);
             }
             else if (m.AccessLevel > AccessLevel.Player)
             {

--- a/Scripts/Items/Books/SpecialScrollBooks/SpecialScrollBookGump.cs
+++ b/Scripts/Items/Books/SpecialScrollBooks/SpecialScrollBookGump.cs
@@ -15,8 +15,6 @@ namespace Server.Gumps
             : base(pm, 150, 200)
         {
             Book = book;
-
-            pm.CloseGump(typeof(SpecialScrollBookGump));
         }
 
         public override void AddGumpLayout()

--- a/Scripts/Items/Consumables/MelisandesHairDye.cs
+++ b/Scripts/Items/Consumables/MelisandesHairDye.cs
@@ -23,7 +23,7 @@ namespace Server.Items
         {
             if (IsChildOf(from.Backpack))
             {
-                BaseGump.SendGump(new HairDyeConfirmGump(from as PlayerMobile, Hue, this));
+                BaseGump.SendGump(new HairDyeConfirmGump(from as PlayerMobile, Hue, this), true);
             }
             else
                 from.SendLocalizedMessage(1042001); // That must be in your pack for you to use it.

--- a/Scripts/Items/Consumables/SkinTingeingTincture.cs
+++ b/Scripts/Items/Consumables/SkinTingeingTincture.cs
@@ -24,10 +24,7 @@ namespace Server.Items
         {
             if (IsChildOf(m.Backpack) && m is PlayerMobile mobile)
             {
-                if (!mobile.HasGump(typeof(InternalGump)))
-                {
-                    BaseGump.SendGump(new InternalGump(mobile, this));
-                }
+                BaseGump.SendGump(new InternalGump(mobile, this), true);
             }
         }
 

--- a/Scripts/Items/Decorative/CustomizableRoundedDoorMat.cs
+++ b/Scripts/Items/Decorative/CustomizableRoundedDoorMat.cs
@@ -40,7 +40,7 @@ namespace Server.Items
             if (IsChildOf(from.Backpack))
             {
                 if (from is PlayerMobile mobile)
-                    BaseGump.SendGump(new AddCustomizableMessageGump(mobile, this));
+                    BaseGump.SendGump(new AddCustomizableMessageGump(mobile, this), true);
             }
             else
             {

--- a/Scripts/Items/Decorative/CustomizableWallSign.cs
+++ b/Scripts/Items/Decorative/CustomizableWallSign.cs
@@ -24,7 +24,7 @@ namespace Server.Items
             if (IsChildOf(from.Backpack))
             {
                 if (from is PlayerMobile mobile)
-                    BaseGump.SendGump(new AddCustomizableMessageGump(mobile, this));
+                    BaseGump.SendGump(new AddCustomizableMessageGump(mobile, this), true);
             }
             else
             {

--- a/Scripts/Items/Decorative/ValentineBear.cs
+++ b/Scripts/Items/Decorative/ValentineBear.cs
@@ -50,7 +50,7 @@ namespace Server.Items
             {
                 if (from is PlayerMobile mobile && EditEnd > DateTime.UtcNow)
                 {
-                    BaseGump.SendGump(new AddCustomizableMessageGump(mobile, this, 1150294, 1150293));
+                    BaseGump.SendGump(new AddCustomizableMessageGump(mobile, this, 1150294, 1150293), true);
                 }
             }
             else

--- a/Scripts/Items/Equipment/Spellbooks/BookOfMasteries.cs
+++ b/Scripts/Items/Equipment/Spellbooks/BookOfMasteries.cs
@@ -50,7 +50,9 @@ namespace Server.Items
             SimpleContextMenuEntry menu = new SimpleContextMenuEntry(from, 1151948, m =>
                 {
                     if (m is PlayerMobile mobile && IsChildOf(mobile.Backpack) && CheckCooldown(mobile))
-                        BaseGump.SendGump(new MasterySelectionGump(mobile, this));
+                    {
+                        BaseGump.SendGump(new MasterySelectionGump(mobile, this), true);
+                    }
                 });
 
             if (!IsChildOf(from.Backpack) || !CheckCooldown(from))

--- a/Scripts/Items/Functional/AuctionSafe/AuctionMap.cs
+++ b/Scripts/Items/Functional/AuctionSafe/AuctionMap.cs
@@ -254,7 +254,7 @@ namespace Server.Items
             {
                 if (Clicker is PlayerMobile mobile)
                 {
-                    BaseGump.SendGump(new ConfirmTeleportGump(VendorMap, mobile));
+                    BaseGump.SendGump(new ConfirmTeleportGump(VendorMap, mobile), true);
                 }
             }
         }

--- a/Scripts/Items/Functional/CircuitTrapTrainingKit.cs
+++ b/Scripts/Items/Functional/CircuitTrapTrainingKit.cs
@@ -56,7 +56,7 @@ namespace Server.Items
                     }
                 }
 
-                BaseGump.SendGump(new CircuitTrapGump(mobile, this));
+                BaseGump.SendGump(new CircuitTrapGump(mobile, this), true);
             }
         }
 

--- a/Scripts/Items/Functional/SeedBox/SeedBox.cs
+++ b/Scripts/Items/Functional/SeedBox/SeedBox.cs
@@ -74,7 +74,7 @@ namespace Server.Engines.Plants
             {
                 if (CheckAccessible(m, this))
                 {
-                    BaseGump.SendGump(new SeedBoxGump(mobile, this));
+                    BaseGump.SendGump(new SeedBoxGump(mobile, this), true);
                 }
                 else
                 {
@@ -214,7 +214,7 @@ namespace Server.Engines.Plants
                             gump = new SeedBoxGump(mobile, this);
                             gump.CheckPage(entry);
 
-                            BaseGump.SendGump(gump);
+                            BaseGump.SendGump(gump, true);
                         }
                     }
 

--- a/Scripts/Items/Functional/SeedBox/SeedBoxGump.cs
+++ b/Scripts/Items/Functional/SeedBox/SeedBoxGump.cs
@@ -21,8 +21,6 @@ namespace Server.Engines.Plants
         {
             Box = box;
             Page = page;
-
-            user.CloseGump(GetType());
         }
 
         public override void AddGumpLayout()
@@ -151,7 +149,7 @@ namespace Server.Engines.Plants
                             return;
 
                         Refresh();
-                        SendGump(new SeedInfoGump(User, Box, entry, this));
+                        SendGump(new SeedInfoGump(User, Box, entry, this), true);
                     }
                     break;
             }
@@ -263,7 +261,7 @@ namespace Server.Engines.Plants
                     from.SendLocalizedMessage(1158426, amount.ToString()); // You remove ~1_quant~ seed(s) from the seedbox.
 
                     if (from is PlayerMobile pm)
-                        SendGump(new SeedBoxGump(pm, m_Box));
+                        SendGump(new SeedBoxGump(pm, m_Box), true);
                 }
             }
         }

--- a/Scripts/Items/Functional/SliderTrapTrainingKit.cs
+++ b/Scripts/Items/Functional/SliderTrapTrainingKit.cs
@@ -133,7 +133,7 @@ namespace Server.Items
         {
             if (from is PlayerMobile mobile)
             {
-                BaseGump.SendGump(new SliderTrapGump(mobile, this));
+                BaseGump.SendGump(new SliderTrapGump(mobile, this), true);
             }
         }
 
@@ -210,7 +210,6 @@ namespace Server.Items
         public SliderTrapGump(PlayerMobile pm, ISliderKit kit)
             : base(pm, 100, 100)
         {
-            pm.CloseGump(GetType());
             Kit = kit;
         }
 

--- a/Scripts/Items/StoreBought/AbyssalHairDye.cs
+++ b/Scripts/Items/StoreBought/AbyssalHairDye.cs
@@ -22,7 +22,7 @@ namespace Server.Items
         {
             if (IsChildOf(m.Backpack))
             {
-                BaseGump.SendGump(new HairDyeConfirmGump(m as PlayerMobile, Hue, this));
+                BaseGump.SendGump(new HairDyeConfirmGump(m as PlayerMobile, Hue, this), true);
             }
             else
             {

--- a/Scripts/Items/StoreBought/GenderChangeToken.cs
+++ b/Scripts/Items/StoreBought/GenderChangeToken.cs
@@ -33,8 +33,7 @@ namespace Server.Items
                 _HairID = 0;
                 _BeardID = 0;
 
-                mobile.CloseGump(typeof(GenderChangeConfirmGump));
-                BaseGump.SendGump(new GenderChangeConfirmGump(mobile, this));
+                BaseGump.SendGump(new GenderChangeConfirmGump(mobile, this), true);
             }
         }
 

--- a/Scripts/Items/StoreBought/MythicalCharacterToken.cs
+++ b/Scripts/Items/StoreBought/MythicalCharacterToken.cs
@@ -31,8 +31,7 @@ namespace Server.Items
                 }
                 else
                 {
-                    mobile.CloseGump(typeof(MythicCharacterGump));
-                    BaseGump.SendGump(new MythicCharacterGump(mobile, this));
+                    BaseGump.SendGump(new MythicCharacterGump(mobile, this), true);
                 }
             }
         }

--- a/Scripts/Items/StoreBought/NameChangeToken.cs
+++ b/Scripts/Items/StoreBought/NameChangeToken.cs
@@ -27,8 +27,7 @@ namespace Server.Items
             }
             else if (from is PlayerMobile mobile)
             {
-                mobile.CloseGump(typeof(NameChangeConfirmGump));
-                BaseGump.SendGump(new NameChangeConfirmGump(mobile, this));
+                BaseGump.SendGump(new NameChangeConfirmGump(mobile, this), true);
             }
         }
 

--- a/Scripts/Items/StoreBought/NaturalHairDyes.cs
+++ b/Scripts/Items/StoreBought/NaturalHairDyes.cs
@@ -97,7 +97,7 @@ namespace Server.Items
         {
             if (IsChildOf(m.Backpack))
             {
-                BaseGump.SendGump(new HairDyeConfirmGump(m as PlayerMobile, Hue, this));
+                BaseGump.SendGump(new HairDyeConfirmGump(m as PlayerMobile, Hue, this), true);
             }
             else
             {
@@ -166,8 +166,6 @@ namespace Server.Items
         {
             Hue = hue;
             Dye = dye;
-
-            pm.CloseGump(typeof(HairDyeConfirmGump));
         }
 
         public override void AddGumpLayout()

--- a/Scripts/Items/StoreBought/RaceChangeToken.cs
+++ b/Scripts/Items/StoreBought/RaceChangeToken.cs
@@ -27,8 +27,7 @@ namespace Server.Items
             }
             else if (from is PlayerMobile mobile)
             {
-                mobile.CloseGump(typeof(RaceChangeConfirmGump));
-                BaseGump.SendGump(new RaceChangeConfirmGump(mobile, this));
+                BaseGump.SendGump(new RaceChangeConfirmGump(mobile, this), true);
             }
         }
 

--- a/Scripts/Items/Tools/GreaterBraceletOfBinding.cs
+++ b/Scripts/Items/Tools/GreaterBraceletOfBinding.cs
@@ -51,11 +51,11 @@ namespace Server.Items
             {
                 if (Pending != null)
                 {
-                    BaseGump.SendGump(new GreaterBraceletOfBindingGump(mobile, this, Pending));
+                    BaseGump.SendGump(new GreaterBraceletOfBindingGump(mobile, this, Pending), true);
                 }
                 else
                 {
-                    BaseGump.SendGump(new GreaterBraceletOfBindingGump(mobile, this));
+                    BaseGump.SendGump(new GreaterBraceletOfBindingGump(mobile, this), true);
                 }
             }
             else
@@ -232,7 +232,7 @@ namespace Server.Items
                                             User.SendLocalizedMessage(1151777, pm.Name); // Waiting for ~1_val~ to respond.
                                             Refresh();
 
-                                            SendGump(new ConfirmBindGump(pm, User, id, Bracelet, false));
+                                            SendGump(new ConfirmBindGump(pm, User, id, Bracelet, false), true);
                                         }
                                     }
                                     else
@@ -254,7 +254,7 @@ namespace Server.Items
 
                     if (id >= 0 && id < Bracelet.Friends.Length && Bracelet.Friends[id] != null)
                     {
-                        SendGump(new ConfirmBindGump(User, Bracelet.Friends[id].Mobile, id, Bracelet.Friends[id].Bracelet as GreaterBraceletOfBinding, true));
+                        SendGump(new ConfirmBindGump(User, Bracelet.Friends[id].Mobile, id, Bracelet.Friends[id].Bracelet as GreaterBraceletOfBinding, true), true);
                     }
                 }
             }
@@ -329,7 +329,7 @@ namespace Server.Items
                                 }
 
                                 bracelet.Remove(entry.Mobile);
-                                SendGump(new GreaterBraceletOfBindingGump(User, bracelet));
+                                SendGump(new GreaterBraceletOfBindingGump(User, bracelet), true);
                             }
                         }
                         else
@@ -351,7 +351,7 @@ namespace Server.Items
                                     entry = new BindEntry(From, Bracelet);
                                     binding.Pending = entry;
 
-                                    SendGump(new GreaterBraceletOfBindingGump(User, binding, entry));
+                                    SendGump(new GreaterBraceletOfBindingGump(User, binding, entry), true);
                                 }
                                 else
                                 {

--- a/Scripts/Mobiles/NPCs/TownCrier.cs
+++ b/Scripts/Mobiles/NPCs/TownCrier.cs
@@ -599,7 +599,7 @@ namespace Server.Mobiles
         {
             if (from is PlayerMobile mobile && TownCryerSystem.Enabled)
             {
-                BaseGump.SendGump(new TownCryerGump(mobile, this));
+                BaseGump.SendGump(new TownCryerGump(mobile, this), true);
             }
 
             if (from.AccessLevel >= AccessLevel.GameMaster)
@@ -648,7 +648,7 @@ namespace Server.Mobiles
 
                 if (e.Mobile is PlayerMobile mobile && TownCryerSystem.Enabled)
                 {
-                    BaseGump.SendGump(new TownCryerGump(mobile, this));
+                    BaseGump.SendGump(new TownCryerGump(mobile, this), true);
                 }
             }
         }

--- a/Scripts/Multis/Boats/Cannons and Ammo/ShipCannon.cs
+++ b/Scripts/Multis/Boats/Cannons and Ammo/ShipCannon.cs
@@ -1150,11 +1150,11 @@ namespace Server.Items
                     {
                         if (delay != TimeSpan.Zero)
                         {
-                            Timer.DelayCall(delay, () => BaseGump.SendGump(new ShipCannonGump(pm, this)));
+                            Timer.DelayCall(delay, () => BaseGump.SendGump(new ShipCannonGump(pm, this), true));
                         }
                         else
                         {
-                            BaseGump.SendGump(new ShipCannonGump(pm, this));
+                            BaseGump.SendGump(new ShipCannonGump(pm, this), true);
                         }
                     }
                 }

--- a/Scripts/Multis/Houses/Gumps/HouseGump.cs
+++ b/Scripts/Multis/Houses/Gumps/HouseGump.cs
@@ -840,7 +840,7 @@ namespace Server.Gumps
 
                 if (entries != null)
                 {
-                    BaseGump.SendGump(new HouseSwapGump(from, house, entries));
+                    BaseGump.SendGump(new HouseSwapGump(from, house, entries), true);
                 }
             }
         }

--- a/Scripts/Multis/Houses/HousePlacementTool.cs
+++ b/Scripts/Multis/Houses/HousePlacementTool.cs
@@ -967,7 +967,6 @@ namespace Server.Items
 
             from.CloseGump(typeof(HousePlacementCategoryGump));
             from.CloseGump(typeof(HousePlacementListGump));
-            from.CloseGump(typeof(HouseSwapGump));
         }
 
         public override void AddGumpLayout()

--- a/Scripts/Multis/Houses/HouseTeleporterTile.cs
+++ b/Scripts/Multis/Houses/HouseTeleporterTile.cs
@@ -304,10 +304,7 @@ namespace Server.Multis
                 if (Item == null || Item.Deleted)
                     return;
 
-                if (!Mobile.HasGump(typeof(HouseTeleporterTypeGump)))
-                {
-                    BaseGump.SendGump(new HouseTeleporterTypeGump((PlayerMobile)Mobile, Item));
-                }
+                BaseGump.SendGump(new HouseTeleporterTypeGump((PlayerMobile)Mobile, Item), true);
             }
         }
 

--- a/Scripts/Quests/ProfessionalBountyQuest/BountyBoard.cs
+++ b/Scripts/Quests/ProfessionalBountyQuest/BountyBoard.cs
@@ -16,8 +16,7 @@ namespace Server.Items
 
         public override void OnDoubleClick(Mobile from)
         {
-            if (!from.HasGump(typeof(BountyBoardGump)))
-                BaseGump.SendGump(new BountyBoardGump(from));
+            BaseGump.SendGump(new BountyBoardGump(from), true);
         }
 
         public ProfessionalBountyBoard(Serial serial) : base(serial) { }

--- a/Scripts/Services/AccountVault/AccountVault.cs
+++ b/Scripts/Services/AccountVault/AccountVault.cs
@@ -244,8 +244,8 @@ namespace Server.AccountVault
 
             InvalidateProperties();
 
-            BaseGump.SendGump(new VaultActionsGump(from, this));
-            BaseGump.SendGump(new NewVaultPurchaseGump(from, this));
+            BaseGump.SendGump(new VaultActionsGump(from, this), true);
+            BaseGump.SendGump(new NewVaultPurchaseGump(from, this), true);
         }
 
         public void MoveTo(Mobile from)
@@ -610,7 +610,7 @@ namespace Server.AccountVault
 
                             if (entry != null)
                             {
-                                BaseGump.SendGump(new PromoItemGump(pm, entry, 0x9CCB));
+                                BaseGump.SendGump(new PromoItemGump(pm, entry, 0x9CCB), true);
                             }
                         }
                         else if (manager != null)
@@ -630,7 +630,7 @@ namespace Server.AccountVault
                             {
                                 vault.TakeOwnership(pm);
                             }
-                        }));
+                        }), true);
                     }
                 }
                 else
@@ -847,7 +847,7 @@ namespace Server.AccountVault
             {
                 if (Owner.From is PlayerMobile pm && Container != null && !Container.Deleted)
                 {
-                    BaseGump.SendGump(new ContainerDisplayGump(pm, Container, 1158005));
+                    BaseGump.SendGump(new ContainerDisplayGump(pm, Container, 1158005), true);
                 }
             }
         }

--- a/Scripts/Services/AccountVault/Gumps.cs
+++ b/Scripts/Services/AccountVault/Gumps.cs
@@ -104,7 +104,7 @@ namespace Server.AccountVault
                     User.Prompt = new InternalPrompt(User, Vault);
                     break;
                 case 103:
-                    SendGump(new VaultLocationsGump(User));
+                    SendGump(new VaultLocationsGump(User), true);
                     break;
             }
         }
@@ -122,7 +122,7 @@ namespace Server.AccountVault
 
             public override void OnCancel(Mobile from)
             {
-                SendGump(new VaultActionsGump(From, Vault));
+                SendGump(new VaultActionsGump(From, Vault), true);
             }
 
             public override void OnResponse(Mobile from, string text)
@@ -142,7 +142,7 @@ namespace Server.AccountVault
                     Vault.Balance += num;
                 }
 
-                SendGump(new VaultActionsGump(From, Vault));
+                SendGump(new VaultActionsGump(From, Vault), true);
             }
         }
     }

--- a/Scripts/Services/AccountVault/VaultManager.cs
+++ b/Scripts/Services/AccountVault/VaultManager.cs
@@ -191,7 +191,7 @@ namespace Server.AccountVault
                         BaseGump.SendGump(new PetTrainingStyleConfirmGump(pm, 1074974, 1158037, () =>
                         {
                             vault.ClaimVault(pm);
-                        }));
+                        }), true);
                     }
                     else
                     {
@@ -217,7 +217,7 @@ namespace Server.AccountVault
             {
                 if (Owner.From is PlayerMobile pm && Vault != null)
                 {
-                    BaseGump.SendGump(new VaultActionsGump(pm, Vault));
+                    BaseGump.SendGump(new VaultActionsGump(pm, Vault), true);
                 }
             }
         }
@@ -236,7 +236,7 @@ namespace Server.AccountVault
             {
                 if (Owner.From is PlayerMobile pm)
                 {
-                    BaseGump.SendGump(new VaultLocationsGump(pm));
+                    BaseGump.SendGump(new VaultLocationsGump(pm), true);
                 }
             }
         }

--- a/Scripts/Services/Astronomy/ConstellationLedger.cs
+++ b/Scripts/Services/Astronomy/ConstellationLedger.cs
@@ -19,7 +19,7 @@ namespace Server.Engines.Astronomy
         {
             if (m is PlayerMobile mobile && mobile.InRange(GetWorldLocation(), 3))
             {
-                BaseGump.SendGump(new ConstellationLedgerGump(mobile));
+                BaseGump.SendGump(new ConstellationLedgerGump(mobile), true);
             }
         }
 

--- a/Scripts/Services/Astronomy/StarChart.cs
+++ b/Scripts/Services/Astronomy/StarChart.cs
@@ -85,7 +85,7 @@ namespace Server.Items
         {
             if (m is PlayerMobile pm && IsChildOf(pm.Backpack) && _Constellation > -1)
             {
-                BaseGump.SendGump(new InternalGump(pm, this));
+                BaseGump.SendGump(new InternalGump(pm, this), true);
             }
         }
 
@@ -111,8 +111,6 @@ namespace Server.Items
             public InternalGump(PlayerMobile pm, StarChart chart)
                 : base(pm)
             {
-                pm.CloseGump(typeof(InternalGump));
-
                 Chart = chart;
             }
 

--- a/Scripts/Services/Astronomy/Telescope.cs
+++ b/Scripts/Services/Astronomy/Telescope.cs
@@ -76,7 +76,7 @@ namespace Server.Items
                     }
                     else
                     {
-                        BaseGump.SendGump(new TelescopeGump((PlayerMobile)m, this));
+                        BaseGump.SendGump(new TelescopeGump((PlayerMobile)m, this), true);
                     }
                 }
             }
@@ -165,8 +165,6 @@ namespace Server.Items
             : base(pm, 200, 200)
         {
             Tele = tele;
-
-            pm.CloseGump(typeof(TelescopeGump));
         }
 
         public override void AddGumpLayout()

--- a/Scripts/Services/City Loyalty System/CityLoyaltySystem.cs
+++ b/Scripts/Services/City Loyalty System/CityLoyaltySystem.cs
@@ -685,7 +685,7 @@ namespace Server.Engines.CityLoyalty
             EventSink.Login += OnLogin;
             Timer.DelayCall(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), OnTick);
 
-            CommandSystem.Register("ElectionStartTime", AccessLevel.Administrator, e => Gumps.BaseGump.SendGump(new ElectionStartTimeGump(e.Mobile as PlayerMobile)));
+            CommandSystem.Register("ElectionStartTime", AccessLevel.Administrator, e => Gumps.BaseGump.SendGump(new ElectionStartTimeGump(e.Mobile as PlayerMobile), true));
             CommandSystem.Register("RemoveWait", AccessLevel.Administrator, e =>
             {
                 for (var index = 0; index < Cities.Count; index++)
@@ -700,8 +700,7 @@ namespace Server.Engines.CityLoyalty
             {
                 if (e.Mobile is PlayerMobile mobile)
                 {
-                    mobile.CloseGump(typeof(SystemInfoGump));
-                    Gumps.BaseGump.SendGump(new SystemInfoGump(mobile));
+                    Gumps.BaseGump.SendGump(new SystemInfoGump(mobile), true);
                 }
             });
         }

--- a/Scripts/Services/City Loyalty System/Gumps.cs
+++ b/Scripts/Services/City Loyalty System/Gumps.cs
@@ -147,10 +147,10 @@ namespace Server.Engines.CityLoyalty
             {
                 case 0: break;
                 case 1:
-                    SendGump(new CityTitlesGump(User));
+                    SendGump(new CityTitlesGump(User), true);
                     break;
                 case 2:
-                    SendGump(new RenounceCitizenshipGump(User));
+                    SendGump(new RenounceCitizenshipGump(User), true);
                     break;
                 case 3:
                 default:
@@ -158,7 +158,7 @@ namespace Server.Engines.CityLoyalty
                     if (id >= 0 && id < CityLoyaltySystem.Cities.Count)
                     {
                         if (Citizenship == null)
-                            SendGump(new DeclareCitizenshipGump(CityLoyaltySystem.Cities[id], User));
+                            SendGump(new DeclareCitizenshipGump(CityLoyaltySystem.Cities[id], User), true);
                     }
                     break;
             }
@@ -209,7 +209,9 @@ namespace Server.Engines.CityLoyalty
                 }
             }
             else if (info.ButtonID == 2)
-                SendGump(new CityLoyaltyGump(User));
+            {
+                SendGump(new CityLoyaltyGump(User), true);
+            }
         }
     }
 
@@ -255,7 +257,9 @@ namespace Server.Engines.CityLoyalty
                 }
             }
             else if (info.ButtonID == 2)
-                SendGump(new CityLoyaltyGump(User));
+            {
+                SendGump(new CityLoyaltyGump(User), true);
+            }
         }
     }
 
@@ -320,7 +324,7 @@ namespace Server.Engines.CityLoyalty
                 CityTitle t = (CityTitle)info.ButtonID - 1;
 
                 if (!Citizenship.HasTitle(User, t))
-                    SendGump(new CityTitlesInfoGump(User, t));
+                    SendGump(new CityTitlesInfoGump(User, t), true);
             }
         }
     }
@@ -386,7 +390,7 @@ namespace Server.Engines.CityLoyalty
             }
             else if (info.ButtonID == 2)
             {
-                SendGump(new CityTitlesGump(User));
+                SendGump(new CityTitlesGump(User), true);
             }
         }
     }
@@ -399,8 +403,6 @@ namespace Server.Engines.CityLoyalty
             : base(pm)
         {
             City = city;
-
-            pm.CloseGump(typeof(CityStoneGump));
         }
 
         public override void AddGumpLayout()
@@ -445,8 +447,8 @@ namespace Server.Engines.CityLoyalty
             {
                 case 0: break;
                 case 1: City.Election.TryNominate(User); break;
-                case 2: SendGump(new NomineesGump(User, City)); break;
-                case 3: SendGump(new CandidatesGump(User, City)); break;
+                case 2: SendGump(new NomineesGump(User, City), true); break;
+                case 3: SendGump(new CandidatesGump(User, City), true); break;
             }
         }
     }
@@ -459,8 +461,6 @@ namespace Server.Engines.CityLoyalty
             : base(pm)
         {
             City = city;
-
-            pm.CloseGump(typeof(NomineesGump));
         }
 
         public override void AddGumpLayout()
@@ -518,7 +518,7 @@ namespace Server.Engines.CityLoyalty
         public override void OnResponse(RelayInfo info)
         {
             if (info.ButtonID == 1)
-                SendGump(new CityStoneGump(User, City));
+                SendGump(new CityStoneGump(User, City), true);
             else if (info.ButtonID == 2)
                 City.Election.TryWithdraw(User);
             else if (info.ButtonID >= 100)
@@ -612,7 +612,7 @@ namespace Server.Engines.CityLoyalty
         public override void OnResponse(RelayInfo info)
         {
             if (info.ButtonID == 1)
-                SendGump(new CityStoneGump(User, City));
+                SendGump(new CityStoneGump(User, City), true);
             else if (info.ButtonID == 2)
                 City.Election.TryWithdraw(User);
             else if (info.ButtonID >= 100)
@@ -723,8 +723,6 @@ namespace Server.Engines.CityLoyalty
         {
             Citizen = citizen;
             City = sys;
-
-            pm.CloseGump(typeof(PlayerTitleGump));
         }
 
         public override void AddGumpLayout()
@@ -794,8 +792,6 @@ namespace Server.Engines.CityLoyalty
         public AcceptOfficeGump(PlayerMobile pm, CityLoyaltySystem city) : base(pm)
         {
             City = city;
-
-            pm.CloseGump(typeof(AcceptOfficeGump));
         }
 
         public override void AddGumpLayout()
@@ -845,7 +841,6 @@ namespace Server.Engines.CityLoyalty
     {
         public ElectionStartTimeGump(PlayerMobile pm) : base(pm)
         {
-            pm.CloseGump(typeof(ElectionStartTimeGump));
         }
 
         public override void AddGumpLayout()
@@ -1052,8 +1047,7 @@ namespace Server.Engines.CityLoyalty
                                 m.SendMessage("Ballot box deleted.");
                             }
 
-                            m.CloseGump(typeof(OpenInventoryGump));
-                            SendGump(new OpenInventoryGump(User, City));
+                            SendGump(new OpenInventoryGump(User, City), true);
                         }, box, true));
                 }
             }
@@ -1093,7 +1087,7 @@ namespace Server.Engines.CityLoyalty
             int id = info.ButtonID - 100;
 
             if (id >= 0 && id < CityLoyaltySystem.Cities.Count)
-                SendGump(new CityMessageGump(User, CityLoyaltySystem.Cities[id]));
+                SendGump(new CityMessageGump(User, CityLoyaltySystem.Cities[id]), true);
         }
     }
 
@@ -1160,7 +1154,7 @@ namespace Server.Engines.CityLoyalty
 
             if (id >= 0 && id < CityLoyaltySystem.Cities.Count)
             {
-                SendGump(new CityInfoGump(User, CityLoyaltySystem.Cities[id]));
+                SendGump(new CityInfoGump(User, CityLoyaltySystem.Cities[id]), true);
             }
         }
     }
@@ -1233,7 +1227,7 @@ namespace Server.Engines.CityLoyalty
 
             if (info.ButtonID == 1)
             {
-                SendGump(new SystemInfoGump(User));
+                SendGump(new SystemInfoGump(User), true);
                 return;
             }
 

--- a/Scripts/Services/City Loyalty System/Items/CityStone.cs
+++ b/Scripts/Services/City Loyalty System/Items/CityStone.cs
@@ -28,7 +28,7 @@ namespace Server.Engines.CityLoyalty
         {
             if (CityLoyaltySystem.Enabled && CityLoyaltySystem.IsSetup() && from is PlayerMobile pm && pm.InRange(pm.Location, 3))
             {
-                BaseGump.SendGump(new CityStoneGump(pm, City));
+                BaseGump.SendGump(new CityStoneGump(pm, City), true);
             }
         }
 
@@ -96,7 +96,7 @@ namespace Server.Engines.CityLoyalty
                                 {
                                     if (City.IsCitizen(pm))
                                     {
-                                        BaseGump.SendGump(new PlayerTitleGump(mob as PlayerMobile, pm, City));
+                                        BaseGump.SendGump(new PlayerTitleGump(mob as PlayerMobile, pm, City), true);
                                     }
                                     else
                                         mob.SendLocalizedMessage(1154029); // You may only bestow a title on citizens of this city!
@@ -111,7 +111,7 @@ namespace Server.Engines.CityLoyalty
             {
                 if (City.IsGovernor(m))
                 {
-                    BaseGump.SendGump(new ChooseTradeDealGump(m as PlayerMobile, City));
+                    BaseGump.SendGump(new ChooseTradeDealGump(m as PlayerMobile, City), true);
                 }
             }, enabled: City.IsGovernor(from)));
 
@@ -119,7 +119,7 @@ namespace Server.Engines.CityLoyalty
             {
                 if (m is PlayerMobile mobile && City.IsGovernor(mobile))
                 {
-                    BaseGump.SendGump(new OpenInventoryGump(mobile, City));
+                    BaseGump.SendGump(new OpenInventoryGump(mobile, City), true);
                 }
             }, enabled: City.IsGovernor(from)));
 
@@ -185,7 +185,7 @@ namespace Server.Engines.CityLoyalty
             {
                 if (m is PlayerMobile mobile && m == City.GovernorElect && City.Governor == null)
                 {
-                    BaseGump.SendGump(new AcceptOfficeGump(mobile, City));
+                    BaseGump.SendGump(new AcceptOfficeGump(mobile, City), true);
                 }
             }, enabled: City.GovernorElect == from && City.Governor == null && City.GetLoyaltyRating(from) >= LoyaltyRating.Unknown));
         }

--- a/Scripts/Services/CleanUpBritannia/PointExchange.cs
+++ b/Scripts/Services/CleanUpBritannia/PointExchange.cs
@@ -28,8 +28,7 @@ namespace Server.Engines.Points
             {
                 if (m is PlayerMobile pm)
                 {
-                    pm.CloseGump(typeof(InternalGump));
-                    BaseGump.SendGump(new InternalGump(pm));
+                    BaseGump.SendGump(new InternalGump(pm), true);
                 }
             }
             else

--- a/Scripts/Services/Dungeons/Underworld/PuzzleRoom/MazePuzzleItem.cs
+++ b/Scripts/Services/Dungeons/Underworld/PuzzleRoom/MazePuzzleItem.cs
@@ -39,7 +39,7 @@ namespace Server.Items
             {
                 pm.CloseGump(typeof(PuzzleChest.PuzzleGump));
                 pm.CloseGump(typeof(PuzzleChest.StatusGump));
-                BaseGump.SendGump(new CircuitTrapGump(pm, this));
+                BaseGump.SendGump(new CircuitTrapGump(pm, this), true);
             }
         }
 

--- a/Scripts/Services/ExploringTheDeep/Questers/HeplerPaulson.cs
+++ b/Scripts/Services/ExploringTheDeep/Questers/HeplerPaulson.cs
@@ -71,7 +71,7 @@ namespace Server.Mobiles
             {
                 if (!m.HasGump(typeof(HeplerPaulsonGump)))
                 {
-                    BaseGump.SendGump(new HeplerPaulsonGump((PlayerMobile) m));
+                    BaseGump.SendGump(new HeplerPaulsonGump((PlayerMobile) m), true);
                     pm.ExploringTheDeepQuest = ExploringTheDeepQuestChain.HeplerPaulson;
                 }
             }
@@ -82,13 +82,13 @@ namespace Server.Mobiles
             }
             else if (pm.ExploringTheDeepQuest == ExploringTheDeepQuestChain.CollectTheComponentComplete)
             {
-                BaseGump.SendGump(new HeplerPaulsonCollectCompleteGump((PlayerMobile) m));
+                BaseGump.SendGump(new HeplerPaulsonCollectCompleteGump((PlayerMobile) m), true);
             }
             else
             {
                 if (!m.HasGump(typeof(HeplerPaulsonCompleteGump)))
                 {
-                    BaseGump.SendGump(new HeplerPaulsonCompleteGump((PlayerMobile) m));
+                    BaseGump.SendGump(new HeplerPaulsonCompleteGump((PlayerMobile) m), true);
                 }
             }
         }
@@ -114,7 +114,7 @@ namespace Server.Mobiles
                     if (m.ExploringTheDeepQuest == ExploringTheDeepQuestChain.HeplerPaulson)
                     {
                         dropped.Delete();
-                        BaseGump.SendGump(new HeplerPaulsonCompleteGump(m));
+                        BaseGump.SendGump(new HeplerPaulsonCompleteGump(m), true);
                         m.ExploringTheDeepQuest = ExploringTheDeepQuestChain.HeplerPaulsonComplete;
                     }
                     else if (m.ExploringTheDeepQuest >= ExploringTheDeepQuestChain.HeplerPaulsonComplete)
@@ -144,7 +144,7 @@ namespace Server.Mobiles
 
         private static void HeplerPaulsonGump_OnCommand(CommandEventArgs e)
         {
-            SendGump(new HeplerPaulsonGump(e.Mobile as PlayerMobile));
+            SendGump(new HeplerPaulsonGump(e.Mobile as PlayerMobile), true);
         }
 
         private static readonly PageData[] GumpInfo =
@@ -178,7 +178,7 @@ namespace Server.Mobiles
 
         private static void HeplerPaulsonCompleteGump_OnCommand(CommandEventArgs e)
         {
-            SendGump(new HeplerPaulsonCompleteGump(e.Mobile as PlayerMobile));
+            SendGump(new HeplerPaulsonCompleteGump(e.Mobile as PlayerMobile), true);
         }
 
         public HeplerPaulsonCompleteGump(PlayerMobile pm)
@@ -196,7 +196,7 @@ namespace Server.Mobiles
 
         private static void HeplerPaulsonCollectCompleteGump_OnCommand(CommandEventArgs e)
         {
-            SendGump(new HeplerPaulsonCollectCompleteGump(e.Mobile as PlayerMobile));
+            SendGump(new HeplerPaulsonCollectCompleteGump(e.Mobile as PlayerMobile), true);
         }
 
         private static readonly PageData[] GumpInfo =

--- a/Scripts/Services/LootGeneration/Imbuing/Core/Imbuing.cs
+++ b/Scripts/Services/LootGeneration/Imbuing/Core/Imbuing.cs
@@ -37,8 +37,7 @@ namespace Server.SkillHandlers
             }
             else if (from is PlayerMobile pm)
             {
-                pm.CloseGump(typeof(ImbuingGump));
-                BaseGump.SendGump(new ImbuingGump(pm));
+                BaseGump.SendGump(new ImbuingGump(pm), true);
                 pm.BeginAction(typeof(Imbuing));
             }
 

--- a/Scripts/Services/LootGeneration/Imbuing/Gumps/ImbueGump.cs
+++ b/Scripts/Services/LootGeneration/Imbuing/Gumps/ImbueGump.cs
@@ -340,7 +340,7 @@ namespace Server.Gumps
 
                 case 10099: // Back
                     {
-                        SendGump(new ImbueSelectGump(User, context.LastImbued));
+                        SendGump(new ImbueSelectGump(User, context.LastImbued), true);
                         break;
                     }
                 case 10100:  // Imbue the Item
@@ -360,7 +360,7 @@ namespace Server.Gumps
         {
             Timer.DelayCall(TimeSpan.FromSeconds(1.5), () =>
             {
-                SendGump(new ImbuingGump(pm));
+                SendGump(new ImbuingGump(pm), true);
             });
         }
 

--- a/Scripts/Services/LootGeneration/Imbuing/Gumps/ImbueSelectGump.cs
+++ b/Scripts/Services/LootGeneration/Imbuing/Gumps/ImbueSelectGump.cs
@@ -803,7 +803,7 @@ namespace Server.Gumps
 
                         if (Imbuing.OnBeforeImbue(User, context.LastImbued, id, -1))
                         {
-                            SendGump(new ImbueGump(User, context.LastImbued, id, -1));
+                            SendGump(new ImbueGump(User, context.LastImbued, id, -1), true);
                         }
 
                         break;

--- a/Scripts/Services/LootGeneration/Imbuing/Gumps/ImbuingGump.cs
+++ b/Scripts/Services/LootGeneration/Imbuing/Gumps/ImbuingGump.cs
@@ -178,7 +178,7 @@ namespace Server.Gumps
                 else if (m is PlayerMobile pm && Imbuing.CanUnravelItem(pm, item))
                 {
                     pm.BeginAction(typeof(Imbuing));
-                    SendGump(new UnravelGump(pm, item));
+                    SendGump(new UnravelGump(pm, item), true);
                 }
             }
 
@@ -280,7 +280,7 @@ namespace Server.Gumps
                     if (unraveled)
                     {
                         pm.BeginAction(typeof(Imbuing));
-                        SendGump(new UnravelContainerGump(pm, cont));
+                        SendGump(new UnravelContainerGump(pm, cont), true);
                     }
                     else
                     {
@@ -422,7 +422,7 @@ namespace Server.Gumps
                     context.ImbMenu_Cat = 1;
 
                 pm.CloseGump(typeof(ImbuingGump));
-                SendGump(new ImbueSelectGump(pm, item));
+                SendGump(new ImbueSelectGump(pm, item), true);
             }
         }
 

--- a/Scripts/Services/LootGeneration/ItemPropertiesGump.cs
+++ b/Scripts/Services/LootGeneration/ItemPropertiesGump.cs
@@ -12,7 +12,7 @@ namespace Server.Gumps
         {
             CommandSystem.Register("ItemProps", AccessLevel.GameMaster, e =>
             {
-                SendGump(new ItemPropertiesGump((PlayerMobile)e.Mobile));
+                SendGump(new ItemPropertiesGump((PlayerMobile)e.Mobile), true);
             });
         }
 
@@ -280,7 +280,7 @@ namespace Server.Gumps
                 {
                     ItemPropertyInfo propInfo = Infos[id];
 
-                    SendGump(new InfoSpecificGump(User, propInfo, TypeFilter));
+                    SendGump(new InfoSpecificGump(User, propInfo, TypeFilter), true);
                 }
             }
         }

--- a/Scripts/Services/LoyaltySystem/LoyaltyRatingGump.cs
+++ b/Scripts/Services/LoyaltySystem/LoyaltyRatingGump.cs
@@ -71,7 +71,7 @@ namespace Server.Engines.Points
         {
             if (CityLoyaltySystem.Enabled && CityLoyaltySystem.Cities != null && state.Mobile is PlayerMobile pm && info.ButtonID == 1)
             {
-                BaseGump.SendGump(new CityLoyaltyGump(pm));
+                BaseGump.SendGump(new CityLoyaltyGump(pm), true);
             }
         }
     }

--- a/Scripts/Services/MondainsLegacyQuests/Helpers/PlayerQuestInfo.cs
+++ b/Scripts/Services/MondainsLegacyQuests/Helpers/PlayerQuestInfo.cs
@@ -49,7 +49,7 @@ namespace Server.Engines.Quests
                         var chains = subject.Chains;
                         var done = subject.DoneQuests;
 
-                        SendGump(new PlayerQuestInfoGump(pm, subject));
+                        SendGump(new PlayerQuestInfoGump(pm, subject), true);
                     }
                 });
             }
@@ -219,7 +219,7 @@ namespace Server.Engines.Quests
                                     {
                                         Subject.DoneQuests.Remove(restart);
                                         User.SendMessage("Restart info removed.");
-                                    }));
+                                    }), true);
                             }
                         }
                     }

--- a/Scripts/Services/New Magincia/Housing Lotto/Core/MaginciaLottoSystem.cs
+++ b/Scripts/Services/New Magincia/Housing Lotto/Core/MaginciaLottoSystem.cs
@@ -407,7 +407,7 @@ namespace Server.Engines.NewMagincia
 
                 if (messages != null)
                 {
-                    BaseGump.SendGump(new NewMaginciaMessageGump(mobile, messages));
+                    BaseGump.SendGump(new NewMaginciaMessageGump(mobile, messages), true);
                 }
             }
         }
@@ -473,8 +473,7 @@ namespace Server.Engines.NewMagincia
 
             if (messages != null)
             {
-                from.CloseGump(typeof(NewMaginciaMessageGump));
-                BaseGump.SendGump(new NewMaginciaMessageGump((PlayerMobile)from, messages));
+                BaseGump.SendGump(new NewMaginciaMessageGump((PlayerMobile)from, messages), true);
             }
             else if (from.Account != null)
             {

--- a/Scripts/Services/New Magincia/Housing Lotto/Gumps/NewMaginciaMessageGump.cs
+++ b/Scripts/Services/New Magincia/Housing Lotto/Gumps/NewMaginciaMessageGump.cs
@@ -35,14 +35,14 @@ namespace Server.Engines.NewMagincia
                     {
                         if (Messages.Count != 0)
                         {
-                            SendGump(new NewMaginciaMessageGump(User, Messages));
+                            SendGump(new NewMaginciaMessageGump(User, Messages), true);
                         }
 
                         break;
                     }
                 case 1:
                     {
-                        SendGump(new NewMaginciaMessageListGump(User, Messages));
+                        SendGump(new NewMaginciaMessageListGump(User, Messages), true);
                         break;
                     }
             }
@@ -146,12 +146,12 @@ namespace Server.Engines.NewMagincia
             {
                 case 0:
                     {
-                        SendGump(new NewMaginciaMessageGump(User, Messages));
+                        SendGump(new NewMaginciaMessageGump(User, Messages), true);
                         break;
                     }
                 case 1:
                     {
-                        SendGump(new NewMaginciaMessageListGump(User, Messages, !Widescreen));
+                        SendGump(new NewMaginciaMessageListGump(User, Messages, !Widescreen), true);
                         break;
                     }
                 default:
@@ -160,7 +160,7 @@ namespace Server.Engines.NewMagincia
 
                         if (id >= 0 && id < Messages.Count)
                         {
-                            SendGump(new NewMaginciaMessageDetailGump(User, Messages, id));
+                            SendGump(new NewMaginciaMessageDetailGump(User, Messages, id), true);
                         }
 
                         break;
@@ -253,13 +253,13 @@ namespace Server.Engines.NewMagincia
             {
                 case 0:
                     {
-                        SendGump(new NewMaginciaMessageGump(User, Messages));
+                        SendGump(new NewMaginciaMessageGump(User, Messages), true);
 
                         break;
                     }
                 case 1:
                     {
-                        SendGump(new NewMaginciaMessageListGump(User, Messages));
+                        SendGump(new NewMaginciaMessageListGump(User, Messages), true);
                     }
                     break;
                 case 2:
@@ -273,7 +273,7 @@ namespace Server.Engines.NewMagincia
 
                         if (messages != null)
                         {
-                            SendGump(new NewMaginciaMessageListGump(User, messages));
+                            SendGump(new NewMaginciaMessageListGump(User, messages), true);
                         }
 
                         break;

--- a/Scripts/Services/New Magincia/Magincia Bazaar/Gumps/PetBrokerGumps.cs
+++ b/Scripts/Services/New Magincia/Magincia Bazaar/Gumps/PetBrokerGumps.cs
@@ -568,7 +568,7 @@ namespace Server.Engines.NewMagincia
                         {
                             Timer.DelayCall(TimeSpan.FromSeconds(1), () =>
                             {
-                                BaseGump.SendGump(new NewAnimalLoreGump((PlayerMobile)from, entry.Pet));
+                                BaseGump.SendGump(new NewAnimalLoreGump((PlayerMobile)from, entry.Pet), true);
                             });
                         }
                     }

--- a/Scripts/Services/PVP Arena System/ArenaDuel.cs
+++ b/Scripts/Services/PVP Arena System/ArenaDuel.cs
@@ -456,7 +456,7 @@ namespace Server.Engines.ArenaSystem
 
             foreach (KeyValuePair<PlayerMobile, PlayerStatsEntry> kvp in GetParticipants())
             {
-                BaseGump.SendGump(new OfferDuelGump(kvp.Key, this, Arena, false, true));
+                BaseGump.SendGump(new OfferDuelGump(kvp.Key, this, Arena, false, true), true);
             }
 
             HasBegun = true;
@@ -842,7 +842,7 @@ namespace Server.Engines.ArenaSystem
         {
             foreach (KeyValuePair<PlayerMobile, PlayerStatsEntry> part in GetParticipants())
             {
-                BaseGump.SendGump(new DuelResultsGump(part.Key, this, winner));
+                BaseGump.SendGump(new DuelResultsGump(part.Key, this, winner), true);
             }
         }
 

--- a/Scripts/Services/PVP Arena System/ArenaStone.cs
+++ b/Scripts/Services/PVP Arena System/ArenaStone.cs
@@ -45,7 +45,7 @@ namespace Server.Engines.ArenaSystem
                     {
                         if (Arena.CurrentDuel.InPreFight)
                         {
-                            BaseGump.SendGump(new OfferDuelGump(pm, Arena.CurrentDuel, Arena, false, true));
+                            BaseGump.SendGump(new OfferDuelGump(pm, Arena.CurrentDuel, Arena, false, true), true);
                         }
                         else
                         {
@@ -62,16 +62,16 @@ namespace Server.Engines.ArenaSystem
 
                             if (booked != null)
                             {
-                                BaseGump.SendGump(new OfferDuelGump(pm, booked, booked.Arena, true));
+                                BaseGump.SendGump(new OfferDuelGump(pm, booked, booked.Arena, true), true);
                             }
                             else
                             {
-                                BaseGump.SendGump(new ArenaStoneGump(pm, Arena));
+                                BaseGump.SendGump(new ArenaStoneGump(pm, Arena), true);
                             }
                         }
                         else
                         {
-                            BaseGump.SendGump(new PendingDuelGump(pm, duel, Arena));
+                            BaseGump.SendGump(new PendingDuelGump(pm, duel, Arena), true);
                         }
                     }
                 }

--- a/Scripts/Services/PVP Arena System/Gumps.cs
+++ b/Scripts/Services/PVP Arena System/Gumps.cs
@@ -127,7 +127,7 @@ namespace Server.Engines.ArenaSystem
                     (m, d) =>
                     {
                         SendGump(m as PlayerMobile);
-                    }));
+                    }), true);
             }
         }
 
@@ -140,7 +140,7 @@ namespace Server.Engines.ArenaSystem
 
             if (gump == null)
             {
-                SendGump(new PVPArenaSystemSetupGump(pm));
+                SendGump(new PVPArenaSystemSetupGump(pm), true);
             }
             else
             {
@@ -297,7 +297,7 @@ namespace Server.Engines.ArenaSystem
             switch (info.ButtonID)
             {
                 case 1: // host
-                    SendGump(new CreateDuelGump(User, Arena));
+                    SendGump(new CreateDuelGump(User, Arena), true);
                     break;
                 case 2: // join
                     List<ArenaDuel> list = Arena.GetPendingPublic();
@@ -306,7 +306,7 @@ namespace Server.Engines.ArenaSystem
                     {
                         if (list.Count < ArenaDuel.MaxEntries)
                         {
-                            SendGump(new JoinDuelGump(User, list, Arena));
+                            SendGump(new JoinDuelGump(User, list, Arena), true);
                         }
                         else
                         {
@@ -319,13 +319,13 @@ namespace Server.Engines.ArenaSystem
                     }
                     break;
                 case 3: // see booked
-                    SendGump(new BookedDuelsGump(User, Arena));
+                    SendGump(new BookedDuelsGump(User, Arena), true);
                     break;
                 case 4: // check stats
-                    SendGump(new IndividualStatsGump(User, Arena, User));
+                    SendGump(new IndividualStatsGump(User, Arena, User), true);
                     break;
                 case 5: // arena rankings
-                    SendGump(new ArenaRankingsGump(User, Arena));
+                    SendGump(new ArenaRankingsGump(User, Arena), true);
                     break;
                 case 6: // ignore invites
                     PlayerStatsEntry entry = PVPArenaSystem.Instance.GetPlayerEntry<PlayerStatsEntry>(User);
@@ -418,7 +418,7 @@ namespace Server.Engines.ArenaSystem
         {
             if (info.ButtonID == 0)
             {
-                SendGump(new ArenaStoneGump(User, Arena));
+                SendGump(new ArenaStoneGump(User, Arena), true);
             }
             else
             {
@@ -501,7 +501,7 @@ namespace Server.Engines.ArenaSystem
                         break;
                     case 50:
                         Arena.AddPendingDuel(Duel);
-                        SendGump(new PendingDuelGump(User, Duel, Arena));
+                        SendGump(new PendingDuelGump(User, Duel, Arena), true);
                         PVPArenaSystem.SendMessage(User, 1115800); // You have created a new duel session.
 
                         PlayerStatsEntry entry = PVPArenaSystem.Instance.GetPlayerEntry<PlayerStatsEntry>(User);
@@ -576,7 +576,7 @@ namespace Server.Engines.ArenaSystem
 
         public override void OnResponse(RelayInfo info)
         {
-            SendGump(new PendingDuelGump(User, Duel, Arena));
+            SendGump(new PendingDuelGump(User, Duel, Arena), true);
         }
     }
 
@@ -707,7 +707,7 @@ namespace Server.Engines.ArenaSystem
                         if (id >= 0 && id < Participants.Count)
                         {
                             Refresh();
-                            SendGump(new IndividualStatsGump(User, Arena, Participants[id]));
+                            SendGump(new IndividualStatsGump(User, Arena, Participants[id]), true);
                         }
                     }
                     else if (info.ButtonID < 200)
@@ -797,10 +797,10 @@ namespace Server.Engines.ArenaSystem
                     }
                     break;
                 case 4:
-                    SendGump(new BookedDuelsGump(User, Arena));
+                    SendGump(new BookedDuelsGump(User, Arena), true);
                     break;
                 case 5:
-                    SendGump(new DuelRulesGump(User, Arena, Duel));
+                    SendGump(new DuelRulesGump(User, Arena, Duel), true);
                     break;
             }
         }
@@ -813,8 +813,7 @@ namespace Server.Engines.ArenaSystem
 
                 if (pm.HasGump(typeof(PendingDuelGump)))
                 {
-                    pm.CloseGump(typeof(PendingDuelGump));
-                    SendGump(new PendingDuelGump(pm, duel, duel.Arena));
+                    SendGump(new PendingDuelGump(pm, duel, duel.Arena), true);
                 }
             }
         }
@@ -878,7 +877,7 @@ namespace Server.Engines.ArenaSystem
                         PVPArenaSystem.SendMessage(from, 1116152); // You have sent the invitation to the player.
                         PVPArenaSystem.SendMessage(pm, 1116212); // You have been invited to a duel.  Select the “OK” button to join this duel.
 
-                        SendGump(new OfferDuelGump(pm, Duel, Arena, true));
+                        SendGump(new OfferDuelGump(pm, Duel, Arena, true), true);
                     }
                 }
                 else
@@ -891,7 +890,7 @@ namespace Server.Engines.ArenaSystem
             {
                 if (from is PlayerMobile mobile)
                 {
-                    SendGump(new PendingDuelGump(mobile, Duel, Arena));
+                    SendGump(new PendingDuelGump(mobile, Duel, Arena), true);
                 }
             }
         }
@@ -982,7 +981,7 @@ namespace Server.Engines.ArenaSystem
         {
             if (info.ButtonID == 0)
             {
-                SendGump(new ArenaStoneGump(User, Arena));
+                SendGump(new ArenaStoneGump(User, Arena), true);
             }
             else
             {
@@ -998,7 +997,7 @@ namespace Server.Engines.ArenaSystem
                     }
                     else
                     {
-                        SendGump(new OfferDuelGump(User, duel, Arena, false));
+                        SendGump(new OfferDuelGump(User, duel, Arena, false), true);
                     }
                 }
             }
@@ -1114,7 +1113,7 @@ namespace Server.Engines.ArenaSystem
 
                         if (list != null && list.Count > 0)
                         {
-                            SendGump(new JoinDuelGump(User, list, Arena));
+                            SendGump(new JoinDuelGump(User, list, Arena), true);
                         }
                     }
                     break;
@@ -1122,7 +1121,7 @@ namespace Server.Engines.ArenaSystem
                     if (Duel.TryAddPlayer(User))
                     {
                         PendingDuelGump.RefreshAll(Duel);
-                        SendGump(new PendingDuelGump(User, Duel, Arena));
+                        SendGump(new PendingDuelGump(User, Duel, Arena), true);
                     }
                     break;
             }
@@ -1207,11 +1206,11 @@ namespace Server.Engines.ArenaSystem
 
                 if (duel == null)
                 {
-                    SendGump(new ArenaStoneGump(User, Arena));
+                    SendGump(new ArenaStoneGump(User, Arena), true);
                 }
                 else
                 {
-                    SendGump(new PendingDuelGump(User, duel, Arena));
+                    SendGump(new PendingDuelGump(User, duel, Arena), true);
                 }
             }
         }
@@ -1358,11 +1357,11 @@ namespace Server.Engines.ArenaSystem
 
                 if (duel == null)
                 {
-                    SendGump(new ArenaStoneGump(User, Arena));
+                    SendGump(new ArenaStoneGump(User, Arena), true);
                 }
                 else
                 {
-                    SendGump(new PendingDuelGump(User, duel, Arena));
+                    SendGump(new PendingDuelGump(User, duel, Arena), true);
                 }
             }
             else if (info.ButtonID == 1)
@@ -1471,11 +1470,11 @@ namespace Server.Engines.ArenaSystem
 
                 if (duel == null)
                 {
-                    SendGump(new ArenaStoneGump(User, Arena));
+                    SendGump(new ArenaStoneGump(User, Arena), true);
                 }
                 else
                 {
-                    SendGump(new PendingDuelGump(User, duel, Arena));
+                    SendGump(new PendingDuelGump(User, duel, Arena), true);
                 }
             }
             else

--- a/Scripts/Services/PVP Arena System/PVPArenaSystem.cs
+++ b/Scripts/Services/PVP Arena System/PVPArenaSystem.cs
@@ -424,7 +424,7 @@ namespace Server.Engines.ArenaSystem
         {
             if (e.Mobile is PlayerMobile pm)
             {
-                BaseGump.SendGump(new PVPArenaSystemSetupGump(pm));
+                BaseGump.SendGump(new PVPArenaSystemSetupGump(pm), true);
             }
         }
 
@@ -450,7 +450,7 @@ namespace Server.Engines.ArenaSystem
                                 ColUtility.Free(a.TeamRankings);
                                 ColUtility.Free(a.SurvivalRankings);
                                 from.SendMessage("Arena stats cleared.");
-                            }));
+                            }), true);
                     }
                 });
         }

--- a/Scripts/Services/Pet Training/Gumps.cs
+++ b/Scripts/Services/Pet Training/Gumps.cs
@@ -459,11 +459,9 @@ namespace Server.Mobiles
                     User.CloseGump(typeof(PetTrainingConfirmationGump));
                     break;
                 case 1: // training tracker
-                    User.CloseGump(typeof(PetTrainingProgressGump));
-
                     Timer.DelayCall(TimeSpan.FromSeconds(.5), () =>
                         {
-                            SendGump(new PetTrainingProgressGump(User, Creature));
+                            SendGump(new PetTrainingProgressGump(User, Creature), true);
                         });
                     break;
                 case 2: // pet training options
@@ -489,9 +487,8 @@ namespace Server.Mobiles
                                     SendGump(new PetTrainingStyleConfirmGump(User, 1157571, 1157572, () =>
                                     {
                                         Refresh();
-                                        User.CloseGump(typeof(PetTrainingOptionsGump));
-                                        SendGump(new PetTrainingOptionsGump(User, Creature));
-                                    }));
+                                        SendGump(new PetTrainingOptionsGump(User, Creature), true);
+                                    }), true);
                                 });
                         }
                         else
@@ -499,8 +496,7 @@ namespace Server.Mobiles
                             Timer.DelayCall(TimeSpan.FromSeconds(.5), () =>
                                 {
                                     Refresh();
-                                    User.CloseGump(typeof(PetTrainingOptionsGump));
-                                    SendGump(new PetTrainingOptionsGump(User, Creature));
+                                    SendGump(new PetTrainingOptionsGump(User, Creature), true);
                                 });
                         }
                     }
@@ -514,7 +510,7 @@ namespace Server.Mobiles
                             {
                                 trainProfile1.EndTraining();
                             }
-                        }));
+                        }), true);
                     break;
                 case 4: // begin training
                     TrainingProfile trainProfile2 = PetTrainingHelper.GetTrainingProfile(Creature, true);
@@ -1127,8 +1123,7 @@ namespace Server.Mobiles
                         if (User.HasGump(typeof(NewAnimalLoreGump)))
                         {
                             Refresh();
-                            User.CloseGump(typeof(PetTrainingPlanningGump));
-                            SendGump(new PetTrainingPlanningGump(User, Creature));
+                            SendGump(new PetTrainingPlanningGump(User, Creature), true);
                         }
                     });
                 return;
@@ -1141,8 +1136,7 @@ namespace Server.Mobiles
                         if (User.HasGump(typeof(NewAnimalLoreGump)))
                         {
                             Refresh();
-                            User.CloseGump(typeof(PetTrainingInfoGump));
-                            SendGump(new PetTrainingInfoGump(User));
+                            SendGump(new PetTrainingInfoGump(User), true);
                         }
                     });
                 return;
@@ -1203,8 +1197,7 @@ namespace Server.Mobiles
                     {
                         if (User.HasGump(typeof(NewAnimalLoreGump)))
                         {
-                            User.CloseGump(typeof(PetTrainingConfirmationGump));
-                            SendGump(new PetTrainingConfirmationGump(User, Creature, tp));
+                            SendGump(new PetTrainingConfirmationGump(User, Creature, tp), true);
                         }
                     });
             }
@@ -1497,7 +1490,7 @@ namespace Server.Mobiles
                         {
                             if (User.HasGump(typeof(NewAnimalLoreGump)))
                             {
-                                SendGump(new PetTrainingOptionsGump(User, Creature));
+                                SendGump(new PetTrainingOptionsGump(User, Creature), true);
                             }
                         });
                     break;
@@ -1660,7 +1653,7 @@ namespace Server.Mobiles
                             () =>
                             {
                                 ResendGumps(profile.HasBegunTraining);
-                            }));
+                            }), true);
                     }
                     else
                     {
@@ -1689,7 +1682,7 @@ namespace Server.Mobiles
                             }
                             else
                             {
-                                SendGump(new PetTrainingPlanningGump(User, Creature));
+                                SendGump(new PetTrainingPlanningGump(User, Creature), true);
                             }
                         }
                     });
@@ -1709,7 +1702,7 @@ namespace Server.Mobiles
                 }
                 else
                 {
-                    SendGump(new NewAnimalLoreGump(User, Creature));
+                    SendGump(new NewAnimalLoreGump(User, Creature), true);
                 }
 
                 if (sendOptions)
@@ -1722,7 +1715,7 @@ namespace Server.Mobiles
                     }
                     else
                     {
-                        SendGump(new PetTrainingOptionsGump(User, Creature));
+                        SendGump(new PetTrainingOptionsGump(User, Creature), true);
                     }
                 }
             });

--- a/Scripts/Services/Pet Training/PetTrainingGate.cs
+++ b/Scripts/Services/Pet Training/PetTrainingGate.cs
@@ -36,7 +36,7 @@ namespace Server.Items
                         if (gump != null)
                             gump.Refresh();
                         else
-                            BaseGump.SendGump(new NewAnimalLoreGump(mobile, bc));
+                            BaseGump.SendGump(new NewAnimalLoreGump(mobile, bc), true);
                     }
                 }
             }

--- a/Scripts/Services/Pet Training/TrainingProfile.cs
+++ b/Scripts/Services/Pet Training/TrainingProfile.cs
@@ -304,7 +304,7 @@ namespace Server.Mobiles
                         {
                             if (mobile.InRange(Creature.Location, 12))
                             {
-                                BaseGump.SendGump(new PetTrainingProgressGump(mobile, Creature));
+                                BaseGump.SendGump(new PetTrainingProgressGump(mobile, Creature), true);
                             }
                         }
 
@@ -350,7 +350,7 @@ namespace Server.Mobiles
 
             if (!(m.FindGump(typeof(PetTrainingProgressGump)) is PetTrainingProgressGump g))
             {
-                BaseGump.SendGump(new PetTrainingProgressGump((PlayerMobile)m, Creature));
+                BaseGump.SendGump(new PetTrainingProgressGump((PlayerMobile)m, Creature), true);
             }
             else
             {

--- a/Scripts/Services/Seasonal Events/SeasonalEventGump.cs
+++ b/Scripts/Services/Seasonal Events/SeasonalEventGump.cs
@@ -9,7 +9,6 @@ namespace Server.Engines.SeasonalEvents
         public SeasonalEventGump(PlayerMobile pm)
             : base(pm, 100, 100)
         {
-            pm.CloseGump(typeof(SeasonalEventGump));
         }
 
         public override void AddGumpLayout()
@@ -95,7 +94,7 @@ namespace Server.Engines.SeasonalEvents
                     }
                     else
                     {
-                        SendGump(new EditEventGump(User, entry));
+                        SendGump(new EditEventGump(User, entry), true);
                     }
                 }
             }
@@ -122,8 +121,6 @@ namespace Server.Engines.SeasonalEvents
         public EditEventGump(PlayerMobile pm, SeasonalEvent entry)
             : base(pm, 100, 100)
         {
-            pm.CloseGump(typeof(EditEventGump));
-
             Entry = entry;
 
             _Month = entry.MonthStart;
@@ -238,11 +235,11 @@ namespace Server.Engines.SeasonalEvents
 
                     Entry.Duration = _Duration;
 
-                    SendGump(new SeasonalEventGump(User));
+                    SendGump(new SeasonalEventGump(User), true);
 
                     return;
                 case 10:
-                    SendGump(new SeasonalEventGump(User));
+                    SendGump(new SeasonalEventGump(User), true);
                     return;
             }
 

--- a/Scripts/Services/Seasonal Events/SeasonalEventSystem.cs
+++ b/Scripts/Services/Seasonal Events/SeasonalEventSystem.cs
@@ -89,7 +89,7 @@ namespace Server.Engines.SeasonalEvents
         {
             if (e.Mobile is PlayerMobile mobile)
             {
-                BaseGump.SendGump(new SeasonalEventGump(mobile));
+                BaseGump.SendGump(new SeasonalEventGump(mobile), true);
             }
         }
 
@@ -160,7 +160,7 @@ namespace Server.Engines.SeasonalEvents
 
                 if (from is PlayerMobile mobile)
                 {
-                    BaseGump.SendGump(new SeasonalEventGump(mobile));
+                    BaseGump.SendGump(new SeasonalEventGump(mobile), true);
                 }
             }
         }

--- a/Scripts/Services/Seasonal Events/TreasuresOfDoom/Mobiles/Elizabeth.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfDoom/Mobiles/Elizabeth.cs
@@ -35,7 +35,7 @@ namespace Server.Engines.TreasuresOfDoom
                     new PageData(3, 1155654, new SelectionEntry(1155653, 5), new SelectionEntry(1155655, 6)),
                     new PageData(4, 1155657, new SelectionEntry(1155652, 5)),
                     new PageData(5, 1155654, new SelectionEntry(1155655, 6)),
-                    new PageData(6, 1155656)));
+                    new PageData(6, 1155656)), true);
             }
         }
 

--- a/Scripts/Services/Seasonal Events/TreasuresOfDoom/Mobiles/Owain.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfDoom/Mobiles/Owain.cs
@@ -37,7 +37,7 @@ namespace Server.Engines.TreasuresOfDoom
                     new PageData(5, 1155674, new SelectionEntry(1155675, 7)),
                     new PageData(6, 1155676, new SelectionEntry(1155677, 8)),
                     new PageData(7, 1155678),
-                    new PageData(8, 1155679)));
+                    new PageData(8, 1155679)), true);
             }
         }
 

--- a/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Items/SterlingSilverRing.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Items/SterlingSilverRing.cs
@@ -26,7 +26,7 @@ namespace Server.Items
         {
             if (IsChildOf(m.Backpack) && m is PlayerMobile mobile && !HasSkillBonus)
             {
-                BaseGump.SendGump(new ApplySkillBonusGump(mobile, SkillBonuses, Skills, 20, 1));
+                BaseGump.SendGump(new ApplySkillBonusGump(mobile, SkillBonuses, Skills, 20, 1), true);
             }
             else
             {

--- a/Scripts/Services/Seasonal Events/TreasuresOfKotlCity/Items/Rewards.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfKotlCity/Items/Rewards.cs
@@ -271,7 +271,7 @@ namespace Server.Items
         {
             if (IsChildOf(m.Backpack) && m is PlayerMobile mobile && !HasSkillBonus)
             {
-                BaseGump.SendGump(new ApplySkillBonusGump(mobile, SkillBonuses, Skills, 20, 2));
+                BaseGump.SendGump(new ApplySkillBonusGump(mobile, SkillBonuses, Skills, 20, 2), true);
             }
             else
             {

--- a/Scripts/Services/Seasonal Events/TreasuresOfSorceresDungeon/Spawner.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfSorceresDungeon/Spawner.cs
@@ -16,7 +16,7 @@ namespace Server.Engines.SorcerersDungeon
                     {
                         if (Instance != null)
                         {
-                            BaseGump.SendGump(new TOSDSpawnerGump(mobile));
+                            BaseGump.SendGump(new TOSDSpawnerGump(mobile), true);
                         }
                         else
                         {

--- a/Scripts/Services/Spawner/Spawner.cs
+++ b/Scripts/Services/Spawner/Spawner.cs
@@ -284,7 +284,7 @@ namespace Server.Mobiles
             }
             else
             {
-                BaseGump.SendGump(new SpawnerGump(from, this));
+                BaseGump.SendGump(new SpawnerGump(from, this), true);
             }
         }
 

--- a/Scripts/Services/Town Cryer/Gumps/CreateCityEntryGump.cs
+++ b/Scripts/Services/Town Cryer/Gumps/CreateCityEntryGump.cs
@@ -93,7 +93,7 @@ namespace Server.Services.TownCryer
 
                     User.SendLocalizedMessage(1158039); // Your entry has been submitted.
 
-                    SendGump(new TownCryerGump(User, Cryer, 0, TownCryerGump.GumpCategory.City));
+                    SendGump(new TownCryerGump(User, Cryer, 0, TownCryerGump.GumpCategory.City), true);
                     return;
                 }
 

--- a/Scripts/Services/Town Cryer/Gumps/CreateEMEntryGump.cs
+++ b/Scripts/Services/Town Cryer/Gumps/CreateEMEntryGump.cs
@@ -99,7 +99,7 @@ namespace Server.Services.TownCryer
 
                     User.SendLocalizedMessage(1158039); // Your entry has been submitted.
 
-                    SendGump(new TownCryerGump(User, Cryer, 0, TownCryerGump.GumpCategory.EventModerator));
+                    SendGump(new TownCryerGump(User, Cryer, 0, TownCryerGump.GumpCategory.EventModerator), true);
                     return;
                 }
 

--- a/Scripts/Services/Town Cryer/Gumps/CreateGuildEntryGump.cs
+++ b/Scripts/Services/Town Cryer/Gumps/CreateGuildEntryGump.cs
@@ -123,7 +123,7 @@ namespace Server.Services.TownCryer
 
                     User.SendLocalizedMessage(1158039); // Your entry has been submitted.
 
-                    SendGump(new TownCryerGump(User, Cryer, 0, TownCryerGump.GumpCategory.Guild));
+                    SendGump(new TownCryerGump(User, Cryer, 0, TownCryerGump.GumpCategory.Guild), true);
                     return;
                 }
 

--- a/Scripts/Services/Town Cryer/Gumps/TownCryerCityGump.cs
+++ b/Scripts/Services/Town Cryer/Gumps/TownCryerCityGump.cs
@@ -33,7 +33,7 @@ namespace Server.Services.TownCryer
                 {
                     Category = TownCryerGump.GumpCategory.City
                 };
-                SendGump(gump);
+                SendGump(gump, true);
             }
         }
     }

--- a/Scripts/Services/Town Cryer/Gumps/TownCryerEMGump.cs
+++ b/Scripts/Services/Town Cryer/Gumps/TownCryerEMGump.cs
@@ -35,7 +35,7 @@ namespace Server.Services.TownCryer
                 {
                     Category = TownCryerGump.GumpCategory.EventModerator
                 };
-                SendGump(gump);
+                SendGump(gump, true);
             }
         }
     }

--- a/Scripts/Services/Town Cryer/Gumps/TownCryerGreetingsGump.cs
+++ b/Scripts/Services/Town Cryer/Gumps/TownCryerGreetingsGump.cs
@@ -162,7 +162,7 @@ namespace Server.Services.TownCryer
                 case 7:
                     if (Entry != null)
                     {
-                        SendGump(new CreateGreetingEntryGump(User, Cryer, Entry));
+                        SendGump(new CreateGreetingEntryGump(User, Cryer, Entry), true);
                     }
                     else
                     {
@@ -170,7 +170,7 @@ namespace Server.Services.TownCryer
                     }
                     break;
                 case 8:
-                    SendGump(new CreateGreetingEntryGump(User, Cryer));
+                    SendGump(new CreateGreetingEntryGump(User, Cryer), true);
                     break;
                 case 9:
                     Refresh();

--- a/Scripts/Services/Town Cryer/Gumps/TownCryerGuildGump.cs
+++ b/Scripts/Services/Town Cryer/Gumps/TownCryerGuildGump.cs
@@ -49,7 +49,7 @@ namespace Server.Services.TownCryer
                 {
                     Category = TownCryerGump.GumpCategory.Guild
                 };
-                SendGump(gump);
+                SendGump(gump, true);
             }
         }
     }

--- a/Scripts/Services/Town Cryer/Gumps/TownCryerGump.cs
+++ b/Scripts/Services/Town Cryer/Gumps/TownCryerGump.cs
@@ -368,7 +368,7 @@ namespace Server.Services.TownCryer
 
                             if (id >= 0 && id < TownCryerSystem.NewsEntries.Count)
                             {
-                                SendGump(new TownCryerNewsGump(User, Cryer, TownCryerSystem.NewsEntries[id]));
+                                SendGump(new TownCryerNewsGump(User, Cryer, TownCryerSystem.NewsEntries[id]), true);
                             }
                         }
                         else if (id < 300)
@@ -377,7 +377,7 @@ namespace Server.Services.TownCryer
 
                             if (id >= 0 && id < TownCryerSystem.ModeratorEntries.Count)
                             {
-                                SendGump(new TownCryerEventModeratorGump(User, Cryer, TownCryerSystem.ModeratorEntries[id]));
+                                SendGump(new TownCryerEventModeratorGump(User, Cryer, TownCryerSystem.ModeratorEntries[id]), true);
                             }
                         }
                         else if (id < 400)
@@ -386,7 +386,7 @@ namespace Server.Services.TownCryer
 
                             if (id >= 0 && id < TownCryerSystem.CityEntries.Count)
                             {
-                                SendGump(new TownCryerCityGump(User, Cryer, TownCryerSystem.CityEntries[id]));
+                                SendGump(new TownCryerCityGump(User, Cryer, TownCryerSystem.CityEntries[id]), true);
                             }
                         }
                         else if (id < 600)
@@ -395,7 +395,7 @@ namespace Server.Services.TownCryer
 
                             if (id >= 0 && id < TownCryerSystem.GuildEntries.Count)
                             {
-                                SendGump(new TownCryerGuildGump(User, Cryer, TownCryerSystem.GuildEntries[id]));
+                                SendGump(new TownCryerGuildGump(User, Cryer, TownCryerSystem.GuildEntries[id]), true);
                             }
                         }
                         else if (id < 3000)
@@ -406,7 +406,7 @@ namespace Server.Services.TownCryer
 
                                 if (id >= 0 && id < TownCryerSystem.ModeratorEntries.Count)
                                 {
-                                    SendGump(new CreateEMEntryGump(User, Cryer, TownCryerSystem.ModeratorEntries[id]));
+                                    SendGump(new CreateEMEntryGump(User, Cryer, TownCryerSystem.ModeratorEntries[id]), true);
                                 }
                             }
                             else
@@ -433,7 +433,7 @@ namespace Server.Services.TownCryer
 
                                     if (id >= 0 && id < TownCryerSystem.CityEntries.Count)
                                     {
-                                        SendGump(new CreateCityEntryGump(User, Cryer, City, TownCryerSystem.CityEntries[id]));
+                                        SendGump(new CreateCityEntryGump(User, Cryer, City, TownCryerSystem.CityEntries[id]), true);
                                     }
                                 }
                                 else
@@ -457,7 +457,7 @@ namespace Server.Services.TownCryer
 
                                 if (id >= 0 && id < TownCryerSystem.GuildEntries.Count)
                                 {
-                                    SendGump(new CreateGuildEntryGump(User, Cryer, TownCryerSystem.GuildEntries[id]));
+                                    SendGump(new CreateGuildEntryGump(User, Cryer, TownCryerSystem.GuildEntries[id]), true);
                                 }
                             }
                             else

--- a/Scripts/Services/Town Cryer/Gumps/TownCryerNewsGump.cs
+++ b/Scripts/Services/Town Cryer/Gumps/TownCryerNewsGump.cs
@@ -53,7 +53,7 @@ namespace Server.Services.TownCryer
                     {
                         Category = TownCryerGump.GumpCategory.News
                     };
-                    SendGump(gump);
+                    SendGump(gump, true);
                     break;
                 case 1:
                     User.LaunchBrowser(Entry.InfoUrl);

--- a/Scripts/Services/Town Cryer/Quests/QuestItems.cs
+++ b/Scripts/Services/Town Cryer/Quests/QuestItems.cs
@@ -142,8 +142,7 @@ namespace Server.Engines.Quests
         {
             if (m is PlayerMobile mobile && IsChildOf(mobile.Backpack))
             {
-                mobile.CloseGump(typeof(InternalGump));
-                BaseGump.SendGump(new InternalGump(mobile));
+                BaseGump.SendGump(new InternalGump(mobile), true);
             }
         }
 
@@ -225,8 +224,7 @@ namespace Server.Engines.Quests
 
             if (m is PlayerMobile mobile && Level == 0)
             {
-                mobile.CloseGump(typeof(InternalGump));
-                BaseGump.SendGump(new InternalGump(mobile, this));
+                BaseGump.SendGump(new InternalGump(mobile, this), true);
             }
         }
 

--- a/Scripts/Services/Town Cryer/TownCryerSystem.cs
+++ b/Scripts/Services/Town Cryer/TownCryerSystem.cs
@@ -164,12 +164,12 @@ namespace Server.Services.TownCryer
 
         public static void CompleteQuest(PlayerMobile pm, BaseQuest quest)
         {
-            BaseGump.SendGump(new TownCrierQuestCompleteGump(pm, quest));
+            BaseGump.SendGump(new TownCrierQuestCompleteGump(pm, quest), true);
         }
 
         public static void CompleteQuest(PlayerMobile pm, object title, object body, int gumpID)
         {
-            BaseGump.SendGump(new TownCrierQuestCompleteGump(pm, title, body, gumpID));
+            BaseGump.SendGump(new TownCrierQuestCompleteGump(pm, title, body, gumpID), true);
         }
 
         public static void OnLogin(LoginEventArgs e)
@@ -180,7 +180,7 @@ namespace Server.Services.TownCryer
                 {
                     if (HasCustomEntries())
                     {
-                        BaseGump.SendGump(new TownCryerGreetingsGump(player, null));
+                        BaseGump.SendGump(new TownCryerGreetingsGump(player, null), true);
                     }
                     else
                     {
@@ -190,7 +190,7 @@ namespace Server.Services.TownCryer
                         {
                             if (m is TownCrier crier)
                             {
-                                BaseGump.SendGump(new TownCryerGreetingsGump(player, crier));
+                                BaseGump.SendGump(new TownCryerGreetingsGump(player, crier), true);
                                 break;
                             }
                         }
@@ -727,7 +727,7 @@ namespace Server.Services.TownCryer
         {
             if (Owner.From is PlayerMobile pm && pm.AccessLevel >= AccessLevel.GameMaster)
             {
-                BaseGump.SendGump(new TownCryerGreetingsGump(pm, Cryer));
+                BaseGump.SendGump(new TownCryerGreetingsGump(pm, Cryer), true);
             }
         }
     }
@@ -749,7 +749,7 @@ namespace Server.Services.TownCryer
             {
                 if (TownCryerSystem.ModeratorEntries.Count < TownCryerSystem.MaxEMEntries)
                 {
-                    BaseGump.SendGump(new CreateEMEntryGump(pm, Cryer));
+                    BaseGump.SendGump(new CreateEMEntryGump(pm, Cryer), true);
                 }
                 else
                 {
@@ -779,7 +779,7 @@ namespace Server.Services.TownCryer
                 {
                     if (TownCryerSystem.CityEntryCount(system.City) < TownCryerSystem.MaxPerCityGoverrnorEntries)
                     {
-                        BaseGump.SendGump(new CreateCityEntryGump(pm, Cryer, system.City));
+                        BaseGump.SendGump(new CreateCityEntryGump(pm, Cryer, system.City), true);
                     }
                     else
                     {
@@ -813,7 +813,7 @@ namespace Server.Services.TownCryer
                     }
                     else
                     {
-                        BaseGump.SendGump(new CreateGuildEntryGump(pm, Cryer));
+                        BaseGump.SendGump(new CreateGuildEntryGump(pm, Cryer), true);
                     }
                 }
                 else

--- a/Scripts/Services/UltimaStore/UltimaStore.cs
+++ b/Scripts/Services/UltimaStore/UltimaStore.cs
@@ -444,7 +444,7 @@ namespace Server.Engines.UOStore
 
             if (!user.HasGump(typeof(UltimaStoreGump)))
             {
-                BaseGump.SendGump(new UltimaStoreGump(user, forcedEntry));
+                BaseGump.SendGump(new UltimaStoreGump(user, forcedEntry), true);
             }
         }
 
@@ -867,7 +867,7 @@ namespace Server.Engines.UOStore
             {
                 if (m is PlayerMobile mobile)
                 {
-                    BaseGump.SendGump(new NoFundsGump(mobile));
+                    BaseGump.SendGump(new NoFundsGump(mobile), true);
                 }
             }
             else

--- a/Scripts/Services/UltimaStore/UltimaStoreGump.cs
+++ b/Scripts/Services/UltimaStore/UltimaStoreGump.cs
@@ -413,7 +413,7 @@ namespace Server.Engines.UOStore
                 case 106:
                     {
                         Refresh();
-                        SendGump(new PromoCodeGump(User, this));
+                        SendGump(new PromoCodeGump(User, this), true);
                         return;
                     }
 
@@ -512,11 +512,11 @@ namespace Server.Engines.UOStore
 
                         if (total <= UltimaStore.GetCurrency(User, true))
                         {
-                            SendGump(new ConfirmPurchaseGump(User));
+                            SendGump(new ConfirmPurchaseGump(User), true);
                         }
                         else
                         {
-                            SendGump(new NoFundsGump(User));
+                            SendGump(new NoFundsGump(User), true);
                         }
 
                         return;
@@ -549,7 +549,7 @@ namespace Server.Engines.UOStore
 
                 if (Cart == null || Cart.Count < 10)
                 {
-                    SendGump(new ConfirmCartGump(User, this, entry));
+                    SendGump(new ConfirmCartGump(User, this, entry), true);
                     return;
                 }
 
@@ -561,7 +561,7 @@ namespace Server.Engines.UOStore
 
                 StoreEntry entry = UltimaStore.Entries[id - 2000];
 
-                SendGump(new ConfirmCartGump(User, this, entry, Cart != null && Cart.ContainsKey(entry) ? Cart[entry] : 0));
+                SendGump(new ConfirmCartGump(User, this, entry, Cart != null && Cart.ContainsKey(entry) ? Cart[entry] : 0), true);
                 return;
             }
             else if (id < 4000) // Remove From Cart
@@ -593,8 +593,6 @@ namespace Server.Engines.UOStore
             Gump = gump;
             Entry = entry;
             Current = current;
-
-            pm.CloseGump(typeof(ConfirmCartGump));
         }
 
         public override void AddGumpLayout()
@@ -681,7 +679,6 @@ namespace Server.Engines.UOStore
         public ConfirmPurchaseGump(PlayerMobile pm)
             : base(pm, 150, 150)
         {
-            pm.CloseGump(typeof(ConfirmPurchaseGump));
         }
 
         public override void AddGumpLayout()
@@ -731,7 +728,6 @@ namespace Server.Engines.UOStore
         public NoFundsGump(PlayerMobile pm)
             : base(pm, 150, 150)
         {
-            pm.CloseGump(typeof(NoFundsGump));
         }
 
         public override void AddGumpLayout()
@@ -791,8 +787,6 @@ namespace Server.Engines.UOStore
             : base(pm, 10, 10)
         {
             Gump = gump;
-
-            pm.CloseGump(typeof(PromoCodeGump));
         }
 
         public override void AddGumpLayout()

--- a/Scripts/Services/Vendor Searching/VendorSearch.cs
+++ b/Scripts/Services/Vendor Searching/VendorSearch.cs
@@ -1354,8 +1354,7 @@ namespace Server.Engines.VendorSearching
         {
             if (VendorSearch.CanSearch(Player))
             {
-                Player.CloseGump(typeof(VendorSearchGump));
-                BaseGump.SendGump(new VendorSearchGump(Player));
+                BaseGump.SendGump(new VendorSearchGump(Player), true);
             }
         }
     }

--- a/Scripts/Services/Vendor Searching/VendorSearchGump.cs
+++ b/Scripts/Services/Vendor Searching/VendorSearchGump.cs
@@ -243,7 +243,7 @@ namespace Server.Engines.VendorSearching
 
                         if (Criteria.IsEmpty)
                         {
-                            SendGump(new VendorSearchGump(User, 1154586)); // Please select some criteria to search for.
+                            SendGump(new VendorSearchGump(User, 1154586), true); // Please select some criteria to search for.
                         }
                         else
                         {
@@ -255,19 +255,19 @@ namespace Server.Engines.VendorSearching
 
                                 if (results == null || results.Count == 0)
                                 {
-                                    SendGump(new VendorSearchGump(User, 1154587)); // No items matched your search.                                     
+                                    SendGump(new VendorSearchGump(User, 1154587), true); // No items matched your search.                                     
                                 }
                                 else
                                 {
                                     Refresh();
-                                    SendGump(new SearchResultsGump(User, results));
+                                    SendGump(new SearchResultsGump(User, results), true);
                                 }
                             });
 
                             resultsTask.Start();
                             pollingTimer.Start();
 
-                            SendGump(new SearchWaitGump(User, pollingTimer));
+                            SendGump(new SearchWaitGump(User, pollingTimer), true);
                         }
                         break;
                     }
@@ -349,7 +349,7 @@ namespace Server.Engines.VendorSearching
                     {
                         if (Criteria.Details.Count >= 20)
                         {
-                            SendGump(new VendorSearchGump(User, 1154681)); // You may not add any more search criteria items.
+                            SendGump(new VendorSearchGump(User, 1154681), true); // You may not add any more search criteria items.
                         }
 
                         var criteria = SearchCriteriaCategory.AllCategories.SelectMany(x => x.Criteria, (x, c) => new { x.Category, c.Object, c.Cliloc, c.PropCliloc }).ToList()[info.ButtonID - 50];

--- a/Scripts/Services/Vendor Searching/VendorSearchMap.cs
+++ b/Scripts/Services/Vendor Searching/VendorSearchMap.cs
@@ -315,7 +315,7 @@ namespace Server.Items
             {
                 if (VendorMap.IsSale())
                 {
-                    BaseGump.SendGump(new ConfirmTeleportGump(VendorMap, (PlayerMobile)Clicker));
+                    BaseGump.SendGump(new ConfirmTeleportGump(VendorMap, (PlayerMobile)Clicker), true);
                 }
                 else
                 {
@@ -340,7 +340,7 @@ namespace Server.Items
             {
                 if (Clicker is PlayerMobile mobile)
                 {
-                    BaseGump.SendGump(new ConfirmTeleportGump(VendorMap, mobile));
+                    BaseGump.SendGump(new ConfirmTeleportGump(VendorMap, mobile), true);
                 }
             }
         }

--- a/Scripts/Services/VeteranRewards/RewardSystem.cs
+++ b/Scripts/Services/VeteranRewards/RewardSystem.cs
@@ -628,7 +628,7 @@ namespace Server.Engines.VeteranRewards
 
             if (e.Mobile is PlayerMobile && !((PlayerMobile)e.Mobile).HasStatReward && HasHalfLevel(e.Mobile))
             {
-                Gumps.BaseGump.SendGump(new StatRewardGump((PlayerMobile)e.Mobile));
+                Gumps.BaseGump.SendGump(new StatRewardGump((PlayerMobile)e.Mobile), true);
             }
 
             if (cur < max)

--- a/Scripts/Services/ViceVsVirtue/VvVBattle.cs
+++ b/Scripts/Services/ViceVsVirtue/VvVBattle.cs
@@ -1047,10 +1047,7 @@ namespace Server.Engines.VvV
         {
             if (m is PlayerMobile mobile && OnGoing)
             {
-                if (mobile.HasGump(typeof(VvVBattleStatusGump)))
-                    mobile.CloseGump(typeof(VvVBattleStatusGump));
-
-                BaseGump.SendGump(new VvVBattleStatusGump(mobile, this));
+                BaseGump.SendGump(new VvVBattleStatusGump(mobile, this), true);
             }
         }
 
@@ -1058,7 +1055,7 @@ namespace Server.Engines.VvV
         {
             if (m is PlayerMobile mobile && OnGoing)
             {
-                BaseGump.SendGump(new VvVBattleStatusGump(mobile, this));
+                BaseGump.SendGump(new VvVBattleStatusGump(mobile, this), true);
             }
         }
 
@@ -1079,7 +1076,7 @@ namespace Server.Engines.VvV
 
                     if (g == null)
                     {
-                        BaseGump.SendGump(new VvVBattleStatusGump(m, this));
+                        BaseGump.SendGump(new VvVBattleStatusGump(m, this), true);
                     }
                     else
                     {

--- a/Scripts/Skills/AnimalLore.cs
+++ b/Scripts/Skills/AnimalLore.cs
@@ -37,7 +37,7 @@ namespace Server.SkillHandlers
                 {
                     Timer.DelayCall(TimeSpan.FromSeconds(1), () =>
                         {
-                            BaseGump.SendGump(new NewAnimalLoreGump((PlayerMobile)from, c));
+                            BaseGump.SendGump(new NewAnimalLoreGump((PlayerMobile)from, c), true);
                         });
                 }
             }


### PR DESCRIPTION
Propose adding a closeOtherInstances bool to SendGump. 

Previously you had to make a call to close other gumps inside the gump itself as one way to prevent duplicated:

OLD WAY EXAMPLE 1
![code1](https://user-images.githubusercontent.com/20760229/190228234-505a0f7e-4d98-4ea1-a36c-b8192bc91109.png)
-----------------------------------------------------------------------

Now you simply set true or false in the SendGump if you want to auto close any existing or not. This removes the need from coding it inside the gump itself.

NEW WAY EXAMPLE 1
![code2](https://user-images.githubusercontent.com/20760229/190228252-0b87d6eb-4d0d-46b0-b3b9-c837e1b7002c.png)
------------------------------------------------------------------------
Another way was to use two calls right away. One to close any gumps that may be open then a call to open the gump.

OLD WAY EXAMPLE 2
![code3](https://user-images.githubusercontent.com/20760229/190228423-f9cd166a-a695-4316-b118-61beb9df62e2.png)
-------------------------------------------------------------------------
NEW WAY EXAMPLE 2 - now we just do one call but have the true/false bool called as well. The old CloseGump can be removed from the code here.
![code4](https://user-images.githubusercontent.com/20760229/190228516-d6f34e81-76e3-4b69-b554-184abe0caa0b.png)
-----------------------------------------------------------------------------
For now everything was marked true - to close when a new instance is opened of that menu but there may be menus that you are allowed to have multiple open or staff menus where it would be easier to have two instances open.

I will be testing this for a while before potentially pushing it or not.