### PR TITLE
Fix broken Greenacre recall check

### DIFF
--- a/Scripts/Spells/Base/SpellHelper.cs
+++ b/Scripts/Spells/Base/SpellHelper.cs
@@ -812,7 +812,7 @@ namespace Server.Spells
                         return false;
                     }
 
-                    if (caster.Region is GreenAcres)
+                    if (Region.Find(loc, map) is GreenAcres) 
                     {
                         caster.SendLocalizedMessage(502360); // You cannot teleport into that area.
                         return false;


### PR DESCRIPTION
The CheckTravel function checks if the caster is in GreenAcres, rather than testing if they are travelling to it.