### PR TITLE
Remove target reflection

### DIFF
--- a/Scripts/Items/Equipment/Instruments/BaseInstrument.cs
+++ b/Scripts/Items/Equipment/Instruments/BaseInstrument.cs
@@ -260,7 +260,7 @@ namespace Server.Items
             else
             {
                 from.SendLocalizedMessage(500617); // What instrument shall you play?
-                from.BeginTarget(1, false, TargetFlags.None, new TargetStateCallback(OnPickedInstrument), callback);
+                Timer.DelayCall(() => from.BeginTarget(1, false, TargetFlags.None, new TargetStateCallback(OnPickedInstrument), callback));
             }
         }
 

--- a/Scripts/Items/Equipment/Spellbooks/Spellbook.cs
+++ b/Scripts/Items/Equipment/Spellbooks/Spellbook.cs
@@ -347,7 +347,7 @@ namespace Server.Items
                             }
                             else if (toI != null)
                             {
-                                spell.InstantTarget = toI as IDamageableItem;
+                                spell.InstantTarget = toI as IEntity;
                             }
                             spell.Cast();
                         }

--- a/Scripts/Items/Equipment/Spellbooks/Spellbook.cs
+++ b/Scripts/Items/Equipment/Spellbooks/Spellbook.cs
@@ -349,7 +349,6 @@ namespace Server.Items
                             {
                                 spell.InstantTarget = toI;
                             }
-
                             spell.Cast();
                         }
                     }

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -833,34 +833,37 @@ namespace Server.Mobiles
 
             from.TargetLocked = true;
 
-            if (e.SkillID == 22)
+            if (e.SkillID == (short)SkillName.Provocation)
             {
                 Provocation.DeferredSecondaryTarget = true;
+                InvokeTarget(e, from, target);
+                Provocation.DeferredSecondaryTarget = false;
             }
 
-            if (e.SkillID == 35)
+            else if (e.SkillID == (short)SkillName.AnimalTaming)
             {
                 AnimalTaming.DisableMessage = true;
                 AnimalTaming.DeferredTarget = false;
+                InvokeTarget(e, from, target);
+                AnimalTaming.DeferredTarget = true;
+                AnimalTaming.DisableMessage = false;
+
+            }
+            else
+            {
+                InvokeTarget(e, from, target);
             }
 
+
+            from.TargetLocked = false;
+        }
+
+        private static void InvokeTarget(TargetedSkillEventArgs e, Mobile from, IEntity target)
+        {
             if (from.UseSkill(e.SkillID))
             {
                 from.Target?.Invoke(from, target);
             }
-
-            if (e.SkillID == 22)
-            {
-                Provocation.DeferredSecondaryTarget = false;
-            }
-
-            if (e.SkillID == 35)
-            {
-                AnimalTaming.DeferredTarget = true;
-                AnimalTaming.DisableMessage = false;
-            }
-
-            from.TargetLocked = false;
         }
 
         public static void EquipMacro(EquipMacroEventArgs e)

