### PR TITLE
MethodSupportForQuestAccessByAccount

### DIFF
--- a/Scripts/Services/MondainsLegacyQuests/BaseQuest.cs
+++ b/Scripts/Services/MondainsLegacyQuests/BaseQuest.cs
@@ -38,6 +38,8 @@ namespace Server.Engines.Quests
 
         public virtual bool IsQuestionQuest => false;
 
+        public virtual bool UseAccountWideQuestRestrictions => false;
+
         private List<BaseObjective> m_Objectives;
         private List<BaseReward> m_Rewards;
         private PlayerMobile m_Owner;

--- a/Scripts/Services/MondainsLegacyQuests/Helpers/QuestHelper.cs
+++ b/Scripts/Services/MondainsLegacyQuests/Helpers/QuestHelper.cs
@@ -1,7 +1,6 @@
 using Server.Accounting;
 using Server.ContextMenus;
 using Server.Mobiles;
-using Server.Network;
 using Server.Regions;
 using Server.Targeting;
 using System;
@@ -92,6 +91,7 @@ namespace Server.Engines.Quests
                     return false;
                 }
 
+                // if player already has an active quest from the chain
                 if (InChainProgress(from, quest))
                 {
                     return false;

--- a/Scripts/Services/MondainsLegacyQuests/Helpers/QuestHelper.cs
+++ b/Scripts/Services/MondainsLegacyQuests/Helpers/QuestHelper.cs
@@ -234,12 +234,9 @@ namespace Server.Engines.Quests
                     {
                         DateTime endTime = restartInfo.RestartTime;
 
-                        if (DateTime.UtcNow < endTime)
+                        if (DateTime.UtcNow < endTime && (earliestEndTime == null || endTime < earliestEndTime))
                         {
-                            if (earliestEndTime == null || endTime < earliestEndTime)
-                            {
-                                earliestEndTime = endTime;
-                            }
+                            earliestEndTime = endTime;
                         }
                     }
                 }


### PR DESCRIPTION
If set to true
`public override bool UseAccountWideQuestRestrictions => true;`

Quests set with an account-wide restriction can only exist in one player on an account's quest log at a time. 

Quests that also have a restart delay set while true will also restrict other players on an account from accessing said quest until the timer has run out.