### PR TITLE
Avoid zero-length array allocations

### DIFF
--- a/Scripts/Abilities/SlayerGroup.cs
+++ b/Scripts/Abilities/SlayerGroup.cs
@@ -149,7 +149,7 @@ namespace Server.Items
 					typeof(CursedMetallicKnight), typeof(CursedMetallicMage)
                 );
 
-            undead.Entries = new SlayerEntry[0];
+            undead.Entries = Array.Empty<SlayerEntry>();
 
             fey.Opposition = new[]
                 {
@@ -175,7 +175,7 @@ namespace Server.Items
                     typeof(FeralTreefellow)
                 );
 
-            fey.Entries = new SlayerEntry[0];
+            fey.Entries = Array.Empty<SlayerEntry>();
 
             elemental.Opposition = new[]
                 {

--- a/Scripts/Accounting/Account.cs
+++ b/Scripts/Accounting/Account.cs
@@ -200,8 +200,8 @@ namespace Server.Accounting
 
             m_Mobiles = new Mobile[7];
 
-            IPRestrictions = new string[0];
-            LoginIPs = new IPAddress[0];
+            IPRestrictions = Array.Empty<string>();
+            LoginIPs = Array.Empty<IPAddress>();
 
             Accounts.Add(this);
         }
@@ -898,7 +898,7 @@ namespace Server.Accounting
             }
             else
             {
-                stringList = new string[0];
+                stringList = Array.Empty<string>();
             }
 
             return stringList;
@@ -953,7 +953,7 @@ namespace Server.Accounting
             }
             else
             {
-                list = new IPAddress[0];
+                list = Array.Empty<IPAddress>();
             }
 
             return list;

--- a/Scripts/Commands/Batch.cs
+++ b/Scripts/Commands/Batch.cs
@@ -227,7 +227,7 @@ namespace Server.Commands
             {
                 argString = "";
                 command = m_Command.ToLower();
-                args = new string[0];
+                args = Array.Empty<string>();
             }
         }
     }

--- a/Scripts/Commands/Decorate.cs
+++ b/Scripts/Commands/Decorate.cs
@@ -1274,7 +1274,7 @@ namespace Server.Commands
             }
         }
 
-        private static readonly string[] m_EmptyParams = new string[0];
+        private static readonly string[] m_EmptyParams = Array.Empty<string>();
 
         public static DecorationList Read(StreamReader ip)
         {

--- a/Scripts/Commands/DecorateDelete.cs
+++ b/Scripts/Commands/DecorateDelete.cs
@@ -1089,7 +1089,7 @@ namespace Server.Commands
             }
         }
 
-        private static readonly string[] m_EmptyParams = new string[0];
+        private static readonly string[] m_EmptyParams = Array.Empty<string>();
 
         public static DecorationListDelete Read(StreamReader ip)
         {

--- a/Scripts/Commands/GenCategorization.cs
+++ b/Scripts/Commands/GenCategorization.cs
@@ -291,7 +291,7 @@ namespace Server.Commands
         public CategoryEntry()
         {
             m_Title = "(empty)";
-            m_Matches = new Type[0];
+            m_Matches = Type.EmptyTypes;
             m_SubCategories = Array.Empty<CategoryEntry>();
             m_Matched = new ArrayList();
         }
@@ -301,7 +301,7 @@ namespace Server.Commands
             m_Parent = parent;
             m_Title = title;
             m_SubCategories = subCats;
-            m_Matches = new Type[0];
+            m_Matches = Type.EmptyTypes;
             m_Matched = new ArrayList();
         }
 

--- a/Scripts/Commands/GenCategorization.cs
+++ b/Scripts/Commands/GenCategorization.cs
@@ -292,7 +292,7 @@ namespace Server.Commands
         {
             m_Title = "(empty)";
             m_Matches = new Type[0];
-            m_SubCategories = new CategoryEntry[0];
+            m_SubCategories = Array.Empty<CategoryEntry>();
             m_Matched = new ArrayList();
         }
 

--- a/Scripts/Gumps/AdminGump.cs
+++ b/Scripts/Gumps/AdminGump.cs
@@ -1639,7 +1639,7 @@ namespace Server.Gumps
                 if (ips.Length != 0 && AccountHandler.IPTable.ContainsKey(ips[0]))
                     --AccountHandler.IPTable[ips[0]];
 
