### PR TITLE
Fix Ticks not processing on Idle

### DIFF
--- a/Server/Main.cs
+++ b/Server/Main.cs
@@ -599,7 +599,7 @@ namespace Server
 
 				while (!Closing)
 				{
-					_Signal.WaitOne();
+					_Signal.WaitOne(1);
 
 					Mobile.ProcessDeltaQueue();
 					Item.ProcessDeltaQueue();


### PR DESCRIPTION
The new timers are not processing Ticks when the server is idle (no players packets hitting the server)
CUO sends 1 ping packet every second, so an idle CUO player keeps the server _ticking_
SteamUO doesnt send a ping, but does send an "Invalid packet" every second, doing the same job as CUO
Orion doesnt send a ping packet, it seems to ping the actual server itself. This means an idle player makes the server think no one is there.

The WaitOne() method defaults to WaitOne(-1), which means the server is waiting indefinitely between Ticks when no packets are coming in. 
In Orion if you cast a spell, you get the cast animation then nothing. The client is waiting for the target response, leaving the player in a Frozen state. This is fixed by sending a packet (war mode, or speech). Then the Target cursor is processed on the server and delivered to the player.

In CUO, you dont actually notice this. You cast, and within 1 second (ping packet delivered) we get a target back. So if a player was really keen on their faster casting, casting magic arrow with FC4, they might actually notice the delay.
If you disable the client ping, it should act like Orion.

Removing the WaitOne, causes the server to go mental in a while loop, trying to processed 100,000 tick per second. Setting WaitOne(1) causes the Tick loop to pause for 1ms, but allows an interupt if a packet comes in still, but the delay on CUO should be gone and Orion issue has resolved.