--- a/Scripts/Skills/Provocation.cs
+++ b/Scripts/Skills/Provocation.cs
@@ -10,6 +10,13 @@ namespace Server.SkillHandlers
 {
     public class Provocation
     {
+        public static bool DeferredSecondaryTarget { get; set; }
+
+        static Provocation()
+        {
+            DeferredSecondaryTarget = true;
+        }
+
         public static void Initialize()
         {
             SkillInfo.Table[(int)SkillName.Provocation].Callback = OnUse;
@@ -65,7 +72,14 @@ namespace Server.SkillHandlers
                         m_Instrument.PlayInstrumentWell(from);
                         from.SendLocalizedMessage(1008085);
                         // You play your music and your target becomes angered.  Whom do you wish them to attack?
-                        from.Target = new InternalSecondTarget(from, m_Instrument, creature);
+                        if (DeferredSecondaryTarget)
+                        {
+                            Timer.DelayCall(() => from.Target = new InternalSecondTarget(from, m_Instrument, creature));
+                        }
+                        else
+                        {
+                            from.Target = new InternalSecondTarget(from, m_Instrument, creature);
+                        }
                     }
                 }
                 else

--- a/Scripts/Spells/Base/InstantCast.cs
+++ b/Scripts/Spells/Base/InstantCast.cs
@@ -1,4 +1,4 @@
-namespace Server.Spells
+namespace Server.Spells.Base
 {
     public interface InstantCast
     {

--- a/Scripts/Spells/Base/InstantCast.cs
+++ b/Scripts/Spells/Base/InstantCast.cs
@@ -1,7 +1,0 @@
-namespace Server.Spells.Base
-{
-    public interface InstantCast
-    {
-        public abstract bool OnInstantCast(IEntity target);
-    }
-}

--- a/Scripts/Spells/Base/Spell.cs
+++ b/Scripts/Spells/Base/Spell.cs
@@ -803,67 +803,12 @@ namespace Server.Spells
         #region Enhanced Client
         public bool OnCastInstantTarget()
         {
-            if (InstantTarget == null)
+            if (this is InstantCast)
+                return (this as InstantCast).OnInstantCast(InstantTarget);
+            else
                 return false;
-
-            Type spellType = GetType();
-
-            if (spellType.BaseType != null && spellType.IsSubclassOf(typeof(SkillMasterySpell)))
-            {
-                try
-                {
-                    spellType
-                        .GetTypeInfo()
-                        .GetMethod("OnTarget",
-                            BindingFlags.Instance | BindingFlags.NonPublic)
-                        ?.Invoke(this, new object[] { InstantTarget });
-                    return true;
-                }
-                catch
-                {
-                    LogBadConstructorForInstantTarget();
-                    return false;
-                }
-
-            }
-
-            Type[] types = spellType.GetNestedTypes(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-
-            Type targetType = null;
-
-            for (var index = 0; index < types.Length; index++)
-            {
-                var t = types[index];
-
-                if (t.IsSubclassOf(typeof(Target)))
-                {
-                    targetType = t;
-                    break;
-                }
-            }
-
-            if (targetType != null)
-            {
-                Target t = null;
-
-                try
-                {
-                    t = Activator.CreateInstance(targetType, this) as Target;
-                }
-                catch
-                {
-                    LogBadConstructorForInstantTarget();
-                }
-
-                if (t != null)
-                {
-                    t.Invoke(Caster, InstantTarget);
-                    return true;
-                }
-            }
-
-            return false;
         }
+
         #endregion
 
         public virtual void OnBeginCast()

--- a/Scripts/Spells/Base/Spell.cs
+++ b/Scripts/Spells/Base/Spell.cs
@@ -15,6 +15,7 @@ using Server.Targeting;
 using System;
 using System.Collections.Generic;
 using Server.Spells.SkillMasteries;
+using Server.Spells.Base;
 
 #endregion
 

--- a/Scripts/Spells/Base/Spell.cs
+++ b/Scripts/Spells/Base/Spell.cs
@@ -14,7 +14,6 @@ using Server.Spells.Second;
 using Server.Targeting;
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 using Server.Spells.SkillMasteries;
 
 #endregion

--- a/Scripts/Spells/Base/Spell.cs
+++ b/Scripts/Spells/Base/Spell.cs
@@ -15,7 +15,7 @@ using Server.Targeting;
 using System;
 using System.Collections.Generic;
 using Server.Spells.SkillMasteries;
-using Server.Spells.Base;
+
 
 #endregion
 
@@ -28,7 +28,6 @@ namespace Server.Spells
         private readonly SpellInfo m_Info;
         private SpellState m_State;
         private long m_CastTime;
-        private IEntity m_InstantTarget;
 
         public int ID => SpellRegistry.GetRegistryNumber(this);
 
@@ -42,7 +41,7 @@ namespace Server.Spells
         public Item Scroll => m_Scroll;
         public long CastTime => m_CastTime;
 
-        public IEntity InstantTarget { get => m_InstantTarget; set => m_InstantTarget = value; }
+        public IEntity InstantTarget { get; set; }
 
         public bool Disturbed { get; set; }
 
@@ -789,7 +788,7 @@ namespace Server.Spells
             m_Caster.NextSpellTime = Core.TickCount + (int)GetCastRecovery().TotalMilliseconds;
             Target originalTarget = m_Caster.Target;
 
-            if (InstantTarget == null || !OnCastInstantTarget())
+            if (InstantTarget == null || !OnInstantCast(InstantTarget))
             {
                 OnCast();
             }
@@ -801,12 +800,9 @@ namespace Server.Spells
         }
 
         #region Enhanced Client
-        public bool OnCastInstantTarget()
+        public virtual bool OnInstantCast(IEntity target)
         {
-            if (this is InstantCast)
-                return (this as InstantCast).OnInstantCast(InstantTarget);
-            else
-                return false;
+            return false;
         }
 
         #endregion

--- a/Scripts/Spells/Bushido/InstantCast.cs
+++ b/Scripts/Spells/Bushido/InstantCast.cs
@@ -1,0 +1,7 @@
+namespace Server.Spells
+{
+    public interface InstantCast
+    {
+        public abstract bool OnInstantCast(IEntity target);
+    }
+}

--- a/Scripts/Spells/Chivalry/CleanseByFire.cs
+++ b/Scripts/Spells/Chivalry/CleanseByFire.cs
@@ -1,11 +1,10 @@
-using Server.Spells.Base;
 using Server.Spells.Bushido;
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Chivalry
 {
-    public class CleanseByFireSpell : PaladinSpell, InstantCast
+    public class CleanseByFireSpell : PaladinSpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Cleanse By Fire", "Expor Flamus",
@@ -27,7 +26,7 @@ namespace Server.Spells.Chivalry
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Chivalry/CleanseByFire.cs
+++ b/Scripts/Spells/Chivalry/CleanseByFire.cs
@@ -1,3 +1,4 @@
+using Server.Spells.Base;
 using Server.Spells.Bushido;
 using Server.Targeting;
 using System;
@@ -24,6 +25,18 @@ namespace Server.Spells.Chivalry
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public override bool CheckDisturb(DisturbType type, bool firstCircle, bool resistable)
@@ -93,16 +106,6 @@ namespace Server.Spells.Chivalry
             FinishSequence();
         }
 
-        public bool OnInstantCast(IEntity target)
-        {
-            if (target is Mobile)
-            { 
-                Target(target as Mobile);
-                 return true;
-            }
-            else
-                return false;
-        }
 
         private class InternalTarget : Target
         {

--- a/Scripts/Spells/Chivalry/CleanseByFire.cs
+++ b/Scripts/Spells/Chivalry/CleanseByFire.cs
@@ -1,9 +1,10 @@
+using Server.Spells.Bushido;
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Chivalry
 {
-    public class CleanseByFireSpell : PaladinSpell
+    public class CleanseByFireSpell : PaladinSpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Cleanse By Fire", "Expor Flamus",
@@ -90,6 +91,17 @@ namespace Server.Spells.Chivalry
             }
 
             FinishSequence();
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            if (target is Mobile)
+            { 
+                Target(target as Mobile);
+                 return true;
+            }
+            else
+                return false;
         }
 
         private class InternalTarget : Target

--- a/Scripts/Spells/Chivalry/CloseWounds.cs
+++ b/Scripts/Spells/Chivalry/CloseWounds.cs
@@ -1,5 +1,6 @@
 using Server.Mobiles;
 using Server.Network;
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 
@@ -34,9 +35,10 @@ namespace Server.Spells.Chivalry
 
         public bool OnInstantCast(IEntity target)
         {
-            if (target is Mobile)
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
             {
-                Target(target as Mobile);
+                t.Invoke(Caster, target);
                 return true;
             }
             else

--- a/Scripts/Spells/Chivalry/CloseWounds.cs
+++ b/Scripts/Spells/Chivalry/CloseWounds.cs
@@ -1,12 +1,12 @@
 using Server.Mobiles;
 using Server.Network;
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Chivalry
 {
-    public class CloseWoundsSpell : PaladinSpell, InstantCast
+    public class CloseWoundsSpell : PaladinSpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Close Wounds", "Obsu Vulni",
@@ -33,7 +33,7 @@ namespace Server.Spells.Chivalry
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Chivalry/CloseWounds.cs
+++ b/Scripts/Spells/Chivalry/CloseWounds.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Server.Spells.Chivalry
 {
-    public class CloseWoundsSpell : PaladinSpell
+    public class CloseWoundsSpell : PaladinSpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Close Wounds", "Obsu Vulni",
@@ -30,6 +30,17 @@ namespace Server.Spells.Chivalry
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            if (target is Mobile)
+            {
+                Target(target as Mobile);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(Mobile m)

--- a/Scripts/Spells/Chivalry/RemoveCurse.cs
+++ b/Scripts/Spells/Chivalry/RemoveCurse.cs
@@ -1,4 +1,5 @@
 using Server.Items;
+using Server.Spells.Base;
 using Server.Spells.First;
 using Server.Spells.Fourth;
 using Server.Spells.Mysticism;
@@ -41,7 +42,14 @@ namespace Server.Spells.Chivalry
 
         public bool OnInstantCast(IEntity target)
         {
-            throw new NotImplementedException();
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(Mobile m)

--- a/Scripts/Spells/Chivalry/RemoveCurse.cs
+++ b/Scripts/Spells/Chivalry/RemoveCurse.cs
@@ -1,5 +1,5 @@
 using Server.Items;
-using Server.Spells.Base;
+
 using Server.Spells.First;
 using Server.Spells.Fourth;
 using Server.Spells.Mysticism;
@@ -9,7 +9,7 @@ using System;
 
 namespace Server.Spells.Chivalry
 {
-    public class RemoveCurseSpell : PaladinSpell, InstantCast
+    public class RemoveCurseSpell : PaladinSpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Remove Curse", "Extermo Vomica",
@@ -40,7 +40,7 @@ namespace Server.Spells.Chivalry
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Chivalry/RemoveCurse.cs
+++ b/Scripts/Spells/Chivalry/RemoveCurse.cs
@@ -8,7 +8,7 @@ using System;
 
 namespace Server.Spells.Chivalry
 {
-    public class RemoveCurseSpell : PaladinSpell
+    public class RemoveCurseSpell : PaladinSpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Remove Curse", "Extermo Vomica",
@@ -37,6 +37,11 @@ namespace Server.Spells.Chivalry
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            throw new NotImplementedException();
         }
 
         public void Target(Mobile m)

--- a/Scripts/Spells/Chivalry/SacredJourney.cs
+++ b/Scripts/Spells/Chivalry/SacredJourney.cs
@@ -5,6 +5,7 @@ using Server.Network;
 using Server.Targeting;
 using System;
 using Server.Engines.NewMagincia;
+using Server.Spells.Base;
 
 namespace Server.Spells.Chivalry
 {
@@ -54,6 +55,18 @@ namespace Server.Spells.Chivalry
                     Effect(m_Entry.Location, m_Entry.Map, true, false);
                 }
             }
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public override bool CheckCast()
@@ -181,11 +194,6 @@ namespace Server.Spells.Chivalry
             }
 
             FinishSequence();
-        }
-
-        public bool OnInstantCast(IEntity target)
-        {
-            throw new NotImplementedException();
         }
 
         private class InternalTarget : Target

--- a/Scripts/Spells/Chivalry/SacredJourney.cs
+++ b/Scripts/Spells/Chivalry/SacredJourney.cs
@@ -8,7 +8,7 @@ using Server.Engines.NewMagincia;
 
 namespace Server.Spells.Chivalry
 {
-    public class SacredJourneySpell : PaladinSpell
+    public class SacredJourneySpell : PaladinSpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Sacred Journey", "Sanctum Viatas",
@@ -181,6 +181,11 @@ namespace Server.Spells.Chivalry
             }
 
             FinishSequence();
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            throw new NotImplementedException();
         }
 
         private class InternalTarget : Target

--- a/Scripts/Spells/Chivalry/SacredJourney.cs
+++ b/Scripts/Spells/Chivalry/SacredJourney.cs
@@ -60,7 +60,7 @@ namespace Server.Spells.Chivalry
         public bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
-            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            if (Caster.InLOS(target))
             {
                 t.Invoke(Caster, target);
                 return true;

--- a/Scripts/Spells/Chivalry/SacredJourney.cs
+++ b/Scripts/Spells/Chivalry/SacredJourney.cs
@@ -5,11 +5,11 @@ using Server.Network;
 using Server.Targeting;
 using System;
 using Server.Engines.NewMagincia;
-using Server.Spells.Base;
+
 
 namespace Server.Spells.Chivalry
 {
-    public class SacredJourneySpell : PaladinSpell, InstantCast
+    public class SacredJourneySpell : PaladinSpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Sacred Journey", "Sanctum Viatas",
@@ -57,7 +57,7 @@ namespace Server.Spells.Chivalry
             }
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InLOS(target))

--- a/Scripts/Spells/Eighth/EnergyVortex.cs
+++ b/Scripts/Spells/Eighth/EnergyVortex.cs
@@ -1,4 +1,5 @@
 using Server.Mobiles;
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 
@@ -42,8 +43,14 @@ namespace Server.Spells.Eighth
 
         public bool OnInstantCast(IEntity target)
         {
-            Target(target.Location);
-            return true;
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(IPoint3D p)

--- a/Scripts/Spells/Eighth/EnergyVortex.cs
+++ b/Scripts/Spells/Eighth/EnergyVortex.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace Server.Spells.Eighth
 {
-    public class EnergyVortexSpell : MagerySpell
+    public class EnergyVortexSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Energy Vortex", "Vas Corp Por",
@@ -38,6 +38,12 @@ namespace Server.Spells.Eighth
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target(target.Location);
+            return true;
         }
 
         public void Target(IPoint3D p)

--- a/Scripts/Spells/Eighth/EnergyVortex.cs
+++ b/Scripts/Spells/Eighth/EnergyVortex.cs
@@ -1,11 +1,11 @@
 using Server.Mobiles;
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Eighth
 {
-    public class EnergyVortexSpell : MagerySpell, InstantCast
+    public class EnergyVortexSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Energy Vortex", "Vas Corp Por",
@@ -41,7 +41,7 @@ namespace Server.Spells.Eighth
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Eighth/Resurrection.cs
+++ b/Scripts/Spells/Eighth/Resurrection.cs
@@ -1,10 +1,10 @@
 using Server.Gumps;
-using Server.Spells.Base;
+
 using Server.Targeting;
 
 namespace Server.Spells.Eighth
 {
-    public class ResurrectionSpell : MagerySpell, InstantCast
+    public class ResurrectionSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Resurrection", "An Corp",
@@ -25,7 +25,7 @@ namespace Server.Spells.Eighth
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Eighth/Resurrection.cs
+++ b/Scripts/Spells/Eighth/Resurrection.cs
@@ -3,7 +3,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Eighth
 {
-    public class ResurrectionSpell : MagerySpell
+    public class ResurrectionSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Resurrection", "An Corp",
@@ -22,6 +22,17 @@ namespace Server.Spells.Eighth
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            if (target is Mobile)
+            {
+                Target(target as Mobile);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(Mobile m)

--- a/Scripts/Spells/Eighth/Resurrection.cs
+++ b/Scripts/Spells/Eighth/Resurrection.cs
@@ -1,4 +1,5 @@
 using Server.Gumps;
+using Server.Spells.Base;
 using Server.Targeting;
 
 namespace Server.Spells.Eighth
@@ -26,9 +27,10 @@ namespace Server.Spells.Eighth
 
         public bool OnInstantCast(IEntity target)
         {
-            if (target is Mobile)
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
             {
-                Target(target as Mobile);
+                t.Invoke(Caster, target);
                 return true;
             }
             else

--- a/Scripts/Spells/Fifth/BladeSpirits.cs
+++ b/Scripts/Spells/Fifth/BladeSpirits.cs
@@ -1,11 +1,11 @@
 using Server.Mobiles;
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Fifth
 {
-    public class BladeSpiritsSpell : MagerySpell, InstantCast
+    public class BladeSpiritsSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Blade Spirits", "In Jux Hur Ylem",
@@ -45,7 +45,7 @@ namespace Server.Spells.Fifth
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Fifth/BladeSpirits.cs
+++ b/Scripts/Spells/Fifth/BladeSpirits.cs
@@ -1,4 +1,5 @@
 using Server.Mobiles;
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 
@@ -43,10 +44,17 @@ namespace Server.Spells.Fifth
         {
             Caster.Target = new InternalTarget(this);
         }
+
         public bool OnInstantCast(IEntity target)
         {
-            Target(target.Location);
-            return true;
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(IPoint3D p)

--- a/Scripts/Spells/Fifth/BladeSpirits.cs
+++ b/Scripts/Spells/Fifth/BladeSpirits.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace Server.Spells.Fifth
 {
-    public class BladeSpiritsSpell : MagerySpell
+    public class BladeSpiritsSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Blade Spirits", "In Jux Hur Ylem",
@@ -42,6 +42,11 @@ namespace Server.Spells.Fifth
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+        public bool OnInstantCast(IEntity target)
+        {
+            Target(target.Location);
+            return true;
         }
 
         public void Target(IPoint3D p)

--- a/Scripts/Spells/Fifth/DispelField.cs
+++ b/Scripts/Spells/Fifth/DispelField.cs
@@ -1,11 +1,11 @@
 using Server.Items;
 using Server.Misc;
-using Server.Spells.Base;
+
 using Server.Targeting;
 
 namespace Server.Spells.Fifth
 {
-    public class DispelFieldSpell : MagerySpell, InstantCast
+    public class DispelFieldSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Dispel Field", "An Grav",
@@ -26,7 +26,7 @@ namespace Server.Spells.Fifth
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Fifth/DispelField.cs
+++ b/Scripts/Spells/Fifth/DispelField.cs
@@ -1,5 +1,6 @@
 using Server.Items;
 using Server.Misc;
+using Server.Spells.Base;
 using Server.Targeting;
 
 namespace Server.Spells.Fifth
@@ -24,10 +25,17 @@ namespace Server.Spells.Fifth
         {
             Caster.Target = new InternalTarget(this);
         }
+
         public bool OnInstantCast(IEntity target)
         {
-            Target(target);
-            return true;
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(IEntity e)

--- a/Scripts/Spells/Fifth/DispelField.cs
+++ b/Scripts/Spells/Fifth/DispelField.cs
@@ -4,7 +4,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Fifth
 {
-    public class DispelFieldSpell : MagerySpell
+    public class DispelFieldSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Dispel Field", "An Grav",
@@ -23,6 +23,11 @@ namespace Server.Spells.Fifth
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+        public bool OnInstantCast(IEntity target)
+        {
+            Target(target);
+            return true;
         }
 
         public void Target(IEntity e)

--- a/Scripts/Spells/Fifth/MindBlast.cs
+++ b/Scripts/Spells/Fifth/MindBlast.cs
@@ -1,3 +1,4 @@
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 
@@ -26,9 +27,10 @@ namespace Server.Spells.Fifth
         }
         public bool OnInstantCast(IEntity target)
         {
-            if (target is Mobile)
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
             {
-                Target(target as Mobile);
+                t.Invoke(Caster, target);
                 return true;
             }
             else

--- a/Scripts/Spells/Fifth/MindBlast.cs
+++ b/Scripts/Spells/Fifth/MindBlast.cs
@@ -1,10 +1,10 @@
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Fifth
 {
-    public class MindBlastSpell : MagerySpell, InstantCast
+    public class MindBlastSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Mind Blast", "Por Corp Wis",
@@ -25,7 +25,7 @@ namespace Server.Spells.Fifth
         {
             Caster.Target = new InternalTarget(this);
         }
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Fifth/MindBlast.cs
+++ b/Scripts/Spells/Fifth/MindBlast.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Server.Spells.Fifth
 {
-    public class MindBlastSpell : MagerySpell
+    public class MindBlastSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Mind Blast", "Por Corp Wis",
@@ -23,6 +23,16 @@ namespace Server.Spells.Fifth
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+        public bool OnInstantCast(IEntity target)
+        {
+            if (target is Mobile)
+            {
+                Target(target as Mobile);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(Mobile m)

--- a/Scripts/Spells/Fifth/Paralyze.cs
+++ b/Scripts/Spells/Fifth/Paralyze.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Server.Spells.Fifth
 {
-    public class ParalyzeSpell : MagerySpell
+    public class ParalyzeSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Paralyze", "An Ex Por",
@@ -23,6 +23,16 @@ namespace Server.Spells.Fifth
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+        public bool OnInstantCast(IEntity target)
+        {
+            if (target is Mobile)
+            {
+                Target(target as Mobile);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(Mobile m)

--- a/Scripts/Spells/Fifth/Paralyze.cs
+++ b/Scripts/Spells/Fifth/Paralyze.cs
@@ -1,4 +1,5 @@
 using Server.Mobiles;
+using Server.Spells.Base;
 using Server.Spells.Chivalry;
 using Server.Targeting;
 using System;
@@ -26,9 +27,10 @@ namespace Server.Spells.Fifth
         }
         public bool OnInstantCast(IEntity target)
         {
-            if (target is Mobile)
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
             {
-                Target(target as Mobile);
+                t.Invoke(Caster, target);
                 return true;
             }
             else

--- a/Scripts/Spells/Fifth/Paralyze.cs
+++ b/Scripts/Spells/Fifth/Paralyze.cs
@@ -1,12 +1,12 @@
 using Server.Mobiles;
-using Server.Spells.Base;
+
 using Server.Spells.Chivalry;
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Fifth
 {
-    public class ParalyzeSpell : MagerySpell, InstantCast
+    public class ParalyzeSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Paralyze", "An Ex Por",
@@ -25,7 +25,7 @@ namespace Server.Spells.Fifth
         {
             Caster.Target = new InternalTarget(this);
         }
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Fifth/PoisonField.cs
+++ b/Scripts/Spells/Fifth/PoisonField.cs
@@ -1,14 +1,14 @@
 using Server.Items;
 using Server.Misc;
 using Server.Mobiles;
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 using System.Collections;
 
 namespace Server.Spells.Fifth
 {
-    public class PoisonFieldSpell : MagerySpell, InstantCast
+    public class PoisonFieldSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Poison Field", "In Nox Grav",
@@ -29,7 +29,7 @@ namespace Server.Spells.Fifth
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Fifth/PoisonField.cs
+++ b/Scripts/Spells/Fifth/PoisonField.cs
@@ -7,7 +7,7 @@ using System.Collections;
 
 namespace Server.Spells.Fifth
 {
-    public class PoisonFieldSpell : MagerySpell
+    public class PoisonFieldSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Poison Field", "In Nox Grav",
@@ -26,6 +26,11 @@ namespace Server.Spells.Fifth
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+        public bool OnInstantCast(IEntity target)
+        {
+            Target(target.Location);
+            return true;
         }
 
         public void Target(IPoint3D p)

--- a/Scripts/Spells/Fifth/PoisonField.cs
+++ b/Scripts/Spells/Fifth/PoisonField.cs
@@ -1,6 +1,7 @@
 using Server.Items;
 using Server.Misc;
 using Server.Mobiles;
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 using System.Collections;
@@ -27,10 +28,17 @@ namespace Server.Spells.Fifth
         {
             Caster.Target = new InternalTarget(this);
         }
+
         public bool OnInstantCast(IEntity target)
         {
-            Target(target.Location);
-            return true;
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(IPoint3D p)

--- a/Scripts/Spells/First/Clumsy.cs
+++ b/Scripts/Spells/First/Clumsy.cs
@@ -1,3 +1,4 @@
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 using System.Collections.Generic;
@@ -53,9 +54,10 @@ namespace Server.Spells.First
         }
         public bool OnInstantCast(IEntity target)
         {
-            if (target is Mobile)
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
             {
-                Target(target as Mobile);
+                t.Invoke(Caster, target);
                 return true;
             }
             else

--- a/Scripts/Spells/First/Clumsy.cs
+++ b/Scripts/Spells/First/Clumsy.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace Server.Spells.First
 {
-    public class ClumsySpell : MagerySpell
+    public class ClumsySpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo _Info = new SpellInfo(
             "Clumsy", "Uus Jux",
@@ -50,6 +50,16 @@ namespace Server.Spells.First
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+        public bool OnInstantCast(IEntity target)
+        {
+            if (target is Mobile)
+            {
+                Target(target as Mobile);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(Mobile m)

--- a/Scripts/Spells/First/Clumsy.cs
+++ b/Scripts/Spells/First/Clumsy.cs
@@ -1,11 +1,11 @@
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 using System.Collections.Generic;
 
 namespace Server.Spells.First
 {
-    public class ClumsySpell : MagerySpell, InstantCast
+    public class ClumsySpell : MagerySpell
     {
         private static readonly SpellInfo _Info = new SpellInfo(
             "Clumsy", "Uus Jux",
@@ -52,7 +52,7 @@ namespace Server.Spells.First
         {
             Caster.Target = new InternalTarget(this);
         }
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/First/Feeblemind.cs
+++ b/Scripts/Spells/First/Feeblemind.cs
@@ -1,3 +1,4 @@
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 using System.Collections.Generic;
@@ -51,9 +52,10 @@ namespace Server.Spells.First
         }
         public bool OnInstantCast(IEntity target)
         {
-            if (target is Mobile)
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
             {
-                Target(target as Mobile);
+                t.Invoke(Caster, target);
                 return true;
             }
             else

--- a/Scripts/Spells/First/Feeblemind.cs
+++ b/Scripts/Spells/First/Feeblemind.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace Server.Spells.First
 {
-    public class FeeblemindSpell : MagerySpell
+    public class FeeblemindSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Feeblemind", "Rel Wis",
@@ -48,6 +48,16 @@ namespace Server.Spells.First
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+        public bool OnInstantCast(IEntity target)
+        {
+            if (target is Mobile)
+            {
+                Target(target as Mobile);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(Mobile m)

--- a/Scripts/Spells/First/Feeblemind.cs
+++ b/Scripts/Spells/First/Feeblemind.cs
@@ -1,11 +1,11 @@
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 using System.Collections.Generic;
 
 namespace Server.Spells.First
 {
-    public class FeeblemindSpell : MagerySpell, InstantCast
+    public class FeeblemindSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Feeblemind", "Rel Wis",
@@ -50,7 +50,7 @@ namespace Server.Spells.First
         {
             Caster.Target = new InternalTarget(this);
         }
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/First/Heal.cs
+++ b/Scripts/Spells/First/Heal.cs
@@ -1,11 +1,11 @@
 using Server.Mobiles;
 using Server.Network;
-using Server.Spells.Base;
+
 using Server.Targeting;
 
 namespace Server.Spells.First
 {
-    public class HealSpell : MagerySpell, InstantCast
+    public class HealSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Heal", "In Mani",
@@ -25,7 +25,7 @@ namespace Server.Spells.First
         {
             Caster.Target = new InternalTarget(this);
         }
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/First/Heal.cs
+++ b/Scripts/Spells/First/Heal.cs
@@ -1,5 +1,6 @@
 using Server.Mobiles;
 using Server.Network;
+using Server.Spells.Base;
 using Server.Targeting;
 
 namespace Server.Spells.First
@@ -26,9 +27,10 @@ namespace Server.Spells.First
         }
         public bool OnInstantCast(IEntity target)
         {
-            if (target is Mobile)
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
             {
-                Target(target as Mobile);
+                t.Invoke(Caster, target);
                 return true;
             }
             else

--- a/Scripts/Spells/First/Heal.cs
+++ b/Scripts/Spells/First/Heal.cs
@@ -4,7 +4,7 @@ using Server.Targeting;
 
 namespace Server.Spells.First
 {
-    public class HealSpell : MagerySpell
+    public class HealSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Heal", "In Mani",
@@ -23,6 +23,16 @@ namespace Server.Spells.First
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+        public bool OnInstantCast(IEntity target)
+        {
+            if (target is Mobile)
+            {
+                Target(target as Mobile);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(Mobile m)

--- a/Scripts/Spells/First/MagicArrow.cs
+++ b/Scripts/Spells/First/MagicArrow.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Server.Spells.First
 {
-    public class MagicArrowSpell : MagerySpell
+    public class MagicArrowSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Magic Arrow", "In Por Ylem",
@@ -23,7 +23,16 @@ namespace Server.Spells.First
         {
             Caster.Target = new InternalTarget(this);
         }
-
+        public bool OnInstantCast(IEntity target)
+        {
+            if (target is IDamageable)
+            {
+                Target(target as IDamageable);
+                return true;
+            }
+            else
+                return false;
+        }
         public void Target(IDamageable d)
         {
             if (!Caster.CanSee(d))

--- a/Scripts/Spells/First/MagicArrow.cs
+++ b/Scripts/Spells/First/MagicArrow.cs
@@ -1,10 +1,10 @@
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.First
 {
-    public class MagicArrowSpell : MagerySpell, InstantCast
+    public class MagicArrowSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Magic Arrow", "In Por Ylem",
@@ -24,7 +24,7 @@ namespace Server.Spells.First
         {
             Caster.Target = new InternalTarget(this);
         }
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/First/MagicArrow.cs
+++ b/Scripts/Spells/First/MagicArrow.cs
@@ -1,3 +1,4 @@
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 
@@ -25,9 +26,10 @@ namespace Server.Spells.First
         }
         public bool OnInstantCast(IEntity target)
         {
-            if (target is IDamageable)
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
             {
-                Target(target as IDamageable);
+                t.Invoke(Caster, target);
                 return true;
             }
             else

--- a/Scripts/Spells/First/NightSight.cs
+++ b/Scripts/Spells/First/NightSight.cs
@@ -1,9 +1,9 @@
-using Server.Spells.Base;
+
 using Server.Targeting;
 
 namespace Server.Spells.First
 {
-    public class NightSightSpell : MagerySpell, InstantCast
+    public class NightSightSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Night Sight", "In Lor",
@@ -22,7 +22,7 @@ namespace Server.Spells.First
         {
             Caster.Target = new NightSightTarget(this);
         }
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new NightSightTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/First/NightSight.cs
+++ b/Scripts/Spells/First/NightSight.cs
@@ -1,3 +1,4 @@
+using Server.Spells.Base;
 using Server.Targeting;
 
 namespace Server.Spells.First
@@ -23,9 +24,10 @@ namespace Server.Spells.First
         }
         public bool OnInstantCast(IEntity target)
         {
-            if (target is Mobile)
+            Target t = new NightSightTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
             {
-                Target(target as Mobile);
+                t.Invoke(Caster, target);
                 return true;
             }
             else

--- a/Scripts/Spells/First/NightSight.cs
+++ b/Scripts/Spells/First/NightSight.cs
@@ -2,7 +2,7 @@ using Server.Targeting;
 
 namespace Server.Spells.First
 {
-    public class NightSightSpell : MagerySpell
+    public class NightSightSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Night Sight", "In Lor",
@@ -20,6 +20,16 @@ namespace Server.Spells.First
         public override void OnCast()
         {
             Caster.Target = new NightSightTarget(this);
+        }
+        public bool OnInstantCast(IEntity target)
+        {
+            if (target is Mobile)
+            {
+                Target(target as Mobile);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(Mobile targ)

--- a/Scripts/Spells/First/Weaken.cs
+++ b/Scripts/Spells/First/Weaken.cs
@@ -1,11 +1,11 @@
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 using System.Collections.Generic;
 
 namespace Server.Spells.First
 {
-    public class WeakenSpell : MagerySpell, InstantCast
+    public class WeakenSpell : MagerySpell
     {
         private static readonly SpellInfo _Info = new SpellInfo(
             "Weaken", "Des Mani",
@@ -53,7 +53,7 @@ namespace Server.Spells.First
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/First/Weaken.cs
+++ b/Scripts/Spells/First/Weaken.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace Server.Spells.First
 {
-    public class WeakenSpell : MagerySpell
+    public class WeakenSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo _Info = new SpellInfo(
             "Weaken", "Des Mani",
@@ -51,7 +51,16 @@ namespace Server.Spells.First
         {
             Caster.Target = new InternalTarget(this);
         }
-
+        public bool OnInstantCast(IEntity target)
+        {
+            if (target is Mobile)
+            {
+                Target(target as Mobile);
+                return true;
+            }
+            else
+                return false;
+        }
         public void Target(Mobile m)
         {
             if (!Caster.CanSee(m))

--- a/Scripts/Spells/First/Weaken.cs
+++ b/Scripts/Spells/First/Weaken.cs
@@ -1,3 +1,4 @@
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 using System.Collections.Generic;
@@ -51,16 +52,19 @@ namespace Server.Spells.First
         {
             Caster.Target = new InternalTarget(this);
         }
+
         public bool OnInstantCast(IEntity target)
         {
-            if (target is Mobile)
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
             {
-                Target(target as Mobile);
+                t.Invoke(Caster, target);
                 return true;
             }
             else
                 return false;
         }
+
         public void Target(Mobile m)
         {
             if (!Caster.CanSee(m))

--- a/Scripts/Spells/Fourth/ArchCure.cs
+++ b/Scripts/Spells/Fourth/ArchCure.cs
@@ -1,12 +1,12 @@
 using Server.Mobiles;
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 using System.Collections.Generic;
 
 namespace Server.Spells.Fourth
 {
-    public class ArchCureSpell : MagerySpell, InstantCast
+    public class ArchCureSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Arch Cure", "Vas An Nox",
@@ -27,7 +27,7 @@ namespace Server.Spells.Fourth
         {
             Caster.Target = new InternalTarget(this);
         }
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Fourth/ArchCure.cs
+++ b/Scripts/Spells/Fourth/ArchCure.cs
@@ -1,4 +1,5 @@
 using Server.Mobiles;
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 using System.Collections.Generic;
@@ -28,8 +29,14 @@ namespace Server.Spells.Fourth
         }
         public bool OnInstantCast(IEntity target)
         {
-            Target(target.Location);
-            return true;
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(IPoint3D p)

--- a/Scripts/Spells/Fourth/ArchCure.cs
+++ b/Scripts/Spells/Fourth/ArchCure.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Server.Spells.Fourth
 {
-    public class ArchCureSpell : MagerySpell
+    public class ArchCureSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Arch Cure", "Vas An Nox",
@@ -25,6 +25,11 @@ namespace Server.Spells.Fourth
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+        public bool OnInstantCast(IEntity target)
+        {
+            Target(target.Location);
+            return true;
         }
 
         public void Target(IPoint3D p)

--- a/Scripts/Spells/Fourth/ArchProtection.cs
+++ b/Scripts/Spells/Fourth/ArchProtection.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace Server.Spells.Fourth
 {
-    public class ArchProtectionSpell : MagerySpell
+    public class ArchProtectionSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo _Info = new SpellInfo(
             "Arch Protection", "Vas Uus Sanct",
@@ -26,7 +26,11 @@ namespace Server.Spells.Fourth
         {
             Caster.Target = new InternalTarget(this);
         }
-
+        public bool OnInstantCast(IEntity target)
+        {
+            Target(target.Location);
+            return true;
+        }
         public void Target(IPoint3D p)
         {
             if (!Caster.CanSee(p))

--- a/Scripts/Spells/Fourth/ArchProtection.cs
+++ b/Scripts/Spells/Fourth/ArchProtection.cs
@@ -1,11 +1,11 @@
 using Server.Engines.PartySystem;
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System.Collections.Generic;
 
 namespace Server.Spells.Fourth
 {
-    public class ArchProtectionSpell : MagerySpell, InstantCast
+    public class ArchProtectionSpell : MagerySpell
     {
         private static readonly SpellInfo _Info = new SpellInfo(
             "Arch Protection", "Vas Uus Sanct",
@@ -28,7 +28,7 @@ namespace Server.Spells.Fourth
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Fourth/ArchProtection.cs
+++ b/Scripts/Spells/Fourth/ArchProtection.cs
@@ -1,4 +1,5 @@
 using Server.Engines.PartySystem;
+using Server.Spells.Base;
 using Server.Targeting;
 using System.Collections.Generic;
 
@@ -26,11 +27,19 @@ namespace Server.Spells.Fourth
         {
             Caster.Target = new InternalTarget(this);
         }
+
         public bool OnInstantCast(IEntity target)
         {
-            Target(target.Location);
-            return true;
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
+
         public void Target(IPoint3D p)
         {
             if (!Caster.CanSee(p))

--- a/Scripts/Spells/Fourth/Curse.cs
+++ b/Scripts/Spells/Fourth/Curse.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Server.Spells.Fourth
 {
-    public class CurseSpell : MagerySpell
+    public class CurseSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo _Info = new SpellInfo(
             "Curse", "Des Sanct",
@@ -96,6 +96,16 @@ namespace Server.Spells.Fourth
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+        public bool OnInstantCast(IEntity target)
+        {
+            if (target is Mobile)
+            {
+                Target(target as Mobile);
+                return true;
+            }
+            else
+                return false;
         }
 
         public static bool DoCurse(Mobile caster, Mobile m, bool masscurse)

--- a/Scripts/Spells/Fourth/Curse.cs
+++ b/Scripts/Spells/Fourth/Curse.cs
@@ -1,4 +1,4 @@
-using Server.Spells.Base;
+
 using Server.Spells.First;
 using Server.Targeting;
 using System;
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace Server.Spells.Fourth
 {
-    public class CurseSpell : MagerySpell, InstantCast
+    public class CurseSpell : MagerySpell
     {
         private static readonly SpellInfo _Info = new SpellInfo(
             "Curse", "Des Sanct",
@@ -99,7 +99,7 @@ namespace Server.Spells.Fourth
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Fourth/Curse.cs
+++ b/Scripts/Spells/Fourth/Curse.cs
@@ -1,3 +1,4 @@
+using Server.Spells.Base;
 using Server.Spells.First;
 using Server.Targeting;
 using System;
@@ -97,11 +98,13 @@ namespace Server.Spells.Fourth
         {
             Caster.Target = new InternalTarget(this);
         }
+
         public bool OnInstantCast(IEntity target)
         {
-            if (target is Mobile)
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
             {
-                Target(target as Mobile);
+                t.Invoke(Caster, target);
                 return true;
             }
             else

--- a/Scripts/Spells/Fourth/FireField.cs
+++ b/Scripts/Spells/Fourth/FireField.cs
@@ -1,14 +1,14 @@
 using Server.Items;
 using Server.Misc;
 using Server.Mobiles;
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 using System.Collections;
 
 namespace Server.Spells.Fourth
 {
-    public class FireFieldSpell : MagerySpell, InstantCast
+    public class FireFieldSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Fire Field", "In Flam Grav",
@@ -29,7 +29,7 @@ namespace Server.Spells.Fourth
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Fourth/FireField.cs
+++ b/Scripts/Spells/Fourth/FireField.cs
@@ -1,6 +1,7 @@
 using Server.Items;
 using Server.Misc;
 using Server.Mobiles;
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 using System.Collections;
@@ -27,10 +28,17 @@ namespace Server.Spells.Fourth
         {
             Caster.Target = new InternalTarget(this);
         }
+
         public bool OnInstantCast(IEntity target)
         {
-            Target(target.Location);
-            return true;
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(IPoint3D p)

--- a/Scripts/Spells/Fourth/FireField.cs
+++ b/Scripts/Spells/Fourth/FireField.cs
@@ -7,7 +7,7 @@ using System.Collections;
 
 namespace Server.Spells.Fourth
 {
-    public class FireFieldSpell : MagerySpell
+    public class FireFieldSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Fire Field", "In Flam Grav",
@@ -26,6 +26,11 @@ namespace Server.Spells.Fourth
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+        public bool OnInstantCast(IEntity target)
+        {
+            Target(target.Location);
+            return true;
         }
 
         public void Target(IPoint3D p)

--- a/Scripts/Spells/Fourth/GreaterHeal.cs
+++ b/Scripts/Spells/Fourth/GreaterHeal.cs
@@ -4,7 +4,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Fourth
 {
-    public class GreaterHealSpell : MagerySpell
+    public class GreaterHealSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Greater Heal", "In Vas Mani",
@@ -24,6 +24,16 @@ namespace Server.Spells.Fourth
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+        public bool OnInstantCast(IEntity target)
+        {
+            if (target is Mobile)
+            {
+                Target(target as Mobile);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(Mobile m)

--- a/Scripts/Spells/Fourth/GreaterHeal.cs
+++ b/Scripts/Spells/Fourth/GreaterHeal.cs
@@ -1,11 +1,11 @@
 using Server.Mobiles;
 using Server.Network;
-using Server.Spells.Base;
+
 using Server.Targeting;
 
 namespace Server.Spells.Fourth
 {
-    public class GreaterHealSpell : MagerySpell, InstantCast
+    public class GreaterHealSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Greater Heal", "In Vas Mani",
@@ -27,7 +27,7 @@ namespace Server.Spells.Fourth
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Fourth/GreaterHeal.cs
+++ b/Scripts/Spells/Fourth/GreaterHeal.cs
@@ -1,5 +1,6 @@
 using Server.Mobiles;
 using Server.Network;
+using Server.Spells.Base;
 using Server.Targeting;
 
 namespace Server.Spells.Fourth
@@ -25,11 +26,13 @@ namespace Server.Spells.Fourth
         {
             Caster.Target = new InternalTarget(this);
         }
+
         public bool OnInstantCast(IEntity target)
         {
-            if (target is Mobile)
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
             {
-                Target(target as Mobile);
+                t.Invoke(Caster, target);
                 return true;
             }
             else

--- a/Scripts/Spells/Fourth/Lightning.cs
+++ b/Scripts/Spells/Fourth/Lightning.cs
@@ -3,7 +3,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Fourth
 {
-    public class LightningSpell : MagerySpell
+    public class LightningSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Lightning", "Por Ort Grav",
@@ -21,6 +21,16 @@ namespace Server.Spells.Fourth
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+        public bool OnInstantCast(IEntity target)
+        {
+            if (target is IDamageable d)
+            {
+                Target(d);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(IDamageable m)

--- a/Scripts/Spells/Fourth/Lightning.cs
+++ b/Scripts/Spells/Fourth/Lightning.cs
@@ -1,12 +1,12 @@
 using Server.Items;
 using Server.Mobiles;
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Fourth
 {
-    public class LightningSpell : MagerySpell, InstantCast
+    public class LightningSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Lightning", "Por Ort Grav",
@@ -26,7 +26,7 @@ namespace Server.Spells.Fourth
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Fourth/Lightning.cs
+++ b/Scripts/Spells/Fourth/Lightning.cs
@@ -1,4 +1,5 @@
 using Server.Mobiles;
+using Server.Spells.Base;
 using Server.Targeting;
 
 namespace Server.Spells.Fourth
@@ -22,11 +23,13 @@ namespace Server.Spells.Fourth
         {
             Caster.Target = new InternalTarget(this);
         }
+
         public bool OnInstantCast(IEntity target)
         {
-            if (target is IDamageable d)
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
             {
-                Target(d);
+                t.Invoke(Caster, target);
                 return true;
             }
             else

--- a/Scripts/Spells/Fourth/Lightning.cs
+++ b/Scripts/Spells/Fourth/Lightning.cs
@@ -74,7 +74,7 @@ namespace Server.Spells.Fourth
             }
             else
             {
-                Effects.SendBoltEffect(EffectMobile.Create(entity.Location, entity.Map, EffectMobile.DefaultDuration), true, new Random().Next(128), false);
+                Effects.SendBoltEffect(EffectMobile.Create(entity.Location, entity.Map, EffectMobile.DefaultDuration), true, Utility.Random(128), false);
             }
         }
 

--- a/Scripts/Spells/Fourth/ManaDrain.cs
+++ b/Scripts/Spells/Fourth/ManaDrain.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace Server.Spells.Fourth
 {
-    public class ManaDrainSpell : MagerySpell
+    public class ManaDrainSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Mana Drain", "Ort Rel",
@@ -23,6 +23,16 @@ namespace Server.Spells.Fourth
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+        public bool OnInstantCast(IEntity target)
+        {
+            if (target is Mobile)
+            {
+                Target(target as Mobile);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(Mobile m)

--- a/Scripts/Spells/Fourth/ManaDrain.cs
+++ b/Scripts/Spells/Fourth/ManaDrain.cs
@@ -1,11 +1,11 @@
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 using System.Collections.Generic;
 
 namespace Server.Spells.Fourth
 {
-    public class ManaDrainSpell : MagerySpell, InstantCast
+    public class ManaDrainSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Mana Drain", "Ort Rel",
@@ -26,7 +26,7 @@ namespace Server.Spells.Fourth
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Fourth/ManaDrain.cs
+++ b/Scripts/Spells/Fourth/ManaDrain.cs
@@ -1,3 +1,4 @@
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 using System.Collections.Generic;
@@ -24,11 +25,13 @@ namespace Server.Spells.Fourth
         {
             Caster.Target = new InternalTarget(this);
         }
+
         public bool OnInstantCast(IEntity target)
         {
-            if (target is Mobile)
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
             {
-                Target(target as Mobile);
+                t.Invoke(Caster, target);
                 return true;
             }
             else

--- a/Scripts/Spells/Fourth/Recall.cs
+++ b/Scripts/Spells/Fourth/Recall.cs
@@ -5,10 +5,11 @@ using Server.Multis;
 using Server.Network;
 using Server.Spells.Necromancy;
 using Server.Targeting;
+using System.Numerics;
 
 namespace Server.Spells.Fourth
 {
-    public class RecallSpell : MagerySpell
+    public class RecallSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Recall", "Kal Ort Por",
@@ -50,7 +51,11 @@ namespace Server.Spells.Fourth
             else
                 base.GetCastSkills(out min, out max);
         }
-
+        public bool OnInstantCast(IEntity target)
+        {
+            new InternalTarget(this, target as object);
+                return true;
+        }
         public override void OnCast()
         {
             if (m_Entry == null && m_SearchMap == null)
@@ -223,6 +228,12 @@ namespace Server.Spells.Fourth
                 m_Owner = owner;
 
                 owner.Caster.LocalOverheadMessage(MessageType.Regular, 0x3B2, 501029); // Select Marked item.
+            }
+            public InternalTarget(RecallSpell owner, object target)
+            : base(10, false, TargetFlags.None)
+            {
+                m_Owner = owner;
+                OnTarget(owner.Caster, target);
             }
 
             protected override void OnTarget(Mobile from, object o)

--- a/Scripts/Spells/Fourth/Recall.cs
+++ b/Scripts/Spells/Fourth/Recall.cs
@@ -3,6 +3,7 @@ using Server.Items;
 using Server.Mobiles;
 using Server.Multis;
 using Server.Network;
+using Server.Spells.Base;
 using Server.Spells.Necromancy;
 using Server.Targeting;
 using System.Numerics;
@@ -51,11 +52,19 @@ namespace Server.Spells.Fourth
             else
                 base.GetCastSkills(out min, out max);
         }
+
         public bool OnInstantCast(IEntity target)
         {
-            new InternalTarget(this, target as object);
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
                 return true;
+            }
+            else
+                return false;
         }
+
         public override void OnCast()
         {
             if (m_Entry == null && m_SearchMap == null)

--- a/Scripts/Spells/Fourth/Recall.cs
+++ b/Scripts/Spells/Fourth/Recall.cs
@@ -3,14 +3,14 @@ using Server.Items;
 using Server.Mobiles;
 using Server.Multis;
 using Server.Network;
-using Server.Spells.Base;
+
 using Server.Spells.Necromancy;
 using Server.Targeting;
 using System.Numerics;
 
 namespace Server.Spells.Fourth
 {
-    public class RecallSpell : MagerySpell, InstantCast
+    public class RecallSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Recall", "Kal Ort Por",
@@ -53,7 +53,7 @@ namespace Server.Spells.Fourth
                 base.GetCastSkills(out min, out max);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InLOS(target))

--- a/Scripts/Spells/Fourth/Recall.cs
+++ b/Scripts/Spells/Fourth/Recall.cs
@@ -55,9 +55,9 @@ namespace Server.Spells.Fourth
 
         public override bool OnInstantCast(IEntity target)
         {
-            Target t = new InternalTarget(this);
             if (Caster.InLOS(target))
             {
+                Target t = new InternalTarget(this);
                 t.Invoke(Caster, target);
                 return true;
             }
@@ -237,12 +237,6 @@ namespace Server.Spells.Fourth
                 m_Owner = owner;
 
                 owner.Caster.LocalOverheadMessage(MessageType.Regular, 0x3B2, 501029); // Select Marked item.
-            }
-            public InternalTarget(RecallSpell owner, object target)
-            : base(10, false, TargetFlags.None)
-            {
-                m_Owner = owner;
-                OnTarget(owner.Caster, target);
             }
 
             protected override void OnTarget(Mobile from, object o)

--- a/Scripts/Spells/Fourth/Recall.cs
+++ b/Scripts/Spells/Fourth/Recall.cs
@@ -56,7 +56,7 @@ namespace Server.Spells.Fourth
         public bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
-            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            if (Caster.InLOS(target))
             {
                 t.Invoke(Caster, target);
                 return true;

--- a/Scripts/Spells/Mysticism/SpellDefinitions/AnimatedWeaponSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/AnimatedWeaponSpell.cs
@@ -1,11 +1,11 @@
 using Server.Mobiles;
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Mysticism
 {
-    public class AnimatedWeaponSpell : MysticSpell, InstantCast
+    public class AnimatedWeaponSpell : MysticSpell
     {
         public override SpellCircle Circle => SpellCircle.Fourth;
 
@@ -28,7 +28,7 @@ namespace Server.Spells.Mysticism
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target(target.Location);
             return true;

--- a/Scripts/Spells/Mysticism/SpellDefinitions/AnimatedWeaponSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/AnimatedWeaponSpell.cs
@@ -1,10 +1,11 @@
 using Server.Mobiles;
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Mysticism
 {
-    public class AnimatedWeaponSpell : MysticSpell
+    public class AnimatedWeaponSpell : MysticSpell, InstantCast
     {
         public override SpellCircle Circle => SpellCircle.Fourth;
 
@@ -25,6 +26,12 @@ namespace Server.Spells.Mysticism
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target(target.Location);
+            return true;
         }
 
         public void Target(IPoint3D p)

--- a/Scripts/Spells/Mysticism/SpellDefinitions/BombardSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/BombardSpell.cs
@@ -1,9 +1,10 @@
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Mysticism
 {
-    public class BombardSpell : MysticSpell
+    public class BombardSpell : MysticSpell, InstantCast
     {
         public override SpellCircle Circle => SpellCircle.Sixth;
         public override bool DelayedDamage => true;
@@ -26,6 +27,18 @@ namespace Server.Spells.Mysticism
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void OnTarget(IDamageable d)
@@ -81,6 +94,7 @@ namespace Server.Spells.Mysticism
 
             FinishSequence();
         }
+
 
         public class InternalTarget : Target
         {

--- a/Scripts/Spells/Mysticism/SpellDefinitions/BombardSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/BombardSpell.cs
@@ -1,10 +1,10 @@
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Mysticism
 {
-    public class BombardSpell : MysticSpell, InstantCast
+    public class BombardSpell : MysticSpell
     {
         public override SpellCircle Circle => SpellCircle.Sixth;
         public override bool DelayedDamage => true;
@@ -29,7 +29,7 @@ namespace Server.Spells.Mysticism
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Mysticism/SpellDefinitions/CleansingWindsSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/CleansingWindsSpell.cs
@@ -1,5 +1,6 @@
 using Server.Engines.PartySystem;
 using Server.Items;
+using Server.Spells.Base;
 using Server.Spells.First;
 using Server.Spells.Fourth;
 using Server.Spells.Necromancy;
@@ -9,7 +10,7 @@ using System.Linq;
 
 namespace Server.Spells.Mysticism
 {
-    public class CleansingWindsSpell : MysticSpell
+    public class CleansingWindsSpell : MysticSpell, InstantCast
     {
         public override SpellCircle Circle => SpellCircle.Sixth;
 
@@ -31,6 +32,18 @@ namespace Server.Spells.Mysticism
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void OnTarget(object o)

--- a/Scripts/Spells/Mysticism/SpellDefinitions/CleansingWindsSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/CleansingWindsSpell.cs
@@ -1,6 +1,6 @@
 using Server.Engines.PartySystem;
 using Server.Items;
-using Server.Spells.Base;
+
 using Server.Spells.First;
 using Server.Spells.Fourth;
 using Server.Spells.Necromancy;
@@ -10,7 +10,7 @@ using System.Linq;
 
 namespace Server.Spells.Mysticism
 {
-    public class CleansingWindsSpell : MysticSpell, InstantCast
+    public class CleansingWindsSpell : MysticSpell
     {
         public override SpellCircle Circle => SpellCircle.Sixth;
 
@@ -34,7 +34,7 @@ namespace Server.Spells.Mysticism
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Mysticism/SpellDefinitions/EagleStrikeSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/EagleStrikeSpell.cs
@@ -1,3 +1,4 @@
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 

--- a/Scripts/Spells/Mysticism/SpellDefinitions/EagleStrikeSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/EagleStrikeSpell.cs
@@ -1,10 +1,10 @@
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Mysticism
 {
-    public class EagleStrikeSpell : MysticSpell, InstantCast
+    public class EagleStrikeSpell : MysticSpell
     {
         public override SpellCircle Circle => SpellCircle.Third;
         public override bool DelayedDamage => true;
@@ -29,7 +29,7 @@ namespace Server.Spells.Mysticism
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Mysticism/SpellDefinitions/EagleStrikeSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/EagleStrikeSpell.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Server.Spells.Mysticism
 {
-    public class EagleStrikeSpell : MysticSpell
+    public class EagleStrikeSpell : MysticSpell, InstantCast
     {
         public override SpellCircle Circle => SpellCircle.Third;
         public override bool DelayedDamage => true;
@@ -26,6 +26,18 @@ namespace Server.Spells.Mysticism
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void OnTarget(IDamageable d)

--- a/Scripts/Spells/Mysticism/SpellDefinitions/HailStormSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/HailStormSpell.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Server.Spells.Mysticism
 {
-    public class HailStormSpell : MysticSpell
+    public class HailStormSpell : MysticSpell, InstantCast
     {
         public override SpellCircle Circle => SpellCircle.Seventh;
         public override bool DelayedDamage => false;
@@ -29,6 +29,18 @@ namespace Server.Spells.Mysticism
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void OnTarget(IPoint3D p)

--- a/Scripts/Spells/Mysticism/SpellDefinitions/HailStormSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/HailStormSpell.cs
@@ -1,12 +1,12 @@
 using Server.Mobiles;
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 using System.Collections.Generic;
 
 namespace Server.Spells.Mysticism
 {
-    public class HailStormSpell : MysticSpell, InstantCast
+    public class HailStormSpell : MysticSpell
     {
         public override SpellCircle Circle => SpellCircle.Seventh;
         public override bool DelayedDamage => false;
@@ -32,7 +32,7 @@ namespace Server.Spells.Mysticism
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Mysticism/SpellDefinitions/HailStormSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/HailStormSpell.cs
@@ -1,4 +1,5 @@
 using Server.Mobiles;
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 using System.Collections.Generic;

--- a/Scripts/Spells/Mysticism/SpellDefinitions/MassSleepSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/MassSleepSpell.cs
@@ -1,10 +1,10 @@
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Mysticism
 {
-    public class MassSleepSpell : MysticSpell, InstantCast
+    public class MassSleepSpell : MysticSpell
     {
         public override SpellCircle Circle => SpellCircle.Fifth;
 
@@ -25,7 +25,7 @@ namespace Server.Spells.Mysticism
         {
             Caster.Target = new InternalTarget(this);
         }
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target(target.Location);
             return true;

--- a/Scripts/Spells/Mysticism/SpellDefinitions/MassSleepSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/MassSleepSpell.cs
@@ -1,9 +1,10 @@
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Mysticism
 {
-    public class MassSleepSpell : MysticSpell
+    public class MassSleepSpell : MysticSpell, InstantCast
     {
         public override SpellCircle Circle => SpellCircle.Fifth;
 
@@ -23,6 +24,11 @@ namespace Server.Spells.Mysticism
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+        public bool OnInstantCast(IEntity target)
+        {
+            Target(target.Location);
+            return true;
         }
 
         public class InternalTarget : Target

--- a/Scripts/Spells/Mysticism/SpellDefinitions/NetherBoltSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/NetherBoltSpell.cs
@@ -1,3 +1,4 @@
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 

--- a/Scripts/Spells/Mysticism/SpellDefinitions/NetherBoltSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/NetherBoltSpell.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Server.Spells.Mysticism
 {
-    public class NetherBoltSpell : MysticSpell
+    public class NetherBoltSpell : MysticSpell, InstantCast
     {
         public override SpellCircle Circle => SpellCircle.First;
 
@@ -26,6 +26,18 @@ namespace Server.Spells.Mysticism
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void OnTarget(IDamageable d)

--- a/Scripts/Spells/Mysticism/SpellDefinitions/NetherBoltSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/NetherBoltSpell.cs
@@ -1,10 +1,10 @@
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Mysticism
 {
-    public class NetherBoltSpell : MysticSpell, InstantCast
+    public class NetherBoltSpell : MysticSpell
     {
         public override SpellCircle Circle => SpellCircle.First;
 
@@ -29,7 +29,7 @@ namespace Server.Spells.Mysticism
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Mysticism/SpellDefinitions/NetherCycloneSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/NetherCycloneSpell.cs
@@ -1,11 +1,11 @@
 using Server.Items;
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Mysticism
 {
-    public class NetherCycloneSpell : MysticSpell, InstantCast
+    public class NetherCycloneSpell : MysticSpell
     {
         public override SpellCircle Circle => SpellCircle.Eighth;
         public override DamageType SpellDamageType => DamageType.SpellAOE;
@@ -29,7 +29,7 @@ namespace Server.Spells.Mysticism
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Mysticism/SpellDefinitions/NetherCycloneSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/NetherCycloneSpell.cs
@@ -1,4 +1,5 @@
 using Server.Items;
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 

--- a/Scripts/Spells/Mysticism/SpellDefinitions/NetherCycloneSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/NetherCycloneSpell.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace Server.Spells.Mysticism
 {
-    public class NetherCycloneSpell : MysticSpell
+    public class NetherCycloneSpell : MysticSpell, InstantCast
     {
         public override SpellCircle Circle => SpellCircle.Eighth;
         public override DamageType SpellDamageType => DamageType.SpellAOE;
@@ -26,6 +26,18 @@ namespace Server.Spells.Mysticism
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void OnTarget(IPoint3D p)

--- a/Scripts/Spells/Mysticism/SpellDefinitions/PurgeMagicSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/PurgeMagicSpell.cs
@@ -25,7 +25,7 @@ namespace Server.Spells.Mysticism
         Bless
     }
 
-    public class PurgeMagicSpell : MysticSpell
+    public class PurgeMagicSpell : MysticSpell, InstantCast
     {
         public override SpellCircle Circle => SpellCircle.Second;
 
@@ -46,6 +46,18 @@ namespace Server.Spells.Mysticism
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void OnTarget(object o)

--- a/Scripts/Spells/Mysticism/SpellDefinitions/PurgeMagicSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/PurgeMagicSpell.cs
@@ -1,5 +1,5 @@
 using Server.Items;
-using Server.Spells.Base;
+
 using Server.Spells.Fifth;
 using Server.Spells.First;
 using Server.Spells.Ninjitsu;
@@ -26,7 +26,7 @@ namespace Server.Spells.Mysticism
         Bless
     }
 
-    public class PurgeMagicSpell : MysticSpell, InstantCast
+    public class PurgeMagicSpell : MysticSpell
     {
         public override SpellCircle Circle => SpellCircle.Second;
 
@@ -49,7 +49,7 @@ namespace Server.Spells.Mysticism
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Mysticism/SpellDefinitions/PurgeMagicSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/PurgeMagicSpell.cs
@@ -1,4 +1,5 @@
 using Server.Items;
+using Server.Spells.Base;
 using Server.Spells.Fifth;
 using Server.Spells.First;
 using Server.Spells.Ninjitsu;

--- a/Scripts/Spells/Mysticism/SpellDefinitions/RisingColossusSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/RisingColossusSpell.cs
@@ -1,11 +1,11 @@
 using Server.Mobiles;
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Mysticism
 {
-    public class RisingColossusSpell : MysticSpell, InstantCast
+    public class RisingColossusSpell : MysticSpell
     {
         public override SpellCircle Circle => SpellCircle.Eighth;
 
@@ -27,7 +27,7 @@ namespace Server.Spells.Mysticism
         {
             Caster.Target = new InternalTarget(this);
         }
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target(target.Location);
             return true;

--- a/Scripts/Spells/Mysticism/SpellDefinitions/RisingColossusSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/RisingColossusSpell.cs
@@ -1,10 +1,11 @@
 using Server.Mobiles;
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Mysticism
 {
-    public class RisingColossusSpell : MysticSpell
+    public class RisingColossusSpell : MysticSpell, InstantCast
     {
         public override SpellCircle Circle => SpellCircle.Eighth;
 
@@ -25,6 +26,11 @@ namespace Server.Spells.Mysticism
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+        public bool OnInstantCast(IEntity target)
+        {
+            Target(target.Location);
+            return true;
         }
 
         public void Target(IPoint3D p)

--- a/Scripts/Spells/Mysticism/SpellDefinitions/SleepSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/SleepSpell.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Server.Spells.Mysticism
 {
-    public class SleepSpell : MysticSpell
+    public class SleepSpell : MysticSpell, InstantCast
     {
         public override SpellCircle Circle => SpellCircle.Third;
 
@@ -26,6 +26,18 @@ namespace Server.Spells.Mysticism
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void OnTarget(object o)

--- a/Scripts/Spells/Mysticism/SpellDefinitions/SleepSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/SleepSpell.cs
@@ -1,12 +1,12 @@
 using Server.Network;
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 using System.Collections.Generic;
 
 namespace Server.Spells.Mysticism
 {
-    public class SleepSpell : MysticSpell, InstantCast
+    public class SleepSpell : MysticSpell
     {
         public override SpellCircle Circle => SpellCircle.Third;
 
@@ -29,7 +29,7 @@ namespace Server.Spells.Mysticism
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Mysticism/SpellDefinitions/SleepSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/SleepSpell.cs
@@ -1,4 +1,5 @@
 using Server.Network;
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 using System.Collections.Generic;

--- a/Scripts/Spells/Mysticism/SpellDefinitions/SpellPlague.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/SpellPlague.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Server.Spells.Mysticism
 {
-    public class SpellPlagueSpell : MysticSpell
+    public class SpellPlagueSpell : MysticSpell, InstantCast
     {
         private static readonly SpellInfo _Info = new SpellInfo(
                 "Spell Plague", "Vas Rel Jux Ort",
@@ -27,6 +27,18 @@ namespace Server.Spells.Mysticism
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void OnTarget(object o)

--- a/Scripts/Spells/Mysticism/SpellDefinitions/SpellPlague.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/SpellPlague.cs
@@ -1,12 +1,12 @@
 using Server.Mobiles;
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 using System.Collections.Generic;
 
 namespace Server.Spells.Mysticism
 {
-    public class SpellPlagueSpell : MysticSpell, InstantCast
+    public class SpellPlagueSpell : MysticSpell
     {
         private static readonly SpellInfo _Info = new SpellInfo(
                 "Spell Plague", "Vas Rel Jux Ort",
@@ -30,7 +30,7 @@ namespace Server.Spells.Mysticism
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Mysticism/SpellDefinitions/SpellPlague.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/SpellPlague.cs
@@ -1,4 +1,5 @@
 using Server.Mobiles;
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 using System.Collections.Generic;

--- a/Scripts/Spells/Necromancy/BloodOathSpell.cs
+++ b/Scripts/Spells/Necromancy/BloodOathSpell.cs
@@ -1,4 +1,4 @@
-using Server.Spells.Base;
+
 using Server.Spells.SkillMasteries;
 using Server.Targeting;
 using System;
@@ -6,7 +6,7 @@ using System.Collections;
 
 namespace Server.Spells.Necromancy
 {
-    public class BloodOathSpell : NecromancerSpell, InstantCast
+    public class BloodOathSpell : NecromancerSpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Blood Oath", "In Jux Mani Xen",
@@ -51,7 +51,7 @@ namespace Server.Spells.Necromancy
         {
             Caster.Target = new InternalTarget(this);
         }
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Necromancy/BloodOathSpell.cs
+++ b/Scripts/Spells/Necromancy/BloodOathSpell.cs
@@ -1,3 +1,4 @@
+using Server.Spells.Base;
 using Server.Spells.SkillMasteries;
 using Server.Targeting;
 using System;
@@ -5,7 +6,7 @@ using System.Collections;
 
 namespace Server.Spells.Necromancy
 {
-    public class BloodOathSpell : NecromancerSpell
+    public class BloodOathSpell : NecromancerSpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Blood Oath", "In Jux Mani Xen",
@@ -49,6 +50,17 @@ namespace Server.Spells.Necromancy
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(Mobile m)

--- a/Scripts/Spells/Necromancy/CorpseSkin.cs
+++ b/Scripts/Spells/Necromancy/CorpseSkin.cs
@@ -1,3 +1,4 @@
+using Server.Spells.Base;
 using Server.Spells.SkillMasteries;
 using Server.Targeting;
 using System;
@@ -5,7 +6,7 @@ using System.Collections.Generic;
 
 namespace Server.Spells.Necromancy
 {
-    public class CorpseSkinSpell : NecromancerSpell
+    public class CorpseSkinSpell : NecromancerSpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Corpse Skin", "In Agle Corp Ylem",
@@ -53,6 +54,18 @@ namespace Server.Spells.Necromancy
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(Mobile m)

--- a/Scripts/Spells/Necromancy/CorpseSkin.cs
+++ b/Scripts/Spells/Necromancy/CorpseSkin.cs
@@ -1,4 +1,4 @@
-using Server.Spells.Base;
+
 using Server.Spells.SkillMasteries;
 using Server.Targeting;
 using System;
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace Server.Spells.Necromancy
 {
-    public class CorpseSkinSpell : NecromancerSpell, InstantCast
+    public class CorpseSkinSpell : NecromancerSpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Corpse Skin", "In Agle Corp Ylem",
@@ -56,7 +56,7 @@ namespace Server.Spells.Necromancy
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Necromancy/EvilOmen.cs
+++ b/Scripts/Spells/Necromancy/EvilOmen.cs
@@ -1,4 +1,5 @@
 using Server.Mobiles;
+using Server.Spells.Base;
 using Server.Spells.SkillMasteries;
 using Server.Targeting;
 using System;
@@ -6,7 +7,7 @@ using System.Collections.Generic;
 
 namespace Server.Spells.Necromancy
 {
-    public class EvilOmenSpell : NecromancerSpell
+    public class EvilOmenSpell : NecromancerSpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Evil Omen", "Pas Tym An Sanct",
@@ -63,6 +64,18 @@ namespace Server.Spells.Necromancy
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(Mobile m)

--- a/Scripts/Spells/Necromancy/EvilOmen.cs
+++ b/Scripts/Spells/Necromancy/EvilOmen.cs
@@ -1,5 +1,5 @@
 using Server.Mobiles;
-using Server.Spells.Base;
+
 using Server.Spells.SkillMasteries;
 using Server.Targeting;
 using System;
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 
 namespace Server.Spells.Necromancy
 {
-    public class EvilOmenSpell : NecromancerSpell, InstantCast
+    public class EvilOmenSpell : NecromancerSpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Evil Omen", "Pas Tym An Sanct",
@@ -66,7 +66,7 @@ namespace Server.Spells.Necromancy
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Necromancy/MindRot.cs
+++ b/Scripts/Spells/Necromancy/MindRot.cs
@@ -1,3 +1,4 @@
+using Server.Spells.Base;
 using Server.Spells.SkillMasteries;
 using Server.Targeting;
 using System;
@@ -5,7 +6,7 @@ using System.Collections;
 
 namespace Server.Spells.Necromancy
 {
-    public class MindRotSpell : NecromancerSpell
+    public class MindRotSpell : NecromancerSpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Mind Rot", "Wis An Ben",
@@ -67,6 +68,18 @@ namespace Server.Spells.Necromancy
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(Mobile m)

--- a/Scripts/Spells/Necromancy/MindRot.cs
+++ b/Scripts/Spells/Necromancy/MindRot.cs
@@ -1,4 +1,4 @@
-using Server.Spells.Base;
+
 using Server.Spells.SkillMasteries;
 using Server.Targeting;
 using System;
@@ -6,7 +6,7 @@ using System.Collections;
 
 namespace Server.Spells.Necromancy
 {
-    public class MindRotSpell : NecromancerSpell, InstantCast
+    public class MindRotSpell : NecromancerSpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Mind Rot", "Wis An Ben",
@@ -70,7 +70,7 @@ namespace Server.Spells.Necromancy
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Necromancy/PainSpike.cs
+++ b/Scripts/Spells/Necromancy/PainSpike.cs
@@ -1,3 +1,4 @@
+using Server.Spells.Base;
 using Server.Spells.SkillMasteries;
 using Server.Targeting;
 using System;
@@ -5,7 +6,7 @@ using System.Collections.Generic;
 
 namespace Server.Spells.Necromancy
 {
-    public class PainSpikeSpell : NecromancerSpell
+    public class PainSpikeSpell : NecromancerSpell  , InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Pain Spike", "In Sar",
@@ -28,6 +29,18 @@ namespace Server.Spells.Necromancy
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(Mobile m)

--- a/Scripts/Spells/Necromancy/PainSpike.cs
+++ b/Scripts/Spells/Necromancy/PainSpike.cs
@@ -1,4 +1,4 @@
-using Server.Spells.Base;
+
 using Server.Spells.SkillMasteries;
 using Server.Targeting;
 using System;
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace Server.Spells.Necromancy
 {
-    public class PainSpikeSpell : NecromancerSpell  , InstantCast
+    public class PainSpikeSpell : NecromancerSpell  
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Pain Spike", "In Sar",
@@ -31,7 +31,7 @@ namespace Server.Spells.Necromancy
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Necromancy/PoisonStrike.cs
+++ b/Scripts/Spells/Necromancy/PoisonStrike.cs
@@ -30,6 +30,18 @@ namespace Server.Spells.Necromancy
             Caster.Target = new InternalTarget(this);
         }
 
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
+        }
+
         public void Target(IDamageable m)
         {
             if (CheckHSequence(m))
@@ -45,7 +57,7 @@ namespace Server.Spells.Necromancy
 
             FinishSequence();
         }
-
+            
         public void ApplyEffects(IDamageable m, double strength = 1.0)
         {
             /* Creates a blast of poisonous energy centered on the target.

--- a/Scripts/Spells/Necromancy/PoisonStrike.cs
+++ b/Scripts/Spells/Necromancy/PoisonStrike.cs
@@ -30,7 +30,7 @@ namespace Server.Spells.Necromancy
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Necromancy/Strangle.cs
+++ b/Scripts/Spells/Necromancy/Strangle.cs
@@ -1,4 +1,4 @@
-using Server.Spells.Base;
+
 using Server.Spells.SkillMasteries;
 using Server.Targeting;
 using System;
@@ -6,7 +6,7 @@ using System.Collections;
 
 namespace Server.Spells.Necromancy
 {
-    public class StrangleSpell : NecromancerSpell, InstantCast
+    public class StrangleSpell : NecromancerSpell
     {
         private static readonly SpellInfo _Info = new SpellInfo(
             "Strangle", "In Bal Nox",
@@ -54,7 +54,7 @@ namespace Server.Spells.Necromancy
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Necromancy/Strangle.cs
+++ b/Scripts/Spells/Necromancy/Strangle.cs
@@ -1,3 +1,4 @@
+using Server.Spells.Base;
 using Server.Spells.SkillMasteries;
 using Server.Targeting;
 using System;
@@ -5,7 +6,7 @@ using System.Collections;
 
 namespace Server.Spells.Necromancy
 {
-    public class StrangleSpell : NecromancerSpell
+    public class StrangleSpell : NecromancerSpell, InstantCast
     {
         private static readonly SpellInfo _Info = new SpellInfo(
             "Strangle", "In Bal Nox",
@@ -51,6 +52,18 @@ namespace Server.Spells.Necromancy
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(Mobile m)

--- a/Scripts/Spells/Necromancy/VengefulSpirit.cs
+++ b/Scripts/Spells/Necromancy/VengefulSpirit.cs
@@ -1,10 +1,11 @@
 using Server.Mobiles;
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Necromancy
 {
-    public class VengefulSpiritSpell : NecromancerSpell
+    public class VengefulSpiritSpell : NecromancerSpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Vengeful Spirit", "Kal Xen Bal Beh",
@@ -38,6 +39,18 @@ namespace Server.Spells.Necromancy
             }
 
             return true;
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(Mobile m)

--- a/Scripts/Spells/Necromancy/VengefulSpirit.cs
+++ b/Scripts/Spells/Necromancy/VengefulSpirit.cs
@@ -1,11 +1,11 @@
 using Server.Mobiles;
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Necromancy
 {
-    public class VengefulSpiritSpell : NecromancerSpell, InstantCast
+    public class VengefulSpiritSpell : NecromancerSpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Vengeful Spirit", "Kal Xen Bal Beh",
@@ -41,7 +41,7 @@ namespace Server.Spells.Necromancy
             return true;
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Ninjitsu/ShadowJump.cs
+++ b/Scripts/Spells/Ninjitsu/ShadowJump.cs
@@ -1,13 +1,13 @@
 using Server.Items;
 using Server.Mobiles;
 using Server.Regions;
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Ninjitsu
 {
-    public class Shadowjump : NinjaSpell, InstantCast
+    public class Shadowjump : NinjaSpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Shadowjump", null,
@@ -44,7 +44,7 @@ namespace Server.Spells.Ninjitsu
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Ninjitsu/ShadowJump.cs
+++ b/Scripts/Spells/Ninjitsu/ShadowJump.cs
@@ -1,12 +1,13 @@
 using Server.Items;
 using Server.Mobiles;
 using Server.Regions;
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Ninjitsu
 {
-    public class Shadowjump : NinjaSpell
+    public class Shadowjump : NinjaSpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Shadowjump", null,
@@ -41,6 +42,18 @@ namespace Server.Spells.Ninjitsu
         {
             Caster.SendLocalizedMessage(1063088); // You prepare to perform a Shadowjump.
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(IPoint3D p)

--- a/Scripts/Spells/Second/Agility.cs
+++ b/Scripts/Spells/Second/Agility.cs
@@ -1,9 +1,10 @@
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Second
 {
-    public class AgilitySpell : MagerySpell
+    public class AgilitySpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Agility", "Ex Uus",
@@ -21,6 +22,18 @@ namespace Server.Spells.Second
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(Mobile m)

--- a/Scripts/Spells/Second/Agility.cs
+++ b/Scripts/Spells/Second/Agility.cs
@@ -1,10 +1,10 @@
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Second
 {
-    public class AgilitySpell : MagerySpell, InstantCast
+    public class AgilitySpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Agility", "Ex Uus",
@@ -24,7 +24,7 @@ namespace Server.Spells.Second
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Second/Cunning.cs
+++ b/Scripts/Spells/Second/Cunning.cs
@@ -1,10 +1,10 @@
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Second
 {
-    public class CunningSpell : MagerySpell, InstantCast
+    public class CunningSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Cunning", "Uus Wis",
@@ -24,7 +24,7 @@ namespace Server.Spells.Second
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Second/Cunning.cs
+++ b/Scripts/Spells/Second/Cunning.cs
@@ -1,9 +1,10 @@
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Second
 {
-    public class CunningSpell : MagerySpell
+    public class CunningSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Cunning", "Uus Wis",
@@ -21,6 +22,18 @@ namespace Server.Spells.Second
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(Mobile m)

--- a/Scripts/Spells/Second/Cure.cs
+++ b/Scripts/Spells/Second/Cure.cs
@@ -1,8 +1,9 @@
+using Server.Spells.Base;
 using Server.Targeting;
 
 namespace Server.Spells.Second
 {
-    public class CureSpell : MagerySpell
+    public class CureSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Cure", "An Nox",
@@ -20,6 +21,18 @@ namespace Server.Spells.Second
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(Mobile m)

--- a/Scripts/Spells/Second/Cure.cs
+++ b/Scripts/Spells/Second/Cure.cs
@@ -1,9 +1,9 @@
-using Server.Spells.Base;
+
 using Server.Targeting;
 
 namespace Server.Spells.Second
 {
-    public class CureSpell : MagerySpell, InstantCast
+    public class CureSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Cure", "An Nox",
@@ -23,7 +23,7 @@ namespace Server.Spells.Second
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Second/Harm.cs
+++ b/Scripts/Spells/Second/Harm.cs
@@ -1,9 +1,9 @@
-using Server.Spells.Base;
+
 using Server.Targeting;
 
 namespace Server.Spells.Second
 {
-    public class HarmSpell : MagerySpell, InstantCast
+    public class HarmSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Harm", "An Mani",
@@ -23,7 +23,7 @@ namespace Server.Spells.Second
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Second/Harm.cs
+++ b/Scripts/Spells/Second/Harm.cs
@@ -1,8 +1,9 @@
+using Server.Spells.Base;
 using Server.Targeting;
 
 namespace Server.Spells.Second
 {
-    public class HarmSpell : MagerySpell
+    public class HarmSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Harm", "An Mani",
@@ -20,6 +21,18 @@ namespace Server.Spells.Second
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public override double GetSlayerDamageScalar(Mobile target)

--- a/Scripts/Spells/Second/MagicTrap.cs
+++ b/Scripts/Spells/Second/MagicTrap.cs
@@ -27,7 +27,7 @@ namespace Server.Spells.Second
         public bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
-            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            if (Caster.InLOS(target))
             {
                 t.Invoke(Caster, target);
                 return true;

--- a/Scripts/Spells/Second/MagicTrap.cs
+++ b/Scripts/Spells/Second/MagicTrap.cs
@@ -1,9 +1,10 @@
 using Server.Items;
+using Server.Spells.Base;
 using Server.Targeting;
 
 namespace Server.Spells.Second
 {
-    public class MagicTrapSpell : MagerySpell
+    public class MagicTrapSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Magic Trap", "In Jux",
@@ -21,6 +22,18 @@ namespace Server.Spells.Second
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(TrapableContainer item)

--- a/Scripts/Spells/Second/MagicTrap.cs
+++ b/Scripts/Spells/Second/MagicTrap.cs
@@ -1,10 +1,10 @@
 using Server.Items;
-using Server.Spells.Base;
+
 using Server.Targeting;
 
 namespace Server.Spells.Second
 {
-    public class MagicTrapSpell : MagerySpell, InstantCast
+    public class MagicTrapSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Magic Trap", "In Jux",
@@ -24,7 +24,7 @@ namespace Server.Spells.Second
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InLOS(target))

--- a/Scripts/Spells/Second/RemoveTrap.cs
+++ b/Scripts/Spells/Second/RemoveTrap.cs
@@ -1,10 +1,10 @@
 using Server.Items;
-using Server.Spells.Base;
+
 using Server.Targeting;
 
 namespace Server.Spells.Second
 {
-    public class RemoveTrapSpell : MagerySpell, InstantCast
+    public class RemoveTrapSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Remove Trap", "An Jux",
@@ -23,7 +23,7 @@ namespace Server.Spells.Second
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InLOS(target))

--- a/Scripts/Spells/Second/RemoveTrap.cs
+++ b/Scripts/Spells/Second/RemoveTrap.cs
@@ -26,7 +26,7 @@ namespace Server.Spells.Second
         public bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
-            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            if (Caster.InLOS(target))
             {
                 t.Invoke(Caster, target);
                 return true;

--- a/Scripts/Spells/Second/RemoveTrap.cs
+++ b/Scripts/Spells/Second/RemoveTrap.cs
@@ -1,9 +1,10 @@
 using Server.Items;
+using Server.Spells.Base;
 using Server.Targeting;
 
 namespace Server.Spells.Second
 {
-    public class RemoveTrapSpell : MagerySpell
+    public class RemoveTrapSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Remove Trap", "An Jux",
@@ -20,6 +21,18 @@ namespace Server.Spells.Second
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(TrapableContainer item)

--- a/Scripts/Spells/Second/Strength.cs
+++ b/Scripts/Spells/Second/Strength.cs
@@ -1,9 +1,10 @@
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Second
 {
-    public class StrengthSpell : MagerySpell
+    public class StrengthSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Strength", "Uus Mani",
@@ -21,6 +22,18 @@ namespace Server.Spells.Second
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(Mobile m)

--- a/Scripts/Spells/Second/Strength.cs
+++ b/Scripts/Spells/Second/Strength.cs
@@ -1,10 +1,10 @@
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Second
 {
-    public class StrengthSpell : MagerySpell, InstantCast
+    public class StrengthSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Strength", "Uus Mani",
@@ -24,7 +24,7 @@ namespace Server.Spells.Second
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Seventh/ChainLightning.cs
+++ b/Scripts/Spells/Seventh/ChainLightning.cs
@@ -1,11 +1,12 @@
 using Server.Mobiles;
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 using System.Collections.Generic;
 
 namespace Server.Spells.Seventh
 {
-    public class ChainLightningSpell : MagerySpell
+    public class ChainLightningSpell : MagerySpell, InstantCast
     {
         public override DamageType SpellDamageType => DamageType.SpellAOE;
 
@@ -28,6 +29,17 @@ namespace Server.Spells.Seventh
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(IPoint3D p)

--- a/Scripts/Spells/Seventh/ChainLightning.cs
+++ b/Scripts/Spells/Seventh/ChainLightning.cs
@@ -1,12 +1,12 @@
 using Server.Mobiles;
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 using System.Collections.Generic;
 
 namespace Server.Spells.Seventh
 {
-    public class ChainLightningSpell : MagerySpell, InstantCast
+    public class ChainLightningSpell : MagerySpell
     {
         public override DamageType SpellDamageType => DamageType.SpellAOE;
 
@@ -30,7 +30,7 @@ namespace Server.Spells.Seventh
         {
             Caster.Target = new InternalTarget(this);
         }
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Seventh/EnergyField.cs
+++ b/Scripts/Spells/Seventh/EnergyField.cs
@@ -1,13 +1,13 @@
 using Server.Items;
 using Server.Misc;
 using Server.Mobiles;
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Seventh
 {
-    public class EnergyFieldSpell : MagerySpell, InstantCast
+    public class EnergyFieldSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Energy Field", "In Sanct Grav",
@@ -29,7 +29,7 @@ namespace Server.Spells.Seventh
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Seventh/EnergyField.cs
+++ b/Scripts/Spells/Seventh/EnergyField.cs
@@ -1,12 +1,13 @@
 using Server.Items;
 using Server.Misc;
 using Server.Mobiles;
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Seventh
 {
-    public class EnergyFieldSpell : MagerySpell
+    public class EnergyFieldSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Energy Field", "In Sanct Grav",
@@ -26,6 +27,18 @@ namespace Server.Spells.Seventh
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(IPoint3D p)

--- a/Scripts/Spells/Seventh/FlameStrike.cs
+++ b/Scripts/Spells/Seventh/FlameStrike.cs
@@ -1,8 +1,9 @@
+using Server.Spells.Base;
 using Server.Targeting;
 
 namespace Server.Spells.Seventh
 {
-    public class FlameStrikeSpell : MagerySpell
+    public class FlameStrikeSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Flame Strike", "Kal Vas Flam",
@@ -20,6 +21,18 @@ namespace Server.Spells.Seventh
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(IDamageable m)

--- a/Scripts/Spells/Seventh/FlameStrike.cs
+++ b/Scripts/Spells/Seventh/FlameStrike.cs
@@ -1,9 +1,9 @@
-using Server.Spells.Base;
+
 using Server.Targeting;
 
 namespace Server.Spells.Seventh
 {
-    public class FlameStrikeSpell : MagerySpell, InstantCast
+    public class FlameStrikeSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Flame Strike", "Kal Vas Flam",
@@ -23,7 +23,7 @@ namespace Server.Spells.Seventh
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Seventh/GateTravel.cs
+++ b/Scripts/Spells/Seventh/GateTravel.cs
@@ -6,11 +6,11 @@ using Server.Network;
 using Server.Targeting;
 using System;
 using Server.Engines.NewMagincia;
-using Server.Spells.Base;
+
 
 namespace Server.Spells.Seventh
 {
-    public class GateTravelSpell : MagerySpell, InstantCast
+    public class GateTravelSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Gate Travel", "Vas Rel Por",
@@ -53,7 +53,7 @@ namespace Server.Spells.Seventh
             }
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Seventh/GateTravel.cs
+++ b/Scripts/Spells/Seventh/GateTravel.cs
@@ -6,10 +6,11 @@ using Server.Network;
 using Server.Targeting;
 using System;
 using Server.Engines.NewMagincia;
+using Server.Spells.Base;
 
 namespace Server.Spells.Seventh
 {
-    public class GateTravelSpell : MagerySpell
+    public class GateTravelSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Gate Travel", "Vas Rel Por",
@@ -50,6 +51,18 @@ namespace Server.Spells.Seventh
                     Effect(m_Entry.Location, m_Entry.Map, true, false);
                 }
             }
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public override bool CheckCast()

--- a/Scripts/Spells/Seventh/ManaVampire.cs
+++ b/Scripts/Spells/Seventh/ManaVampire.cs
@@ -1,8 +1,9 @@
+using Server.Spells.Base;
 using Server.Targeting;
 
 namespace Server.Spells.Seventh
 {
-    public class ManaVampireSpell : MagerySpell
+    public class ManaVampireSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Mana Vampire", "Ort Sanct",
@@ -21,6 +22,18 @@ namespace Server.Spells.Seventh
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(Mobile m)

--- a/Scripts/Spells/Seventh/ManaVampire.cs
+++ b/Scripts/Spells/Seventh/ManaVampire.cs
@@ -1,9 +1,9 @@
-using Server.Spells.Base;
+
 using Server.Targeting;
 
 namespace Server.Spells.Seventh
 {
-    public class ManaVampireSpell : MagerySpell, InstantCast
+    public class ManaVampireSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Mana Vampire", "Ort Sanct",
@@ -24,7 +24,7 @@ namespace Server.Spells.Seventh
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Seventh/MassDispel.cs
+++ b/Scripts/Spells/Seventh/MassDispel.cs
@@ -1,11 +1,12 @@
 using Server.Items;
 using Server.Mobiles;
+using Server.Spells.Base;
 using Server.Targeting;
 using System.Collections.Generic;
 
 namespace Server.Spells.Seventh
 {
-    public class MassDispelSpell : MagerySpell
+    public class MassDispelSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Mass Dispel", "Vas An Ort",
@@ -24,6 +25,18 @@ namespace Server.Spells.Seventh
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(IPoint3D p)

--- a/Scripts/Spells/Seventh/MassDispel.cs
+++ b/Scripts/Spells/Seventh/MassDispel.cs
@@ -1,12 +1,12 @@
 using Server.Items;
 using Server.Mobiles;
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System.Collections.Generic;
 
 namespace Server.Spells.Seventh
 {
-    public class MassDispelSpell : MagerySpell, InstantCast
+    public class MassDispelSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Mass Dispel", "Vas An Ort",
@@ -27,7 +27,7 @@ namespace Server.Spells.Seventh
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Seventh/MeteorSwarm.cs
+++ b/Scripts/Spells/Seventh/MeteorSwarm.cs
@@ -1,12 +1,13 @@
 using Server.Items;
 using Server.Mobiles;
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 using System.Collections.Generic;
 
 namespace Server.Spells.Seventh
 {
-    public class MeteorSwarmSpell : MagerySpell
+    public class MeteorSwarmSpell : MagerySpell, InstantCast
     {
         public override DamageType SpellDamageType => DamageType.SpellAOE;
         public Item Item { get; }
@@ -48,6 +49,18 @@ namespace Server.Spells.Seventh
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this, Item);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this, Item);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(IPoint3D p, Item item)

--- a/Scripts/Spells/Seventh/MeteorSwarm.cs
+++ b/Scripts/Spells/Seventh/MeteorSwarm.cs
@@ -1,13 +1,13 @@
 using Server.Items;
 using Server.Mobiles;
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 using System.Collections.Generic;
 
 namespace Server.Spells.Seventh
 {
-    public class MeteorSwarmSpell : MagerySpell, InstantCast
+    public class MeteorSwarmSpell : MagerySpell
     {
         public override DamageType SpellDamageType => DamageType.SpellAOE;
         public Item Item { get; }
@@ -51,7 +51,7 @@ namespace Server.Spells.Seventh
             Caster.Target = new InternalTarget(this, Item);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this, Item);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Sixth/Dispel.cs
+++ b/Scripts/Spells/Sixth/Dispel.cs
@@ -1,10 +1,11 @@
 using Server.Items;
 using Server.Mobiles;
+using Server.Spells.Base;
 using Server.Targeting;
 
 namespace Server.Spells.Sixth
 {
-    public class DispelSpell : MagerySpell
+    public class DispelSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Dispel", "An Ort",
@@ -22,6 +23,18 @@ namespace Server.Spells.Sixth
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public class InternalTarget : Target

--- a/Scripts/Spells/Sixth/Dispel.cs
+++ b/Scripts/Spells/Sixth/Dispel.cs
@@ -1,11 +1,11 @@
 using Server.Items;
 using Server.Mobiles;
-using Server.Spells.Base;
+
 using Server.Targeting;
 
 namespace Server.Spells.Sixth
 {
-    public class DispelSpell : MagerySpell, InstantCast
+    public class DispelSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Dispel", "An Ort",
@@ -25,7 +25,7 @@ namespace Server.Spells.Sixth
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Sixth/EnergyBolt.cs
+++ b/Scripts/Spells/Sixth/EnergyBolt.cs
@@ -1,9 +1,10 @@
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Sixth
 {
-    public class EnergyBoltSpell : MagerySpell
+    public class EnergyBoltSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Energy Bolt", "Corp Por",
@@ -21,6 +22,18 @@ namespace Server.Spells.Sixth
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(IDamageable m)

--- a/Scripts/Spells/Sixth/EnergyBolt.cs
+++ b/Scripts/Spells/Sixth/EnergyBolt.cs
@@ -1,10 +1,10 @@
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Sixth
 {
-    public class EnergyBoltSpell : MagerySpell, InstantCast
+    public class EnergyBoltSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Energy Bolt", "Corp Por",
@@ -24,7 +24,7 @@ namespace Server.Spells.Sixth
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Sixth/Explosion.cs
+++ b/Scripts/Spells/Sixth/Explosion.cs
@@ -1,10 +1,10 @@
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Sixth
 {
-    public class ExplosionSpell : MagerySpell, InstantCast
+    public class ExplosionSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Explosion", "Vas Ort Flam",
@@ -24,7 +24,7 @@ namespace Server.Spells.Sixth
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Sixth/Explosion.cs
+++ b/Scripts/Spells/Sixth/Explosion.cs
@@ -1,9 +1,10 @@
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Sixth
 {
-    public class ExplosionSpell : MagerySpell
+    public class ExplosionSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Explosion", "Vas Ort Flam",
@@ -21,6 +22,18 @@ namespace Server.Spells.Sixth
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(IDamageable m)

--- a/Scripts/Spells/Sixth/Invisibility.cs
+++ b/Scripts/Spells/Sixth/Invisibility.cs
@@ -1,11 +1,12 @@
 using Server.Items;
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 using System.Collections;
 
 namespace Server.Spells.Sixth
 {
-    public class InvisibilitySpell : MagerySpell
+    public class InvisibilitySpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Invisibility", "An Lor Xen",
@@ -39,6 +40,18 @@ namespace Server.Spells.Sixth
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(Mobile m)

--- a/Scripts/Spells/Sixth/Invisibility.cs
+++ b/Scripts/Spells/Sixth/Invisibility.cs
@@ -1,12 +1,12 @@
 using Server.Items;
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 using System.Collections;
 
 namespace Server.Spells.Sixth
 {
-    public class InvisibilitySpell : MagerySpell, InstantCast
+    public class InvisibilitySpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Invisibility", "An Lor Xen",
@@ -42,7 +42,7 @@ namespace Server.Spells.Sixth
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Sixth/Mark.cs
+++ b/Scripts/Spells/Sixth/Mark.cs
@@ -37,7 +37,7 @@ namespace Server.Spells.Sixth
         public bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
-            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            if (Caster.InLOS(target))
             {
                 t.Invoke(Caster, target);
                 return true;

--- a/Scripts/Spells/Sixth/Mark.cs
+++ b/Scripts/Spells/Sixth/Mark.cs
@@ -1,11 +1,12 @@
 using Server.Items;
 using Server.Multis;
 using Server.Network;
+using Server.Spells.Base;
 using Server.Targeting;
 
 namespace Server.Spells.Sixth
 {
-    public class MarkSpell : MagerySpell
+    public class MarkSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Mark", "Kal Por Ylem",
@@ -31,6 +32,18 @@ namespace Server.Spells.Sixth
                 return false;
 
             return SpellHelper.CheckTravel(Caster, TravelCheckType.Mark);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(RecallRune rune)

--- a/Scripts/Spells/Sixth/Mark.cs
+++ b/Scripts/Spells/Sixth/Mark.cs
@@ -1,12 +1,12 @@
 using Server.Items;
 using Server.Multis;
 using Server.Network;
-using Server.Spells.Base;
+
 using Server.Targeting;
 
 namespace Server.Spells.Sixth
 {
-    public class MarkSpell : MagerySpell, InstantCast
+    public class MarkSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Mark", "Kal Por Ylem",
@@ -34,7 +34,7 @@ namespace Server.Spells.Sixth
             return SpellHelper.CheckTravel(Caster, TravelCheckType.Mark);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InLOS(target))

--- a/Scripts/Spells/Sixth/MassCurse.cs
+++ b/Scripts/Spells/Sixth/MassCurse.cs
@@ -1,10 +1,10 @@
-using Server.Spells.Base;
+
 using Server.Spells.Fourth;
 using Server.Targeting;
 
 namespace Server.Spells.Sixth
 {
-    public class MassCurseSpell : MagerySpell, InstantCast
+    public class MassCurseSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Mass Curse", "Vas Des Sanct",
@@ -27,7 +27,7 @@ namespace Server.Spells.Sixth
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Sixth/MassCurse.cs
+++ b/Scripts/Spells/Sixth/MassCurse.cs
@@ -1,9 +1,10 @@
+using Server.Spells.Base;
 using Server.Spells.Fourth;
 using Server.Targeting;
 
 namespace Server.Spells.Sixth
 {
-    public class MassCurseSpell : MagerySpell
+    public class MassCurseSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Mass Curse", "Vas Des Sanct",
@@ -24,6 +25,18 @@ namespace Server.Spells.Sixth
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(IPoint3D p)

--- a/Scripts/Spells/Sixth/ParalyzeField.cs
+++ b/Scripts/Spells/Sixth/ParalyzeField.cs
@@ -1,12 +1,13 @@
 using Server.Items;
 using Server.Misc;
 using Server.Mobiles;
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Sixth
 {
-    public class ParalyzeFieldSpell : MagerySpell
+    public class ParalyzeFieldSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Paralyze Field", "In Ex Grav",
@@ -25,6 +26,18 @@ namespace Server.Spells.Sixth
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(IPoint3D p)

--- a/Scripts/Spells/Sixth/ParalyzeField.cs
+++ b/Scripts/Spells/Sixth/ParalyzeField.cs
@@ -1,13 +1,13 @@
 using Server.Items;
 using Server.Misc;
 using Server.Mobiles;
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Sixth
 {
-    public class ParalyzeFieldSpell : MagerySpell, InstantCast
+    public class ParalyzeFieldSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Paralyze Field", "In Ex Grav",
@@ -28,7 +28,7 @@ namespace Server.Spells.Sixth
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Sixth/Reveal.cs
+++ b/Scripts/Spells/Sixth/Reveal.cs
@@ -1,9 +1,10 @@
+using Server.Spells.Base;
 using Server.Targeting;
 using System.Collections.Generic;
 
 namespace Server.Spells.Sixth
 {
-    public class RevealSpell : MagerySpell
+    public class RevealSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Reveal", "Wis Quas",
@@ -20,6 +21,18 @@ namespace Server.Spells.Sixth
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(IPoint3D p)

--- a/Scripts/Spells/Sixth/Reveal.cs
+++ b/Scripts/Spells/Sixth/Reveal.cs
@@ -26,13 +26,9 @@ namespace Server.Spells.Sixth
         public bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
-            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
-            {
-                t.Invoke(Caster, target);
-                return true;
-            }
-            else
-                return false;
+
+            t.Invoke(Caster, Caster);
+            return true;
         }
 
         public void Target(IPoint3D p)

--- a/Scripts/Spells/Sixth/Reveal.cs
+++ b/Scripts/Spells/Sixth/Reveal.cs
@@ -1,10 +1,10 @@
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System.Collections.Generic;
 
 namespace Server.Spells.Sixth
 {
-    public class RevealSpell : MagerySpell, InstantCast
+    public class RevealSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Reveal", "Wis Quas",
@@ -23,7 +23,7 @@ namespace Server.Spells.Sixth
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
 

--- a/Scripts/Spells/Skill Masteries/BodyGuard.cs
+++ b/Scripts/Spells/Skill Masteries/BodyGuard.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace Server.Spells.SkillMasteries
 {
-    public class BodyGuardSpell : SkillMasterySpell
+    public class BodyGuardSpell : SkillMasterySpell, InstantCast
     {
         private static readonly SpellInfo _Info = new SpellInfo(
                 "Body Guard", "",
@@ -78,6 +78,16 @@ namespace Server.Spells.SkillMasteries
                         }
                     });
             }
+        }
+        public bool OnInstantCast(IEntity target)
+        {
+            if (target is Mobile)
+            {
+                OnTarget(target as Mobile);
+                return true;
+            }
+            else
+                return false;
         }
 
         protected override void OnTarget(object o)

--- a/Scripts/Spells/Skill Masteries/BodyGuard.cs
+++ b/Scripts/Spells/Skill Masteries/BodyGuard.cs
@@ -1,13 +1,13 @@
 using Server.Gumps;
 using Server.Items;
 using Server.Mobiles;
-using Server.Spells.Base;
+
 using System;
 using System.Collections.Generic;
 
 namespace Server.Spells.SkillMasteries
 {
-    public class BodyGuardSpell : SkillMasterySpell, InstantCast
+    public class BodyGuardSpell : SkillMasterySpell
     {
         private static readonly SpellInfo _Info = new SpellInfo(
                 "Body Guard", "",
@@ -80,7 +80,7 @@ namespace Server.Spells.SkillMasteries
                     });
             }
         }
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             if (target is Mobile)
             {

--- a/Scripts/Spells/Skill Masteries/BodyGuard.cs
+++ b/Scripts/Spells/Skill Masteries/BodyGuard.cs
@@ -1,6 +1,7 @@
 using Server.Gumps;
 using Server.Items;
 using Server.Mobiles;
+using Server.Spells.Base;
 using System;
 using System.Collections.Generic;
 

--- a/Scripts/Spells/Skill Masteries/CommandUndead.cs
+++ b/Scripts/Spells/Skill Masteries/CommandUndead.cs
@@ -1,5 +1,7 @@
 using Server.Items;
 using Server.Mobiles;
+using Server.Spells.Base;
+using Server.Targeting;
 using System;
 
 namespace Server.Spells.SkillMasteries
@@ -34,16 +36,19 @@ namespace Server.Spells.SkillMasteries
         {
             Caster.Target = new MasteryTarget(this);
         }
+
         public bool OnInstantCast(IEntity target)
         {
-            if (target is BaseCreature)
+            Target t = new MasteryTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
             {
-                OnTarget(target as BaseCreature);
+                t.Invoke(Caster, target);
                 return true;
             }
             else
                 return false;
         }
+
         protected override void OnTarget(object o)
         {
             BaseCreature bc = o as BaseCreature;

--- a/Scripts/Spells/Skill Masteries/CommandUndead.cs
+++ b/Scripts/Spells/Skill Masteries/CommandUndead.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace Server.Spells.SkillMasteries
 {
-    public class CommandUndeadSpell : SkillMasterySpell
+    public class CommandUndeadSpell : SkillMasterySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
                 "Command Undead", "In Corp Xen Por",
@@ -34,7 +34,16 @@ namespace Server.Spells.SkillMasteries
         {
             Caster.Target = new MasteryTarget(this);
         }
-
+        public bool OnInstantCast(IEntity target)
+        {
+            if (target is BaseCreature)
+            {
+                OnTarget(target as BaseCreature);
+                return true;
+            }
+            else
+                return false;
+        }
         protected override void OnTarget(object o)
         {
             BaseCreature bc = o as BaseCreature;

--- a/Scripts/Spells/Skill Masteries/CommandUndead.cs
+++ b/Scripts/Spells/Skill Masteries/CommandUndead.cs
@@ -1,12 +1,12 @@
 using Server.Items;
 using Server.Mobiles;
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.SkillMasteries
 {
-    public class CommandUndeadSpell : SkillMasterySpell, InstantCast
+    public class CommandUndeadSpell : SkillMasterySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
                 "Command Undead", "In Corp Xen Por",
@@ -37,7 +37,7 @@ namespace Server.Spells.SkillMasteries
             Caster.Target = new MasteryTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new MasteryTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Skill Masteries/Conduit.cs
+++ b/Scripts/Spells/Skill Masteries/Conduit.cs
@@ -1,11 +1,12 @@
 using Server.Items;
+using Server.Mobiles;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace Server.Spells.SkillMasteries
 {
-    public class ConduitSpell : SkillMasterySpell
+    public class ConduitSpell : SkillMasterySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
                 "Conduit", "Uus Corp Grav",
@@ -43,6 +44,12 @@ namespace Server.Spells.SkillMasteries
         public override void OnCast()
         {
             Caster.Target = new MasteryTarget(this, 10, true, Targeting.TargetFlags.None);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            OnTarget(target);
+            return true;
         }
 
         protected override void OnTarget(object o)

--- a/Scripts/Spells/Skill Masteries/Conduit.cs
+++ b/Scripts/Spells/Skill Masteries/Conduit.cs
@@ -1,6 +1,6 @@
 using Server.Items;
 using Server.Mobiles;
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 using System.Collections.Generic;
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace Server.Spells.SkillMasteries
 {
-    public class ConduitSpell : SkillMasterySpell, InstantCast
+    public class ConduitSpell : SkillMasterySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
                 "Conduit", "Uus Corp Grav",
@@ -48,7 +48,7 @@ namespace Server.Spells.SkillMasteries
             Caster.Target = new MasteryTarget(this, 10, true, Targeting.TargetFlags.None);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new MasteryTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Skill Masteries/Conduit.cs
+++ b/Scripts/Spells/Skill Masteries/Conduit.cs
@@ -1,5 +1,7 @@
 using Server.Items;
 using Server.Mobiles;
+using Server.Spells.Base;
+using Server.Targeting;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -48,8 +50,14 @@ namespace Server.Spells.SkillMasteries
 
         public bool OnInstantCast(IEntity target)
         {
-            OnTarget(target);
-            return true;
+            Target t = new MasteryTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         protected override void OnTarget(object o)

--- a/Scripts/Spells/Skill Masteries/DeathRay.cs
+++ b/Scripts/Spells/Skill Masteries/DeathRay.cs
@@ -1,11 +1,11 @@
 using Server.Mobiles;
 using System;
 using Server.Targeting;
-using Server.Spells.Base;
+
 
 namespace Server.Spells.SkillMasteries
 {
-    public class DeathRaySpell : SkillMasterySpell, InstantCast
+    public class DeathRaySpell : SkillMasterySpell
     {
         /*The mage focuses a death ray on their opponent which snares the mage to their 
          * location and does damage based on magery skill, evaluating intelligence skill,
@@ -48,7 +48,7 @@ namespace Server.Spells.SkillMasteries
         {
             Caster.Target = new MasteryTarget(this);
         }
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new MasteryTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Skill Masteries/DeathRay.cs
+++ b/Scripts/Spells/Skill Masteries/DeathRay.cs
@@ -4,7 +4,7 @@ using Server.Targeting;
 
 namespace Server.Spells.SkillMasteries
 {
-    public class DeathRaySpell : SkillMasterySpell
+    public class DeathRaySpell : SkillMasterySpell, InstantCast
     {
         /*The mage focuses a death ray on their opponent which snares the mage to their 
          * location and does damage based on magery skill, evaluating intelligence skill,
@@ -46,6 +46,11 @@ namespace Server.Spells.SkillMasteries
         public override void OnCast()
         {
             Caster.Target = new MasteryTarget(this, flags: TargetFlags.Harmful);
+        }
+        public bool OnInstantCast(IEntity target)
+        {
+            OnTarget(target);
+            return true;
         }
 
         protected override void OnTarget(object o)

--- a/Scripts/Spells/Skill Masteries/DeathRay.cs
+++ b/Scripts/Spells/Skill Masteries/DeathRay.cs
@@ -1,6 +1,7 @@
 using Server.Mobiles;
 using System;
 using Server.Targeting;
+using Server.Spells.Base;
 
 namespace Server.Spells.SkillMasteries
 {
@@ -49,8 +50,14 @@ namespace Server.Spells.SkillMasteries
         }
         public bool OnInstantCast(IEntity target)
         {
-            OnTarget(target);
-            return true;
+            Target t = new MasteryTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         protected override void OnTarget(object o)

--- a/Scripts/Spells/Skill Masteries/FlamingShot.cs
+++ b/Scripts/Spells/Skill Masteries/FlamingShot.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Server.Spells.SkillMasteries
 {
-    public class FlamingShotSpell : SkillMasterySpell
+    public class FlamingShotSpell : SkillMasterySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
                 "Flameing Shot", "",
@@ -46,6 +46,12 @@ namespace Server.Spells.SkillMasteries
         public override void OnCast()
         {
             Caster.Target = new MasteryTarget(this, allowGround: true);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            OnTarget(target);
+            return true;
         }
 
         protected override void OnTarget(object o)

--- a/Scripts/Spells/Skill Masteries/FlamingShot.cs
+++ b/Scripts/Spells/Skill Masteries/FlamingShot.cs
@@ -1,13 +1,13 @@
 using Server.Items;
 using Server.Network;
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 using System.Collections.Generic;
 
 namespace Server.Spells.SkillMasteries
 {
-    public class FlamingShotSpell : SkillMasterySpell, InstantCast
+    public class FlamingShotSpell : SkillMasterySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
                 "Flameing Shot", "",
@@ -50,7 +50,7 @@ namespace Server.Spells.SkillMasteries
             Caster.Target = new MasteryTarget(this, allowGround: true);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new MasteryTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Skill Masteries/FlamingShot.cs
+++ b/Scripts/Spells/Skill Masteries/FlamingShot.cs
@@ -1,5 +1,7 @@
 using Server.Items;
 using Server.Network;
+using Server.Spells.Base;
+using Server.Targeting;
 using System;
 using System.Collections.Generic;
 
@@ -50,8 +52,14 @@ namespace Server.Spells.SkillMasteries
 
         public bool OnInstantCast(IEntity target)
         {
-            OnTarget(target);
-            return true;
+            Target t = new MasteryTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         protected override void OnTarget(object o)

--- a/Scripts/Spells/Skill Masteries/HolyFistSpell.cs
+++ b/Scripts/Spells/Skill Masteries/HolyFistSpell.cs
@@ -10,7 +10,7 @@ using System;
 
 namespace Server.Spells.SkillMasteries
 {
-    public class HolyFistSpell : SkillMasterySpell
+    public class HolyFistSpell : SkillMasterySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
                 "Holy Fist", "Kal Vas Grav",
@@ -54,6 +54,12 @@ namespace Server.Spells.SkillMasteries
         public override void OnCast()
         {
             Caster.Target = new MasteryTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            OnTarget(target);
+            return true;
         }
 
         protected override void OnTarget(object o)

--- a/Scripts/Spells/Skill Masteries/HolyFistSpell.cs
+++ b/Scripts/Spells/Skill Masteries/HolyFistSpell.cs
@@ -1,7 +1,7 @@
 using Server.Items;
 using Server.Mobiles;
 using Server.Network;
-using Server.Spells.Base;
+
 using Server.Spells.Ninjitsu;
 using Server.Targeting;
 using System;
@@ -12,7 +12,7 @@ using System;
 
 namespace Server.Spells.SkillMasteries
 {
-    public class HolyFistSpell : SkillMasterySpell, InstantCast
+    public class HolyFistSpell : SkillMasterySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
                 "Holy Fist", "Kal Vas Grav",
@@ -58,7 +58,7 @@ namespace Server.Spells.SkillMasteries
             Caster.Target = new MasteryTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new MasteryTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Skill Masteries/HolyFistSpell.cs
+++ b/Scripts/Spells/Skill Masteries/HolyFistSpell.cs
@@ -1,7 +1,9 @@
 using Server.Items;
 using Server.Mobiles;
 using Server.Network;
+using Server.Spells.Base;
 using Server.Spells.Ninjitsu;
+using Server.Targeting;
 using System;
 
 /*The paladin unleashes a flying fist against a target that does energy damage based on the paladin's chivalry 
@@ -58,8 +60,14 @@ namespace Server.Spells.SkillMasteries
 
         public bool OnInstantCast(IEntity target)
         {
-            OnTarget(target);
-            return true;
+            Target t = new MasteryTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         protected override void OnTarget(object o)

--- a/Scripts/Spells/Skill Masteries/InjectedStrike.cs
+++ b/Scripts/Spells/Skill Masteries/InjectedStrike.cs
@@ -1,12 +1,12 @@
 using Server.Items;
 using Server.Mobiles;
-using Server.Spells.Base;
+
 using System;
 using System.Collections.Generic;
 
 namespace Server.Spells.SkillMasteries
 {
-    public class InjectedStrikeSpell : SkillMasterySpell, InstantCast
+    public class InjectedStrikeSpell : SkillMasterySpell
     {
         private static readonly SpellInfo _Info = new SpellInfo(
                 "Injected Strike", "",
@@ -78,7 +78,7 @@ namespace Server.Spells.SkillMasteries
             FinishSequence();
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             BaseWeapon weapon = GetWeapon();
 

--- a/Scripts/Spells/Skill Masteries/InjectedStrike.cs
+++ b/Scripts/Spells/Skill Masteries/InjectedStrike.cs
@@ -1,5 +1,6 @@
 using Server.Items;
 using Server.Mobiles;
+using Server.Spells.Base;
 using System;
 using System.Collections.Generic;
 
@@ -76,6 +77,7 @@ namespace Server.Spells.SkillMasteries
 
             FinishSequence();
         }
+
         public bool OnInstantCast(IEntity target)
         {
             BaseWeapon weapon = GetWeapon();

--- a/Scripts/Spells/Skill Masteries/NetherBlast.cs
+++ b/Scripts/Spells/Skill Masteries/NetherBlast.cs
@@ -1,5 +1,7 @@
 using Server.Items;
 using Server.Misc;
+using Server.Spells.Base;
+using Server.Targeting;
 using System;
 using System.Collections.Generic;
 
@@ -64,8 +66,14 @@ namespace Server.Spells.SkillMasteries
 
         public bool OnInstantCast(IEntity target)
         {
-            OnTarget(target);
-            return true;
+            Target t = new MasteryTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         protected override void OnTarget(object o)

--- a/Scripts/Spells/Skill Masteries/NetherBlast.cs
+++ b/Scripts/Spells/Skill Masteries/NetherBlast.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Server.Spells.SkillMasteries
 {
-    public class NetherBlastSpell : SkillMasterySpell
+    public class NetherBlastSpell : SkillMasterySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
                 "Nether Blast", "In Vas Por Grav",
@@ -60,6 +60,12 @@ namespace Server.Spells.SkillMasteries
         public override void OnCast()
         {
             Caster.Target = new MasteryTarget(this, 10, true, Targeting.TargetFlags.None);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            OnTarget(target);
+            return true;
         }
 
         protected override void OnTarget(object o)

--- a/Scripts/Spells/Skill Masteries/NetherBlast.cs
+++ b/Scripts/Spells/Skill Masteries/NetherBlast.cs
@@ -1,13 +1,13 @@
 using Server.Items;
 using Server.Misc;
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 using System.Collections.Generic;
 
 namespace Server.Spells.SkillMasteries
 {
-    public class NetherBlastSpell : SkillMasterySpell, InstantCast
+    public class NetherBlastSpell : SkillMasterySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
                 "Nether Blast", "In Vas Por Grav",
@@ -64,7 +64,7 @@ namespace Server.Spells.SkillMasteries
             Caster.Target = new MasteryTarget(this, 10, true, Targeting.TargetFlags.None);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new MasteryTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Skill Masteries/Rejuvinate.cs
+++ b/Scripts/Spells/Skill Masteries/Rejuvinate.cs
@@ -1,7 +1,9 @@
 using Server.Items;
 using Server.Mobiles;
+using Server.Spells.Base;
 using Server.Spells.Fourth;
 using Server.Spells.Necromancy;
+using Server.Targeting;
 using System;
 
 namespace Server.Spells.SkillMasteries
@@ -59,8 +61,14 @@ namespace Server.Spells.SkillMasteries
 
         public bool OnInstantCast(IEntity target)
         {
-            OnTarget(target);
-            return true;
+            Target t = new MasteryTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         protected override void OnTarget(object o)

--- a/Scripts/Spells/Skill Masteries/Rejuvinate.cs
+++ b/Scripts/Spells/Skill Masteries/Rejuvinate.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace Server.Spells.SkillMasteries
 {
-    public class RejuvinateSpell : SkillMasterySpell
+    public class RejuvinateSpell : SkillMasterySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
                 "Rejuvinate", "In Vas Ort Grav Mani",
@@ -55,6 +55,12 @@ namespace Server.Spells.SkillMasteries
         public override void OnCast()
         {
             Caster.Target = new MasteryTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            OnTarget(target);
+            return true;
         }
 
         protected override void OnTarget(object o)

--- a/Scripts/Spells/Skill Masteries/Rejuvinate.cs
+++ b/Scripts/Spells/Skill Masteries/Rejuvinate.cs
@@ -1,6 +1,6 @@
 using Server.Items;
 using Server.Mobiles;
-using Server.Spells.Base;
+
 using Server.Spells.Fourth;
 using Server.Spells.Necromancy;
 using Server.Targeting;
@@ -8,7 +8,7 @@ using System;
 
 namespace Server.Spells.SkillMasteries
 {
-    public class RejuvinateSpell : SkillMasterySpell, InstantCast
+    public class RejuvinateSpell : SkillMasterySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
                 "Rejuvinate", "In Vas Ort Grav Mani",
@@ -59,7 +59,7 @@ namespace Server.Spells.SkillMasteries
             Caster.Target = new MasteryTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new MasteryTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Spellweaving/DryadAllure.cs
+++ b/Scripts/Spells/Spellweaving/DryadAllure.cs
@@ -1,11 +1,12 @@
 using Server.Items;
 using Server.Mobiles;
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Spellweaving
 {
-    public class DryadAllureSpell : ArcanistSpell
+    public class DryadAllureSpell : ArcanistSpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Dryad Allure", "Rathril",
@@ -44,6 +45,17 @@ namespace Server.Spells.Spellweaving
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            if (target is BaseCreature)
+            {
+                Target(target as BaseCreature);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(BaseCreature bc)

--- a/Scripts/Spells/Spellweaving/DryadAllure.cs
+++ b/Scripts/Spells/Spellweaving/DryadAllure.cs
@@ -1,12 +1,12 @@
 using Server.Items;
 using Server.Mobiles;
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Spellweaving
 {
-    public class DryadAllureSpell : ArcanistSpell, InstantCast
+    public class DryadAllureSpell : ArcanistSpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Dryad Allure", "Rathril",
@@ -47,7 +47,7 @@ namespace Server.Spells.Spellweaving
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             if (target is BaseCreature)
             {

--- a/Scripts/Spells/Spellweaving/GiftOfLife.cs
+++ b/Scripts/Spells/Spellweaving/GiftOfLife.cs
@@ -1,13 +1,13 @@
 using Server.Gumps;
 using Server.Mobiles;
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 using System.Collections.Generic;
 
 namespace Server.Spells.Spellweaving
 {
-    public class GiftOfLifeSpell : ArcanistSpell, InstantCast
+    public class GiftOfLifeSpell : ArcanistSpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Gift of Life", "Illorae",
@@ -44,7 +44,7 @@ namespace Server.Spells.Spellweaving
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             if (target is Mobile)
             {

--- a/Scripts/Spells/Spellweaving/GiftOfLife.cs
+++ b/Scripts/Spells/Spellweaving/GiftOfLife.cs
@@ -1,12 +1,13 @@
 using Server.Gumps;
 using Server.Mobiles;
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 using System.Collections.Generic;
 
 namespace Server.Spells.Spellweaving
 {
-    public class GiftOfLifeSpell : ArcanistSpell
+    public class GiftOfLifeSpell : ArcanistSpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Gift of Life", "Illorae",
@@ -41,6 +42,17 @@ namespace Server.Spells.Spellweaving
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            if (target is Mobile)
+            {
+                Target(target as Mobile);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(Mobile m)

--- a/Scripts/Spells/Spellweaving/GiftOfRenewal.cs
+++ b/Scripts/Spells/Spellweaving/GiftOfRenewal.cs
@@ -1,10 +1,11 @@
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 using System.Collections.Generic;
 
 namespace Server.Spells.Spellweaving
 {
-    public class GiftOfRenewalSpell : ArcanistSpell
+    public class GiftOfRenewalSpell : ArcanistSpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Gift of Renewal", "Olorisstra",
@@ -23,6 +24,17 @@ namespace Server.Spells.Spellweaving
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            if (target is Mobile)
+            {
+                Target(target as Mobile);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(Mobile m)

--- a/Scripts/Spells/Spellweaving/GiftOfRenewal.cs
+++ b/Scripts/Spells/Spellweaving/GiftOfRenewal.cs
@@ -1,11 +1,11 @@
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 using System.Collections.Generic;
 
 namespace Server.Spells.Spellweaving
 {
-    public class GiftOfRenewalSpell : ArcanistSpell, InstantCast
+    public class GiftOfRenewalSpell : ArcanistSpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Gift of Renewal", "Olorisstra",
@@ -26,7 +26,7 @@ namespace Server.Spells.Spellweaving
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             if (target is Mobile)
             {

--- a/Scripts/Spells/Spellweaving/NatureFury.cs
+++ b/Scripts/Spells/Spellweaving/NatureFury.cs
@@ -1,12 +1,12 @@
 using Server.Mobiles;
 using Server.Regions;
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Spellweaving
 {
-    public class NatureFurySpell : ArcanistSpell, InstantCast
+    public class NatureFurySpell : ArcanistSpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Nature's Fury", "Rauvvrae",
@@ -39,7 +39,7 @@ namespace Server.Spells.Spellweaving
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target(target.Location);
             return true;

--- a/Scripts/Spells/Spellweaving/NatureFury.cs
+++ b/Scripts/Spells/Spellweaving/NatureFury.cs
@@ -1,11 +1,12 @@
 using Server.Mobiles;
 using Server.Regions;
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Spellweaving
 {
-    public class NatureFurySpell : ArcanistSpell
+    public class NatureFurySpell : ArcanistSpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Nature's Fury", "Rauvvrae",
@@ -36,6 +37,12 @@ namespace Server.Spells.Spellweaving
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target(target.Location);
+            return true;
         }
 
         public void Target(IPoint3D point)

--- a/Scripts/Spells/Spellweaving/Wildfire.cs
+++ b/Scripts/Spells/Spellweaving/Wildfire.cs
@@ -1,14 +1,14 @@
 using Server.Mobiles;
 using Server.Multis;
 using Server.Regions;
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 using System.Collections.Generic;
 
 namespace Server.Spells.Spellweaving
 {
-    public class WildfireSpell : ArcanistSpell, InstantCast
+    public class WildfireSpell : ArcanistSpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Wildfire", "Haelyn",
@@ -28,7 +28,7 @@ namespace Server.Spells.Spellweaving
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target(target.Location);
             return true;

--- a/Scripts/Spells/Spellweaving/Wildfire.cs
+++ b/Scripts/Spells/Spellweaving/Wildfire.cs
@@ -1,13 +1,14 @@
 using Server.Mobiles;
 using Server.Multis;
 using Server.Regions;
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 using System.Collections.Generic;
 
 namespace Server.Spells.Spellweaving
 {
-    public class WildfireSpell : ArcanistSpell
+    public class WildfireSpell : ArcanistSpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Wildfire", "Haelyn",
@@ -25,6 +26,12 @@ namespace Server.Spells.Spellweaving
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target(target.Location);
+            return true;
         }
 
         public void Target(Point3D p)

--- a/Scripts/Spells/Spellweaving/WordOfDeath.cs
+++ b/Scripts/Spells/Spellweaving/WordOfDeath.cs
@@ -1,10 +1,10 @@
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Spellweaving
 {
-    public class WordOfDeathSpell : ArcanistSpell, InstantCast
+    public class WordOfDeathSpell : ArcanistSpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo("Word of Death", "Nyraxle", -1);
         public WordOfDeathSpell(Mobile caster, Item scroll)
@@ -20,7 +20,7 @@ namespace Server.Spells.Spellweaving
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             if (target is Mobile)
             {

--- a/Scripts/Spells/Spellweaving/WordOfDeath.cs
+++ b/Scripts/Spells/Spellweaving/WordOfDeath.cs
@@ -1,9 +1,10 @@
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Spellweaving
 {
-    public class WordOfDeathSpell : ArcanistSpell
+    public class WordOfDeathSpell : ArcanistSpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo("Word of Death", "Nyraxle", -1);
         public WordOfDeathSpell(Mobile caster, Item scroll)
@@ -17,6 +18,17 @@ namespace Server.Spells.Spellweaving
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            if (target is Mobile)
+            {
+                Target(target as Mobile);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(Mobile m)

--- a/Scripts/Spells/Third/Bless.cs
+++ b/Scripts/Spells/Third/Bless.cs
@@ -1,11 +1,11 @@
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 using System.Collections.Generic;
 
 namespace Server.Spells.Third
 {
-    public class BlessSpell : MagerySpell, InstantCast
+    public class BlessSpell : MagerySpell
     {
         private static readonly SpellInfo _Info = new SpellInfo(
             "Bless", "Rel Sanct",
@@ -59,7 +59,7 @@ namespace Server.Spells.Third
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Third/Bless.cs
+++ b/Scripts/Spells/Third/Bless.cs
@@ -1,10 +1,11 @@
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 using System.Collections.Generic;
 
 namespace Server.Spells.Third
 {
-    public class BlessSpell : MagerySpell
+    public class BlessSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo _Info = new SpellInfo(
             "Bless", "Rel Sanct",
@@ -56,6 +57,18 @@ namespace Server.Spells.Third
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(Mobile m)

--- a/Scripts/Spells/Third/Fireball.cs
+++ b/Scripts/Spells/Third/Fireball.cs
@@ -1,9 +1,10 @@
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Third
 {
-    public class FireballSpell : MagerySpell
+    public class FireballSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Fireball", "Vas Flam",
@@ -20,6 +21,18 @@ namespace Server.Spells.Third
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(IDamageable m)

--- a/Scripts/Spells/Third/Fireball.cs
+++ b/Scripts/Spells/Third/Fireball.cs
@@ -1,10 +1,10 @@
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Third
 {
-    public class FireballSpell : MagerySpell, InstantCast
+    public class FireballSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Fireball", "Vas Flam",
@@ -23,7 +23,7 @@ namespace Server.Spells.Third
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Third/MagicLock.cs
+++ b/Scripts/Spells/Third/MagicLock.cs
@@ -1,10 +1,11 @@
 using Server.Items;
 using Server.Network;
+using Server.Spells.Base;
 using Server.Targeting;
 
 namespace Server.Spells.Third
 {
-    public class MagicLockSpell : MagerySpell
+    public class MagicLockSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Magic Lock", "An Por",
@@ -22,6 +23,18 @@ namespace Server.Spells.Third
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(LockableContainer targ)

--- a/Scripts/Spells/Third/MagicLock.cs
+++ b/Scripts/Spells/Third/MagicLock.cs
@@ -28,7 +28,7 @@ namespace Server.Spells.Third
         public bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
-            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            if (Caster.InLOS(target))
             {
                 t.Invoke(Caster, target);
                 return true;

--- a/Scripts/Spells/Third/MagicLock.cs
+++ b/Scripts/Spells/Third/MagicLock.cs
@@ -1,11 +1,11 @@
 using Server.Items;
 using Server.Network;
-using Server.Spells.Base;
+
 using Server.Targeting;
 
 namespace Server.Spells.Third
 {
-    public class MagicLockSpell : MagerySpell, InstantCast
+    public class MagicLockSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Magic Lock", "An Por",
@@ -25,7 +25,7 @@ namespace Server.Spells.Third
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InLOS(target))

--- a/Scripts/Spells/Third/Poison.cs
+++ b/Scripts/Spells/Third/Poison.cs
@@ -1,9 +1,9 @@
-using Server.Spells.Base;
+
 using Server.Targeting;
 
 namespace Server.Spells.Third
 {
-    public class PoisonSpell : MagerySpell, InstantCast
+    public class PoisonSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Poison", "In Nox",
@@ -23,7 +23,7 @@ namespace Server.Spells.Third
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Third/Poison.cs
+++ b/Scripts/Spells/Third/Poison.cs
@@ -1,8 +1,9 @@
+using Server.Spells.Base;
 using Server.Targeting;
 
 namespace Server.Spells.Third
 {
-    public class PoisonSpell : MagerySpell
+    public class PoisonSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Poison", "In Nox",
@@ -20,6 +21,18 @@ namespace Server.Spells.Third
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(Mobile m)

--- a/Scripts/Spells/Third/Telekinesis.cs
+++ b/Scripts/Spells/Third/Telekinesis.cs
@@ -1,9 +1,10 @@
 using Server.Items;
+using Server.Spells.Base;
 using Server.Targeting;
 
 namespace Server.Spells.Third
 {
-    public class TelekinesisSpell : MagerySpell
+    public class TelekinesisSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Telekinesis", "Ort Por Ylem",
@@ -20,6 +21,18 @@ namespace Server.Spells.Third
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(ITelekinesisable obj)

--- a/Scripts/Spells/Third/Telekinesis.cs
+++ b/Scripts/Spells/Third/Telekinesis.cs
@@ -1,10 +1,10 @@
 using Server.Items;
-using Server.Spells.Base;
+
 using Server.Targeting;
 
 namespace Server.Spells.Third
 {
-    public class TelekinesisSpell : MagerySpell, InstantCast
+    public class TelekinesisSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Telekinesis", "Ort Por Ylem",
@@ -23,7 +23,7 @@ namespace Server.Spells.Third
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Third/Teleport.cs
+++ b/Scripts/Spells/Third/Teleport.cs
@@ -1,10 +1,11 @@
 using Server.Items;
 using Server.Regions;
+using Server.Spells.Base;
 using Server.Targeting;
 
 namespace Server.Spells.Third
 {
-    public class TeleportSpell : MagerySpell
+    public class TeleportSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Teleport", "Rel Por",
@@ -32,6 +33,18 @@ namespace Server.Spells.Third
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(IPoint3D p)

--- a/Scripts/Spells/Third/Teleport.cs
+++ b/Scripts/Spells/Third/Teleport.cs
@@ -37,10 +37,9 @@ namespace Server.Spells.Third
 
         public bool OnInstantCast(IEntity target)
         {
-            Target t = new InternalTarget(this);
-            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            if (target != null)
             {
-                t.Invoke(Caster, target);
+                Target(target.Location);
                 return true;
             }
             else

--- a/Scripts/Spells/Third/Teleport.cs
+++ b/Scripts/Spells/Third/Teleport.cs
@@ -1,11 +1,11 @@
 using Server.Items;
 using Server.Regions;
-using Server.Spells.Base;
+
 using Server.Targeting;
 
 namespace Server.Spells.Third
 {
-    public class TeleportSpell : MagerySpell, InstantCast
+    public class TeleportSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Teleport", "Rel Por",
@@ -35,7 +35,7 @@ namespace Server.Spells.Third
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             if (target != null)
             {

--- a/Scripts/Spells/Third/Unlock.cs
+++ b/Scripts/Spells/Third/Unlock.cs
@@ -1,6 +1,6 @@
 using Server.Items;
 using Server.Network;
-using Server.Spells.Base;
+
 using Server.Targeting;
 
 namespace Server.Spells.Third
@@ -10,7 +10,7 @@ namespace Server.Spells.Third
         void OnMageUnlock(Mobile from);
     }
 
-    public class UnlockSpell : MagerySpell, InstantCast
+    public class UnlockSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Unlock Spell", "Ex Por",
@@ -102,7 +102,7 @@ namespace Server.Spells.Third
 
             FinishSequence();
         }
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InLOS(target))

--- a/Scripts/Spells/Third/Unlock.cs
+++ b/Scripts/Spells/Third/Unlock.cs
@@ -105,7 +105,7 @@ namespace Server.Spells.Third
         public bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
-            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            if (Caster.InLOS(target))
             {
                 t.Invoke(Caster, target);
                 return true;
@@ -125,10 +125,7 @@ namespace Server.Spells.Third
 
             protected override void OnTarget(Mobile from, object o)
             {
-                if (o is Mobile mobile)
-                {
-                    m_Owner.Target(mobile);
-                }
+                m_Owner.Target(o);
             }
 
             protected override void OnTargetFinish(Mobile from)

--- a/Scripts/Spells/Third/Unlock.cs
+++ b/Scripts/Spells/Third/Unlock.cs
@@ -1,5 +1,6 @@
 using Server.Items;
 using Server.Network;
+using Server.Spells.Base;
 using Server.Targeting;
 
 namespace Server.Spells.Third
@@ -9,7 +10,7 @@ namespace Server.Spells.Third
         void OnMageUnlock(Mobile from);
     }
 
-    public class UnlockSpell : MagerySpell
+    public class UnlockSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Unlock Spell", "Ex Por",
@@ -28,6 +29,91 @@ namespace Server.Spells.Third
             Caster.Target = new InternalTarget(this);
         }
 
+        private void Target(object o)
+        {
+            IPoint3D loc = o as IPoint3D;
+
+            if (loc == null)
+                return;
+
+            if (CheckSequence())
+            {
+                SpellHelper.Turn(Caster, o);
+
+                Effects.SendLocationParticles(EffectItem.Create(new Point3D(loc), Caster.Map, EffectItem.DefaultDuration), 0x376A, 9, 32, 5024);
+
+                Effects.PlaySound(loc, Caster.Map, 0x1FF);
+
+                if (o is Mobile)
+                    Caster.LocalOverheadMessage(MessageType.Regular, 0x3B2, 503101); // That did not need to be unlocked.
+                else if (o is IMageUnlockable mageUnlockable)
+                    mageUnlockable.OnMageUnlock(Caster);
+                else if (!(o is LockableContainer))
+                    Caster.SendLocalizedMessage(501666); // You can't unlock that!
+                else
+                {
+                    LockableContainer cont = (LockableContainer)o;
+
+                    if (Multis.BaseHouse.CheckSecured(cont))
+                        Caster.SendLocalizedMessage(503098); // You cannot cast this on a secure item.
+                    else if (!cont.Locked)
+                        Caster.LocalOverheadMessage(MessageType.Regular, 0x3B2, 503101); // That did not need to be unlocked.
+                    else if (cont.LockLevel == 0)
+                        Caster.SendLocalizedMessage(501666); // You can't unlock that!
+                    else if (cont is HotItemChest)
+                        Caster.SendLocalizedMessage(503099); // My spell does not seem to have an effect on that lock
+                    else if (cont is TreasureMapChest chest && chest.Level > 2)
+                        Caster.LocalOverheadMessage(MessageType.Regular, 0x3B2, 503099); // My spell does not seem to have an effect on that lock.
+                    else
+                    {
+                        int level;
+                        int reqSkill;
+
+                        if (cont is TreasureMapChest mapChest)
+                        {
+                            level = (int)Caster.Skills[SkillName.Magery].Value;
+
+                            switch (mapChest.Level)
+                            {
+                                default:
+                                case 0: reqSkill = 50; break;
+                                case 1: reqSkill = 80; break;
+                                case 2: reqSkill = 100; break;
+                            }
+                        }
+                        else
+                        {
+                            level = (int)(Caster.Skills[SkillName.Magery].Value * 0.8) - 4;
+                            reqSkill = cont.RequiredSkill;
+                        }
+
+                        if (level >= reqSkill)
+                        {
+                            cont.Locked = false;
+
+                            if (cont.LockLevel == -255)
+                                cont.LockLevel = cont.RequiredSkill - 10;
+                        }
+                        else
+                            Caster.LocalOverheadMessage(MessageType.Regular, 0x3B2, 503099); // My spell does not seem to have an effect on that lock.
+                    }
+                }
+            }
+
+            FinishSequence();
+        }
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
+        }
+
         private class InternalTarget : Target
         {
             private readonly UnlockSpell m_Owner;
@@ -39,76 +125,10 @@ namespace Server.Spells.Third
 
             protected override void OnTarget(Mobile from, object o)
             {
-                IPoint3D loc = o as IPoint3D;
-
-                if (loc == null)
-                    return;
-
-                if (m_Owner.CheckSequence())
+                if (o is Mobile mobile)
                 {
-                    SpellHelper.Turn(from, o);
-
-                    Effects.SendLocationParticles(EffectItem.Create(new Point3D(loc), from.Map, EffectItem.DefaultDuration), 0x376A, 9, 32, 5024);
-
-                    Effects.PlaySound(loc, from.Map, 0x1FF);
-
-                    if (o is Mobile)
-                        from.LocalOverheadMessage(MessageType.Regular, 0x3B2, 503101); // That did not need to be unlocked.
-                    else if (o is IMageUnlockable mageUnlockable)
-                        mageUnlockable.OnMageUnlock(from);
-                    else if (!(o is LockableContainer))
-                        from.SendLocalizedMessage(501666); // You can't unlock that!
-                    else
-                    {
-                        LockableContainer cont = (LockableContainer)o;
-
-                        if (Multis.BaseHouse.CheckSecured(cont))
-                            from.SendLocalizedMessage(503098); // You cannot cast this on a secure item.
-                        else if (!cont.Locked)
-                            from.LocalOverheadMessage(MessageType.Regular, 0x3B2, 503101); // That did not need to be unlocked.
-                        else if (cont.LockLevel == 0)
-                            from.SendLocalizedMessage(501666); // You can't unlock that!
-                        else if (cont is HotItemChest)
-                            from.SendLocalizedMessage(503099); // My spell does not seem to have an effect on that lock
-                        else if (cont is TreasureMapChest chest && chest.Level > 2)
-                            from.LocalOverheadMessage(MessageType.Regular, 0x3B2, 503099); // My spell does not seem to have an effect on that lock.
-                        else
-                        {
-                            int level;
-                            int reqSkill;
-
-                            if (cont is TreasureMapChest mapChest)
-                            {
-                                level = (int)from.Skills[SkillName.Magery].Value;
-
-                                switch (mapChest.Level)
-                                {
-                                    default:
-                                    case 0: reqSkill = 50; break;
-                                    case 1: reqSkill = 80; break;
-                                    case 2: reqSkill = 100; break;
-                                }
-                            }
-                            else
-                            {
-                                level = (int)(from.Skills[SkillName.Magery].Value * 0.8) - 4;
-                                reqSkill = cont.RequiredSkill;
-                            }
-
-                            if (level >= reqSkill)
-                            {
-                                cont.Locked = false;
-
-                                if (cont.LockLevel == -255)
-                                    cont.LockLevel = cont.RequiredSkill - 10;
-                            }
-                            else
-                                from.LocalOverheadMessage(MessageType.Regular, 0x3B2, 503099); // My spell does not seem to have an effect on that lock.
-                        }
-                    }
+                    m_Owner.Target(mobile);
                 }
-
-                m_Owner.FinishSequence();
             }
 
             protected override void OnTargetFinish(Mobile from)

--- a/Scripts/Spells/Third/WallOfStone.cs
+++ b/Scripts/Spells/Third/WallOfStone.cs
@@ -1,12 +1,12 @@
 using Server.Misc;
 using Server.Mobiles;
-using Server.Spells.Base;
+
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Third
 {
-    public class WallOfStoneSpell : MagerySpell, InstantCast
+    public class WallOfStoneSpell : MagerySpell
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Wall of Stone", "In Sanct Ylem",
@@ -26,7 +26,7 @@ namespace Server.Spells.Third
             Caster.Target = new InternalTarget(this);
         }
 
-        public bool OnInstantCast(IEntity target)
+        public override bool OnInstantCast(IEntity target)
         {
             Target t = new InternalTarget(this);
             if (Caster.InRange(target, t.Range) && Caster.InLOS(target))

--- a/Scripts/Spells/Third/WallOfStone.cs
+++ b/Scripts/Spells/Third/WallOfStone.cs
@@ -1,11 +1,12 @@
 using Server.Misc;
 using Server.Mobiles;
+using Server.Spells.Base;
 using Server.Targeting;
 using System;
 
 namespace Server.Spells.Third
 {
-    public class WallOfStoneSpell : MagerySpell
+    public class WallOfStoneSpell : MagerySpell, InstantCast
     {
         private static readonly SpellInfo m_Info = new SpellInfo(
             "Wall of Stone", "In Sanct Ylem",
@@ -23,6 +24,18 @@ namespace Server.Spells.Third
         public override void OnCast()
         {
             Caster.Target = new InternalTarget(this);
+        }
+
+        public bool OnInstantCast(IEntity target)
+        {
+            Target t = new InternalTarget(this);
+            if (Caster.InRange(target, t.Range) && Caster.InLOS(target))
+            {
+                t.Invoke(Caster, target);
+                return true;
+            }
+            else
+                return false;
         }
 
         public void Target(IPoint3D p)

--- a/Server/Skills.cs
+++ b/Server/Skills.cs
@@ -24,6 +24,7 @@ namespace Server
 		Locked = 2
 	}
 
+    [Flags]
 	public enum SkillName
 	{
 		Alchemy = 0,


### PR DESCRIPTION
Removed existing reflection from Spells.cs, by adding an interface for InstantCast spells.
Any targettable spell will now have an additional method from the interface to hook into the existing Targets and pass the target in the same call, without the overhead of Reflection references.

Also tidied the Skill reference by ID numbers in PlayerMobile.cs/Skills.cs