-                a.LoginIPs = new IPAddress[0];
+                a.LoginIPs = Array.Empty<IPAddress>();
 
                 notice = "All addresses in the list have been removed.";
             }

--- a/Scripts/Gumps/CategorizedAddGump.cs
+++ b/Scripts/Gumps/CategorizedAddGump.cs
@@ -73,7 +73,7 @@ namespace Server.Gumps
 
             if (xml.IsEmptyElement)
             {
-                m_Nodes = new CAGNode[0];
+                m_Nodes = Array.Empty<CAGNode>();
             }
             else
             {
@@ -99,7 +99,7 @@ namespace Server.Gumps
         private CAGCategory()
         {
             m_Title = "no data";
-            m_Nodes = new CAGNode[0];
+            m_Nodes = Array.Empty<CAGNode>();
         }
 
         public static CAGCategory Root

--- a/Scripts/Gumps/Go/ParentNode.cs
+++ b/Scripts/Gumps/Go/ParentNode.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Xml;
 
@@ -27,7 +28,7 @@ namespace Server.Gumps
 
             if (xml.IsEmptyElement)
             {
-                m_Children = new object[0];
+                m_Children = Array.Empty<object>();
             }
             else
             {

--- a/Scripts/Gumps/PlayerVendorGumps.cs
+++ b/Scripts/Gumps/PlayerVendorGumps.cs
@@ -390,7 +390,7 @@ namespace Server.Gumps
 
                 try
                 {
-                    ConstructorInfo ctor = Type.GetConstructor(new Type[0]);
+                    ConstructorInfo ctor = Type.GetConstructor(Type.EmptyTypes);
                     if (ctor != null)
                         i = ctor.Invoke(null) as Item;
                 }

--- a/Scripts/Gumps/Props/PropsGump.cs
+++ b/Scripts/Gumps/Props/PropsGump.cs
@@ -553,14 +553,14 @@ namespace Server.Gumps
 
             if (attrs.Length == 0)
             {
-                return new string[0];
+                return Array.Empty<string>();
             }
 
             CustomEnumAttribute ce = attrs[0] as CustomEnumAttribute;
 
             if (ce == null)
             {
-                return new string[0];
+                return Array.Empty<string>();
             }
 
             return ce.Names;

--- a/Scripts/Gumps/Props/SetObjectGump.cs
+++ b/Scripts/Gumps/Props/SetObjectGump.cs
@@ -264,7 +264,7 @@ namespace Server.Gumps
                         shouldSet = false;
                         m_Mobile.SendMessage("No object with that serial was found.");
                     }
-                    else if (!m_Type.IsAssignableFrom(toSet.GetType()))
+                    else if (!m_Type.IsInstanceOfType(toSet))
                     {
                         toSet = null;
                         shouldSet = false;

--- a/Scripts/Gumps/Props/SetObjectTarget.cs
+++ b/Scripts/Gumps/Props/SetObjectTarget.cs
@@ -40,7 +40,7 @@ namespace Server.Gumps
                 else if ((m_Type == typeof(BaseAddon) || m_Type.IsAssignableFrom(typeof(BaseAddon))) && targeted is AddonComponent component)
                     targeted = component.Addon;
 
-                if (m_Type.IsAssignableFrom(targeted.GetType()))
+                if (m_Type.IsInstanceOfType(targeted))
                 {
                     CommandLogging.LogChangeProperty(m_Mobile, m_Object, m_Property.Name, targeted.ToString());
                     m_Property.SetValue(m_Object, targeted, null);

--- a/Scripts/Items/Addons/BallotBox.cs
+++ b/Scripts/Items/Addons/BallotBox.cs
@@ -17,7 +17,7 @@ namespace Server.Items
         public BallotBox()
             : base(0x9A8)
         {
-            m_Topic = new string[0];
+            m_Topic = Array.Empty<string>();
             m_Yes = new List<Mobile>();
             m_No = new List<Mobile>();
         }
@@ -33,7 +33,7 @@ namespace Server.Items
         public List<Mobile> No => m_No;
         public void ClearTopic()
         {
-            m_Topic = new string[0];
+            m_Topic = Array.Empty<string>();
 
             ClearVotes();
         }

--- a/Scripts/Items/Books/BaseBook.cs
+++ b/Scripts/Items/Books/BaseBook.cs
@@ -17,7 +17,7 @@ namespace Server.Items
 
         public BookPageInfo()
         {
-            m_Lines = new string[0];
+            m_Lines = Array.Empty<string>();
         }
 
         public BookPageInfo(params string[] lines)
@@ -129,7 +129,7 @@ namespace Server.Items
 
             if (content == null)
             {
-                m_Pages = new BookPageInfo[0];
+                m_Pages = Array.Empty<BookPageInfo>();
             }
             else
             {
@@ -297,7 +297,7 @@ namespace Server.Items
                             if (content != null)
                                 m_Pages = content.Copy();
                             else
-                                m_Pages = new BookPageInfo[0];
+                                m_Pages = Array.Empty<BookPageInfo>();
                         }
 
                         break;
@@ -323,7 +323,7 @@ namespace Server.Items
                             if (content != null)
                                 m_Pages = content.Copy();
                             else
-                                m_Pages = new BookPageInfo[0];
+                                m_Pages = Array.Empty<BookPageInfo>();
                         }
 
                         break;

--- a/Scripts/Items/Consumables/SkinTingeingTincture.cs
+++ b/Scripts/Items/Consumables/SkinTingeingTincture.cs
@@ -1,3 +1,4 @@
+using System;
 using Server.Gumps;
 using Server.Mobiles;
 
@@ -168,7 +169,7 @@ namespace Server.Items
                     return GargoyleSkinHues;
                 }
 
-                return new int[0];
+                return Array.Empty<int>();
             }
 
             private static int[] _HumanSkinHues;

