### PR TITLE
Fixing Reptalon|ColdDrake|CuSidhe

### DIFF
--- a/Scripts/Services/Pet Training/PetTrainingHelper.cs
+++ b/Scripts/Services/Pet Training/PetTrainingHelper.cs
@@ -93,7 +93,7 @@ namespace Server.Mobiles
         Tokuno1 = Tokuno | Chivalry | Discordance | MageryMastery | Mysticism | Poisoning | Spellweaving,
         Dragon1 = Bashing | BattleDefense | Chivalry | Discordance | MageryMastery | Mysticism | Piercing | Poisoning | Slashing | Spellweaving | WrestlingMastery,
         Dragon2 = Bashing | Chivalry | Discordance | MageryMastery | Mysticism | Piercing | Poisoning | Slashing | Spellweaving | WrestlingMastery,
-        ColdDrake = Chivalry | Discordance | Poisoning | Mysticism | Spellweaving,
+        ColdDrake = Chivalry | Discordance | Poisoning | MageryMastery | Mysticism | Spellweaving,
         Cusidhe = ColdDrake | WrestlingMastery,
         Wolf = Bashing | Tokuno | Necromage | Necromancy | Piercing | Poisoning | Slashing | WrestlingMastery,
         DragonWolf = Bashing | BattleDefense | Piercing | Poisoning | Slashing | WrestlingMastery,


### PR DESCRIPTION
Reptalon|ColdDrake|CuSidhe can't be trained to Magery Mastery and must be able to Adding "| MageryMastery" to line 96 fix these 3.