### PR TITLE
Event spawner loot bugs

### DIFF
--- a/Scripts/Services/Dungeons/BlackthornDungeon/InvasionSpawner/InvasionController.cs
+++ b/Scripts/Services/Dungeons/BlackthornDungeon/InvasionSpawner/InvasionController.cs
@@ -467,7 +467,7 @@ namespace Server.Engines.Blackthorn
 
             if (i != null)
             {
-                RunicReforging.GenerateRandomItem(i, damager, Utility.RandomMinMax(700, 800), damager is PlayerMobile pm ? pm.RealLuck : 0, ReforgedPrefix.None, ReforgedSuffix.Minax);
+                RunicReforging.GenerateRandomItem(i, damager, Utility.RandomMinMax(700, 800), LootPack.GetLuckChance(damager is PlayerMobile pm ? pm.RealLuck : 0), ReforgedPrefix.None, ReforgedSuffix.Minax);
             }
 
             return i;

--- a/Scripts/Services/PointsSystems/BlackthornData.cs
+++ b/Scripts/Services/PointsSystems/BlackthornData.cs
@@ -56,7 +56,7 @@ namespace Server.Engines.Points
 
                     if (i != null)
                     {
-                        RunicReforging.GenerateRandomItem(i, mobile, Math.Max(100, RunicReforging.GetDifficultyFor(bc)), RunicReforging.GetLuckForKiller(bc), ReforgedPrefix.None, ReforgedSuffix.Minax);
+                        RunicReforging.GenerateRandomItem(i, mobile, Math.Max(100, RunicReforging.GetDifficultyFor(bc)), LootPack.GetLuckChance(mobile.RealLuck), ReforgedPrefix.None, ReforgedSuffix.Minax);
 
                         mobile.PlaySound(0x5B4);
                         mobile.SendLocalizedMessage(1062317); // For your valor in combating the fallen beast, a special artifact has been bestowed on you.

--- a/Scripts/Services/Seasonal Events/JollyRoger/ShrineBattleSpawner/ShrineBattleController.cs
+++ b/Scripts/Services/Seasonal Events/JollyRoger/ShrineBattleSpawner/ShrineBattleController.cs
@@ -357,7 +357,7 @@ namespace Server.Engines.JollyRoger
 
             if (i != null)
             {
-                RunicReforging.GenerateRandomItem(i, damager, Utility.RandomMinMax(600, 800), damager is PlayerMobile pm ? pm.RealLuck : 0, ReforgedPrefix.None, ReforgedSuffix.Fellowship);
+                RunicReforging.GenerateRandomItem(i, damager, Utility.RandomMinMax(600, 800), LootPack.GetLuckChance(damager is PlayerMobile pm ? pm.RealLuck : 0), ReforgedPrefix.None, ReforgedSuffix.Fellowship);
             }
 
             return i;

--- a/Scripts/Services/Seasonal Events/TreasuresOfDoom/DoomData.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfDoom/DoomData.cs
@@ -57,7 +57,7 @@ namespace Server.Engines.Points
 
                     if (i != null)
                     {
-                        RunicReforging.GenerateRandomItem(i, mobile, Math.Max(100, RunicReforging.GetDifficultyFor(bc)), RunicReforging.GetLuckForKiller(bc), ReforgedPrefix.None, ReforgedSuffix.Doom);
+                        RunicReforging.GenerateRandomItem(i, mobile, Math.Max(100, RunicReforging.GetDifficultyFor(bc)), LootPack.GetLuckChance(mobile.RealLuck), ReforgedPrefix.None, ReforgedSuffix.Doom);
 
                         mobile.PlaySound(0x5B4);
                         mobile.SendLocalizedMessage(1155588); // You notice the crest of Doom on your fallen foe's equipment and decide it may be of some value...

--- a/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/KhaldunData.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/KhaldunData.cs
@@ -58,7 +58,7 @@ namespace Server.Engines.Points
 
                     if (i != null)
                     {
-                        RunicReforging.GenerateRandomItem(i, mobile, Math.Max(100, RunicReforging.GetDifficultyFor(bc)), RunicReforging.GetLuckForKiller(bc), ReforgedPrefix.None, ReforgedSuffix.Khaldun);
+                        RunicReforging.GenerateRandomItem(i, mobile, Math.Max(100, RunicReforging.GetDifficultyFor(bc)), LootPack.GetLuckChance(mobile.RealLuck), ReforgedPrefix.None, ReforgedSuffix.Khaldun);
 
                         mobile.PlaySound(0x5B4);
                         mobile.SendLocalizedMessage(1062317); // For your valor in combating the fallen beast, a special artifact has been bestowed on you.

--- a/Scripts/Services/Seasonal Events/TreasuresOfKotlCity/KotlCityData.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfKotlCity/KotlCityData.cs
@@ -65,7 +65,7 @@ namespace Server.Engines.Points
 
                     if (i != null)
                     {
-                        RunicReforging.GenerateRandomItem(i, mobile, Math.Max(100, RunicReforging.GetDifficultyFor(bc)), RunicReforging.GetLuckForKiller(bc), ReforgedPrefix.None, ReforgedSuffix.Kotl);
+                        RunicReforging.GenerateRandomItem(i, mobile, Math.Max(100, RunicReforging.GetDifficultyFor(bc)), LootPack.GetLuckChance(mobile.RealLuck), ReforgedPrefix.None, ReforgedSuffix.Kotl);
 
                         mobile.PlaySound(0x5B4);
                         mobile.SendLocalizedMessage(1062317); // For your valor in combating the fallen beast, a special artifact has been bestowed on you.

--- a/Scripts/Services/Seasonal Events/TreasuresOfSorceresDungeon/SorcerersDungeonData.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfSorceresDungeon/SorcerersDungeonData.cs
@@ -66,7 +66,7 @@ namespace Server.Engines.SorcerersDungeon
 
                     if (i != null)
                     {
-                        RunicReforging.GenerateRandomItem(i, mobile, Math.Max(100, RunicReforging.GetDifficultyFor(bc)), RunicReforging.GetLuckForKiller(bc), ReforgedPrefix.None, ReforgedSuffix.EnchantedOrigin);
+                        RunicReforging.GenerateRandomItem(i, mobile, Math.Max(100, RunicReforging.GetDifficultyFor(bc)), LootPack.GetLuckChance(mobile.RealLuck), ReforgedPrefix.None, ReforgedSuffix.EnchantedOrigin);
 
                         mobile.PlaySound(0x5B4);
                         mobile.SendLocalizedMessage(1157613); // You notice some of your fallen foes' equipment to be of enchanted origin and decide it may be of some value...


### PR DESCRIPTION
All random event item generation is creating items passing character luck, instead of the LuckChance.