--- a/Scripts/Items/Internal/FlipableAttribute.cs
+++ b/Scripts/Items/Internal/FlipableAttribute.cs
@@ -78,7 +78,7 @@ namespace Server.Items
                 {
                     MethodInfo flipMethod = item.GetType().GetMethod("Flip", Type.EmptyTypes);
                     if (flipMethod != null)
-                        flipMethod.Invoke(item, new object[0]);
+                        flipMethod.Invoke(item, Array.Empty<object>());
                 }
                 catch (Exception e)
                 {

--- a/Scripts/Items/Tools/DyeTubs/DyeTub.cs
+++ b/Scripts/Items/Tools/DyeTubs/DyeTub.cs
@@ -63,7 +63,7 @@ namespace Server.Items
         public virtual int TargetMessage => 500859;  // Select the clothing to dye.        
         public virtual int FailMessage => 1042083;  // You can not dye that.
 
-        public virtual Type[] ForcedDyables => new Type[0];
+        public virtual Type[] ForcedDyables => Type.EmptyTypes;
 
         public virtual bool CanForceDye(Item item)
         {

--- a/Scripts/Misc/AOS.cs
+++ b/Scripts/Misc/AOS.cs
@@ -2160,7 +2160,7 @@ namespace Server
         private uint m_Names;
         private int[] m_Values;
 
-        private static readonly int[] m_Empty = new int[0];
+        private static readonly int[] m_Empty = Array.Empty<int>();
 
         public bool IsEmpty => m_Names == 0;
         public Item Owner => m_Owner;

--- a/Scripts/Misc/NameVerification.cs
+++ b/Scripts/Misc/NameVerification.cs
@@ -1,3 +1,4 @@
+using System;
 using Server.Commands;
 
 namespace Server.Misc
@@ -8,7 +9,7 @@ namespace Server.Misc
         {
             ' ', '-', '.', '\''
         };
-        public static readonly char[] Empty = new char[0];
+        public static readonly char[] Empty = Array.Empty<char>();
         private static readonly string[] m_StartDisallowed =
         {
             "seer",

--- a/Scripts/Misc/ShardPoller.cs
+++ b/Scripts/Misc/ShardPoller.cs
@@ -22,8 +22,8 @@ namespace Server.Misc
             : base(0x1047)
         {
             m_Duration = TimeSpan.FromHours(24.0);
-            m_Options = new ShardPollOption[0];
-            m_Addresses = new IPAddress[0];
+            m_Options = Array.Empty<ShardPollOption>();
+            m_Addresses = Array.Empty<IPAddress>();
 
             Movable = false;
         }
@@ -266,7 +266,7 @@ namespace Server.Misc
         {
             m_Title = title;
             m_LineBreaks = GetBreaks(m_Title);
-            m_Voters = new IPAddress[0];
+            m_Voters = Array.Empty<IPAddress>();
         }
 
         public ShardPollOption(GenericReader reader)

--- a/Scripts/Misc/ShrinkTable.cs
+++ b/Scripts/Misc/ShrinkTable.cs
@@ -52,7 +52,7 @@ namespace Server
 
             if (!File.Exists(path))
             {
-                m_Table = new int[0];
+                m_Table = Array.Empty<int>();
                 return;
             }
 

--- a/Scripts/Misc/WebStatus.cs
+++ b/Scripts/Misc/WebStatus.cs
@@ -16,7 +16,7 @@ namespace Server.Misc
         private static HttpListener _Listener;
 
         private static string _StatusPage = string.Empty;
-        private static byte[] _StatusBuffer = new byte[0];
+        private static byte[] _StatusBuffer = Array.Empty<byte>();
 
         private static readonly object _StatusLock = new object();
 

--- a/Scripts/Mobiles/NPCs/Banker.cs
+++ b/Scripts/Mobiles/NPCs/Banker.cs
@@ -81,7 +81,7 @@ namespace Server.Mobiles
 
                 if (balance > int.MaxValue)
                 {
-                    gold = checks = new Item[0];
+                    gold = checks = Array.Empty<Item>();
                     return int.MaxValue;
                 }
             }
@@ -121,7 +121,7 @@ namespace Server.Mobiles
             }
             else
             {
-                gold = checks = new Item[0];
+                gold = checks = Array.Empty<Item>();
             }
 
             return (int)Math.Max(0, Math.Min(int.MaxValue, balance));

--- a/Scripts/Mobiles/NPCs/BaseTurnInMobile.cs
+++ b/Scripts/Mobiles/NPCs/BaseTurnInMobile.cs
@@ -82,7 +82,7 @@ namespace Server.Mobiles
 
                 m_Buttons = m_Vendor.FindRedeemableItems(m_Mobile);
 
-                if (m_Buttons.Count() > 0)
+                if (m_Buttons.Any())
                     Enabled = true;
                 else
                     Enabled = false;
@@ -171,7 +171,7 @@ namespace Server.Mobiles
 
             IEnumerable<ItemTileButtonInfo> buttons = m_Collector.FindRedeemableItems(pm);
 
-            if (buttons != null && buttons.Count() > 0)
+            if (buttons != null && buttons.Any())
                 pm.SendGump(new TurnInGump(m_Collector, buttons));
         }
 

