### PR TITLE
TMapLootTypeNameChange

### DIFF
--- a/Scripts/Services/City Loyalty System/Trading/Mobiles/Slim.cs
+++ b/Scripts/Services/City Loyalty System/Trading/Mobiles/Slim.cs
@@ -128,10 +128,9 @@ namespace Server.Engines.CityLoyalty
                 case 1:
                     Item item = Loot.RandomArmorOrShieldOrWeaponOrJewelry(false, false, true);
 
-                    int min, max;
-                    TreasureMapChest.GetRandomItemStat(out min, out max);
+                    TreasureMapChest.GetRandomItemStat(out var min, out var max);
 
-                    RunicReforging.GenerateRandomItem(item, 0, min, max, Map);
+                    RunicReforging.GenerateRandomItem(item, 0, min, max);
                     return item;
                 case 2:
                     return ScrollOfTranscendence.CreateRandom(1, 10);

--- a/Scripts/Services/Dungeons/WrongDungeon/EnchantedHotItem.cs
+++ b/Scripts/Services/Dungeons/WrongDungeon/EnchantedHotItem.cs
@@ -126,10 +126,10 @@ namespace Server.Items
                         weapon.ExtendedWeaponAttributes.AssassinHoned = 1;
                     }
 
-                    int min = 400;
-                    int max = 1400;
+                    const int min = 400;
+                    const int max = 1400;
 
-                    RunicReforging.GenerateRandomItem(item, 0, min, max, Map);
+                    RunicReforging.GenerateRandomItem(item, 0, min, max);
 
                     item.Hue = 1258;
                     item.AttachSocket(new EnchantedHotItemSocket(this));

--- a/Scripts/Services/LootGeneration/RunicReforging/RunicReforging.cs
+++ b/Scripts/Services/LootGeneration/RunicReforging/RunicReforging.cs
@@ -1873,7 +1873,7 @@ namespace Server.Items
         /// <param name="maxBudget"></param>
         /// <param name="map"></param>
         /// <returns></returns>
-        public static bool GenerateRandomItem(Item item, int luck, int minBudget, int maxBudget, Map map)
+        public static bool GenerateRandomTreasureMapItem(Item item, int luck, int minBudget, int maxBudget, Map map)
         {
             if (item is BaseWeapon || item is BaseArmor || item is BaseJewel || item is BaseHat)
             {

--- a/Scripts/Services/LootGeneration/RunicReforging/RunicReforging.cs
+++ b/Scripts/Services/LootGeneration/RunicReforging/RunicReforging.cs
@@ -1878,9 +1878,12 @@ namespace Server.Items
             if (item is BaseWeapon || item is BaseArmor || item is BaseJewel || item is BaseHat)
             {
                 int budget = Utility.RandomMinMax(minBudget, maxBudget);
+
                 GenerateRandomItem(item, null, budget, LootPack.GetLuckChance(luck), ReforgedPrefix.None, ReforgedSuffix.None, map);
+
                 return true;
             }
+
             return false;
         }
 

--- a/Scripts/Services/TreasureMaps/TreasureMapChest.cs
+++ b/Scripts/Services/TreasureMaps/TreasureMapChest.cs
@@ -238,7 +238,7 @@ namespace Server.Items
                         int min, max;
                         GetRandomItemStat(out min, out max, propsScale);
 
-                        RunicReforging.GenerateRandomItem(item, luck, min, max, map);
+                        RunicReforging.GenerateRandomTreasureMapItem(item, luck, min, max, map);
 
                         cont.DropItem(item);
                     }

--- a/Scripts/Services/TreasureMaps/TreasureMapInfo.cs
+++ b/Scripts/Services/TreasureMaps/TreasureMapInfo.cs
@@ -973,7 +973,7 @@ namespace Server.Items
                                 int min, max;
 
                                 GetMinMaxBudget(level, deco, out min, out max);
-                                RunicReforging.GenerateRandomItem(deco, from is PlayerMobile pm ? pm.RealLuck : from.Luck, min, max, chest.Map);
+                                RunicReforging.GenerateRandomTreasureMapItem(deco, from is PlayerMobile pm ? pm.RealLuck : from.Luck, min, max, chest.Map);
                             }
                         }
 
@@ -1022,7 +1022,7 @@ namespace Server.Items
 
                 if (item != null)
                 {
-                    RunicReforging.GenerateRandomItem(item, from is PlayerMobile pm ? pm.RealLuck : from.Luck, min, max, chest.Map);
+                    RunicReforging.GenerateRandomTreasureMapItem(item, from is PlayerMobile pm ? pm.RealLuck : from.Luck, min, max, chest.Map);
                     chest.DropItem(item);
                 }
             }


### PR DESCRIPTION
1- some clean up. Renamed GenerateRandomItem to GenerateRandomTreasureMapItem 
2 - Slim and EnchantedHotItem were using the physical item Item.Map in its last argument.