### PR TITLE
Explosion Potion Fix

### DIFF
--- a/Scripts/Items/Consumables/Potions/BaseExplosionPotion.cs
+++ b/Scripts/Items/Consumables/Potions/BaseExplosionPotion.cs
@@ -134,7 +134,7 @@ namespace Server.Items
 
             foreach (IDamageable indirectTarget in SpellHelper.AcquireIndirectTargets(from, loc, map, ExplosionRange, false))
             {
-                if (indirectTarget is Mobile mobile)
+                if (indirectTarget is Mobile mobile && mobile.InLOS(this))
                 {
                     list.Add(mobile);
                 }


### PR DESCRIPTION
- This resolves an issue where players would take damage from an explosion potion while inside a home and behind a wall (no LOS)
- LOS(Line of Sight) for explosion potions are determined based on the LOS on the ITEM not the mobile who threw it or its target.