--- a/Scripts/Multis/Houses/HouseFoundation.cs
+++ b/Scripts/Multis/Houses/HouseFoundation.cs
@@ -1891,7 +1891,7 @@ namespace Server.Multis
         {
             Foundation = foundation;
             Components = components;
-            Fixtures = new MultiTileEntry[0];
+            Fixtures = Array.Empty<MultiTileEntry>();
         }
 
         public DesignState(DesignState toCopy)
@@ -2009,7 +2009,7 @@ namespace Server.Multis
                 Components.Add(mte.m_ItemID, mte.m_OffsetX, mte.m_OffsetY, mte.m_OffsetZ);
             }
 
-            Fixtures = new MultiTileEntry[0];
+            Fixtures = Array.Empty<MultiTileEntry>();
         }
 
         public void MeltFixtures()

--- a/Scripts/Quests/WitchApprentice/Conversations.cs
+++ b/Scripts/Quests/WitchApprentice/Conversations.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Server.Engines.Quests.Hag
 {
     public class DontOfferConversation : QuestConversation
@@ -254,7 +256,7 @@ namespace Server.Engines.Quests.Hag
                 1055009;
         public override void OnRead()
         {
-            System.AddObjective(new FindIngredientObjective(new Ingredient[0]));
+            System.AddObjective(new FindIngredientObjective(Array.Empty<Ingredient>()));
         }
     }
 

--- a/Scripts/Services/Harvest/Fishing/Fishing.cs
+++ b/Scripts/Services/Harvest/Fishing/Fishing.cs
@@ -64,7 +64,7 @@ namespace Server.Engines.Harvest
 
                 // The fishing
                 EffectActions = new[] { 6 },
-                EffectSounds = new int[0],
+                EffectSounds = Array.Empty<int>(),
                 EffectCounts = new[] { 1 },
                 EffectDelay = TimeSpan.Zero,
                 EffectSoundDelay = TimeSpan.FromSeconds(8.0),

--- a/Scripts/Services/MondainsLegacyQuests/Helpers/QuestHelper.cs
+++ b/Scripts/Services/MondainsLegacyQuests/Helpers/QuestHelper.cs
@@ -554,7 +554,7 @@ namespace Server.Engines.Quests
 
                     if (item.QuestItem || !questItem)
                     {
-                        if (itemType.IsAssignableFrom(item.GetType()))
+                        if (itemType.IsInstanceOfType(item))
                         {
                             deleted += item.Amount;
 
@@ -680,7 +680,7 @@ namespace Server.Engines.Quests
                     {
                         ObtainObjective obtain = (ObtainObjective)quest.Objectives[j];
 
-                        if (obtain.Obtain != null && obtain.Obtain.IsAssignableFrom(item.GetType()))
+                        if (obtain.Obtain != null && obtain.Obtain.IsInstanceOfType(item))
                         {
                             obtain.CurProgress -= item.Amount;
                             item.QuestItem = false;
@@ -692,7 +692,7 @@ namespace Server.Engines.Quests
                     {
                         DeliverObjective deliver = (DeliverObjective)quest.Objectives[j];
 
-                        if (deliver.Delivery != null && deliver.Delivery.IsAssignableFrom(item.GetType()))
+                        if (deliver.Delivery != null && deliver.Delivery.IsInstanceOfType(item))
                         {
                             from.SendLocalizedMessage(1074813);  // You have failed to complete your delivery.
                             DeleteItems(from, deliver.Delivery, deliver.MaxProgress, false);

--- a/Scripts/Services/MondainsLegacyQuests/QuestObjectives.cs
+++ b/Scripts/Services/MondainsLegacyQuests/QuestObjectives.cs
@@ -216,7 +216,7 @@ namespace Server.Engines.Quests
             {
                 Type type = Creatures[index];
 
-                if (type.IsAssignableFrom(mob.GetType()))
+                if (type.IsInstanceOfType(mob))
                 {
                     if (Region != null && !mob.Region.IsPartOf(Region))
                     {
@@ -333,7 +333,7 @@ namespace Server.Engines.Quests
             if (m_Obtain == null)
                 return false;
 
-            if (m_Obtain.IsAssignableFrom(item.GetType()))
+            if (m_Obtain.IsInstanceOfType(item))
                 return true;
 
             return false;

--- a/Scripts/Services/RemoteAdmin/PacketHandlers.cs
+++ b/Scripts/Services/RemoteAdmin/PacketHandlers.cs
@@ -210,7 +210,7 @@ namespace Server.RemoteAdmin
                 if (list.Count > 0)
                     a.IPRestrictions = (string[])list.ToArray(typeof(string));
                 else
-                    a.IPRestrictions = new string[0];
+                    a.IPRestrictions = Array.Empty<string>();
 
                 if (invalid)
                     state.Send(new MessageBoxMessage("Warning: one or more of the IP Restrictions you specified was not valid.", "Invalid IP Restriction"));

--- a/Scripts/Services/TestCenter.cs
+++ b/Scripts/Services/TestCenter.cs
@@ -1009,7 +1009,7 @@ namespace Server.Misc
                     case 3: // Command list
                         {
                             sender.Mobile.SendAsciiMessage(0x482, "The command prefix is \"{0}\"", CommandSystem.Prefix);
-                            CommandHandlers.Help_OnCommand(new CommandEventArgs(sender.Mobile, "help", "", new string[0]));
+                            CommandHandlers.Help_OnCommand(new CommandEventArgs(sender.Mobile, "help", "", Array.Empty<string>()));
 
                             break;
                         }

--- a/Scripts/Services/XmlSpawner/XmlPropsGumps/XmlPropsGump.cs
+++ b/Scripts/Services/XmlSpawner/XmlPropsGumps/XmlPropsGump.cs
@@ -324,12 +324,12 @@ namespace Server.Gumps
             object[] attrs = type.GetCustomAttributes(typeofCustomEnum, false);
 
             if (attrs.Length == 0)
-                return new string[0];
+                return Array.Empty<string>();
 
             CustomEnumAttribute ce = attrs[0] as CustomEnumAttribute;
 
             if (ce == null)
-                return new string[0];
+                return Array.Empty<string>();
 
             return ce.Names;
         }

--- a/Scripts/Services/XmlSpawner/XmlSpawner2.cs
+++ b/Scripts/Services/XmlSpawner/XmlSpawner2.cs
@@ -2877,7 +2877,7 @@ namespace Server.Mobiles
                             }
 
                             // try loading the new spawn specifications first
-                            SpawnObject[] Spawns = new SpawnObject[0];
+                            SpawnObject[] Spawns = Array.Empty<SpawnObject>();
                             bool havenew = true;
                             valid_entry = true;
                             try
@@ -6522,7 +6522,7 @@ namespace Server.Mobiles
                             }
 
                             // try loading the new spawn specifications first
-                            SpawnObject[] Spawns = new SpawnObject[0];
+                            SpawnObject[] Spawns = Array.Empty<SpawnObject>();
                             bool havenew = true;
                             try
                             {
@@ -7874,7 +7874,7 @@ namespace Server.Mobiles
             SpawnRange = defSpawnRange;
 
             InitSpawn(0, 0, m_Width, m_Height, string.Empty, 0, defMinDelay, defMaxDelay, defDuration,
-                defProximityRange, defProximityTriggerSound, defAmount, defTeam, defHomeRange, defRelativeHome, new SpawnObject[0], defMinRefractory, defMaxRefractory,
+                defProximityRange, defProximityTriggerSound, defAmount, defTeam, defHomeRange, defRelativeHome, Array.Empty<SpawnObject>(), defMinRefractory, defMaxRefractory,
                 defTODStart, defTODEnd, null, null, null, null, null, null, null, null, null, defTriggerProbability, null, defIsGroup, defTODMode,
                 defKillReset, false, -1, null, false, false, false, null, defDespawnTime, null, false, null);
         }

--- a/Scripts/Services/XmlSpawner/XmlUtils/XmlAdd.cs
+++ b/Scripts/Services/XmlSpawner/XmlUtils/XmlAdd.cs
@@ -1029,7 +1029,7 @@ namespace Server.Mobiles
 
                 XmlSpawner spawner = new XmlSpawner(SpawnId, from.Location.X, from.Location.Y, 0, 0, sname, maxcount,
                     defs.MinDelay, defs.MaxDelay, defs.Duration, defs.ProximityRange, defs.ProximitySound, 1,
-                    defs.Team, defs.HomeRange, defs.HomeRangeIsRelative, new XmlSpawner.SpawnObject[0], defs.RefractMin, defs.RefractMax,
+                    defs.Team, defs.HomeRange, defs.HomeRangeIsRelative, Array.Empty<XmlSpawner.SpawnObject>(), defs.RefractMin, defs.RefractMax,
                     defs.TODStart, defs.TODEnd, null, defs.TriggerObjectProp, defs.ProximityMsg, defs.TriggerOnCarried, defs.NoTriggerOnCarried,
                     defs.SpeechTrigger, null, null, defs.PlayerTriggerProp, defs.TriggerProbability, null, defs.Group, defs.TODMode, defs.KillReset, defs.ExternalTriggering,
                     defs.SequentialSpawn, null, defs.AllowGhostTrig, defs.AllowNPCTrig, defs.SpawnOnTrigger, null, defs.DespawnTime, defs.SkillTrigger, defs.SmartSpawning, null)

--- a/Scripts/Services/XmlSpawner/XmlUtils/XmlCategorizedAddGump.cs
+++ b/Scripts/Services/XmlSpawner/XmlUtils/XmlCategorizedAddGump.cs
@@ -97,7 +97,7 @@ namespace Server.Gumps
         private XmlAddCAGCategory()
         {
             m_Title = "no data";
-            Nodes = new XmlAddCAGNode[0];
+            Nodes = Array.Empty<XmlAddCAGNode>();
         }
 
         public XmlAddCAGCategory(XmlAddCAGCategory parent, XmlReader xml)
@@ -116,7 +116,7 @@ namespace Server.Gumps
 
             if (xml.IsEmptyElement)
             {
-                Nodes = new XmlAddCAGNode[0];
+                Nodes = Array.Empty<XmlAddCAGNode>();
             }
             else
             {

--- a/Scripts/Spells/Necromancy/AnimateDeadSpell.cs
+++ b/Scripts/Spells/Necromancy/AnimateDeadSpell.cs
@@ -78,7 +78,7 @@ namespace Server.Spells.Necromancy
         private static readonly CreatureGroup[] m_Groups =
         {
             // Undead group--empty
-            new CreatureGroup(SlayerGroup.GetEntryByName(SlayerName.Silver).Types, new SummonEntry[0]),
+            new CreatureGroup(SlayerGroup.GetEntryByName(SlayerName.Silver).Types, Array.Empty<SummonEntry>()),
             // Insects
             new CreatureGroup(new[]
             {

--- a/Scripts/Spells/Necromancy/AnimateDeadSpell.cs
+++ b/Scripts/Spells/Necromancy/AnimateDeadSpell.cs
@@ -137,7 +137,7 @@ namespace Server.Spells.Necromancy
                    new SummonEntry(0, typeof(PatchworkSkeleton))
                }),
             // Default group
-            new CreatureGroup(new Type[0], new[]
+            new CreatureGroup(Type.EmptyTypes, new[]
             {
                 new SummonEntry(18000, typeof(LichLord)),
                 new SummonEntry(10000, typeof(FleshGolem)),

--- a/Server/Body.cs
+++ b/Server/Body.cs
@@ -58,7 +58,7 @@ namespace Server
 			{
 				Console.WriteLine("Warning: Data/bodyTable.cfg does not exist");
 
-				m_Types = new BodyType[0];
+				m_Types = Array.Empty<BodyType>();
 			}
 		}
 

--- a/Server/Commands.cs
+++ b/Server/Commands.cs
@@ -243,7 +243,7 @@ namespace Server.Commands
 				{
 					argString = "";
 					command = text.ToLower();
-					args = new string[0];
+					args = Array.Empty<string>();
 				}
 
 				m_Entries.TryGetValue(command, out CommandEntry entry);

--- a/Server/HueData.cs
+++ b/Server/HueData.cs
@@ -17,7 +17,7 @@ namespace Server
 #else
         public const PixelFormat PixelFormat = System.Drawing.Imaging.PixelFormat.Format16bppArgb1555;
 #endif
-        private static readonly int[] m_Header = new int[0];
+        private static readonly int[] m_Header = Array.Empty<int>();
 
         public static Hue[] List { get; } = new Hue[3000];
 

--- a/Server/KeywordList.cs
+++ b/Server/KeywordList.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Server
 {
 	public class KeywordList
@@ -41,7 +43,7 @@ namespace Server
 			m_Keywords[m_Count++] = keyword;
 		}
 
-		private static readonly int[] m_EmptyInts = new int[0];
+		private static readonly int[] m_EmptyInts = Array.Empty<int>();
 
 		public int[] ToArray()
 		{

--- a/Server/Map.cs
+++ b/Server/Map.cs
@@ -1559,7 +1559,7 @@ namespace Server
 
 		public Region DefaultRegion
 		{
-			get => m_DefaultRegion ?? (m_DefaultRegion = new Region(null, this, 0, new Rectangle3D[0]));
+			get => m_DefaultRegion ?? (m_DefaultRegion = new Region(null, this, 0, Array.Empty<Rectangle3D>()));
 			set => m_DefaultRegion = value;
 		}
 

--- a/Server/Mobile.cs
+++ b/Server/Mobile.cs
@@ -4826,7 +4826,7 @@ namespace Server
 
 				if (MutateSpeech(hears, ref mutatedText, ref mutateContext))
 				{
-					mutatedArgs = new SpeechEventArgs(this, mutatedText, type, hue, new int[0]);
+					mutatedArgs = new SpeechEventArgs(this, mutatedText, type, hue, Array.Empty<int>());
 				}
 
 				CheckSpeechManifest();

--- a/Server/MultiData.cs
+++ b/Server/MultiData.cs
@@ -533,7 +533,7 @@ namespace Server
 					}
 					else
 					{
-						newTiles[x][y] = new StaticTile[0];
+						newTiles[x][y] = Array.Empty<StaticTile>();
 					}
 
 					totalLength += newTiles[x][y].Length;
@@ -895,8 +895,8 @@ namespace Server
 
 		private MultiComponentList()
 		{
-			m_Tiles = new StaticTile[0][][];
-			m_List = new MultiTileEntry[0];
+			m_Tiles = Array.Empty<StaticTile[][]>();
+			m_List = Array.Empty<MultiTileEntry>();
 		}
 	}
 

--- a/Server/Network/Listener.cs
+++ b/Server/Network/Listener.cs
@@ -20,7 +20,7 @@ namespace Server.Network
 
 		private readonly AsyncCallback m_OnAccept;
 
-		private static readonly Socket[] m_EmptySockets = new Socket[0];
+		private static readonly Socket[] m_EmptySockets = Array.Empty<Socket>();
 
 		public static IPEndPoint[] EndPoints { get; set; }
 

--- a/Server/Network/PacketHandlers.cs
+++ b/Server/Network/PacketHandlers.cs
@@ -1421,7 +1421,7 @@ namespace Server.Network
 			m.ClearFastwalkStack();
 		}
 
-		private static readonly int[] m_EmptyInts = new int[0];
+		private static readonly int[] m_EmptyInts = Array.Empty<int>();
 
 		public static void AsciiSpeech(NetState state, PacketReader pvSrc)
 		{

--- a/Server/Network/Packets.cs
+++ b/Server/Network/Packets.cs
@@ -4118,7 +4118,7 @@ namespace Server.Network
 							}
 						}
 
-						m_CompiledBuffer = new byte[0];
+						m_CompiledBuffer = Array.Empty<byte>();
 						m_CompiledLength = 0;
 
 						length = m_CompiledLength;

--- a/Server/Point3DList.cs
+++ b/Server/Point3DList.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Server
 {
 	public class Point3DList
@@ -60,7 +62,7 @@ namespace Server
 			++m_Count;
 		}
 
-		private static readonly Point3D[] m_EmptyList = new Point3D[0];
+		private static readonly Point3D[] m_EmptyList = Array.Empty<Point3D>();
 
 		public Point3D[] ToArray()
 		{

--- a/Server/SpawnArea.cs
+++ b/Server/SpawnArea.cs
@@ -20,7 +20,7 @@ namespace Server
 
 		static SpawnArea()
 		{
-			_EmptyFilters = new TileFlag[0];
+			_EmptyFilters = Array.Empty<TileFlag>();
 
 			_AllFilters = Enum.GetValues(typeof(TileFlag)).Cast<TileFlag>().Where(f => f != TileFlag.None).ToArray();
 

--- a/Server/TileList.cs
+++ b/Server/TileList.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Server
 {
 	public class TileList
@@ -50,7 +52,7 @@ namespace Server
 			++m_Count;
 		}
 
-		private static readonly StaticTile[] m_EmptyTiles = new StaticTile[0];
+		private static readonly StaticTile[] m_EmptyTiles = Array.Empty<StaticTile>();
 
 		public StaticTile[] ToArray()
 		{

--- a/Server/TileMatrix.cs
+++ b/Server/TileMatrix.cs
@@ -129,7 +129,7 @@ namespace Server
 
 				for (int j = 0; j < 8; ++j)
 				{
-					m_EmptyStaticBlock[i][j] = new StaticTile[0];
+					m_EmptyStaticBlock[i][j] = Array.Empty<StaticTile>();
 				}
 			}
 


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1825

Initializing a zero-length array leads to an unnecessary memory allocation. Instead, use the statically allocated empty array instance by calling the Array.Empty method. The memory allocation is shared across all invocations of this method.