### PR TITLE
Fix Incorrect Packet Lengths Due to Stale Throttled Packet Data V2 

### DIFF
--- a/Server/Network/NetState.cs
+++ b/Server/Network/NetState.cs
@@ -1063,6 +1063,23 @@ namespace Server.Network
 
 		public ByteQueue Buffer { get; private set; }
 
+        // Secondary ByteQueue to hold throttled (delayed) packet data.
+        public ByteQueue ThrottledQueue { get; } = new ByteQueue();
+
+        /// <summary>
+        /// Merges all throttled packet data from ThrottledQueue back into the main Buffer.
+        /// </summary>
+        public void ProcessThrottledPackets()
+        {
+            int len = ThrottledQueue.Length;
+            if (len > 0)
+            {
+                byte[] temp = new byte[len];
+                ThrottledQueue.Dequeue(temp, 0, len);
+                Buffer.Enqueue(temp, 0, len);
+            }
+        }
+
 		public ExpansionInfo ExpansionInfo
 		{
 			get


### PR DESCRIPTION
This PR refines our packet throttling mechanism to prevent stale packet data from corrupting subsequent packet processing. Instead of allocating a new byte array for every delayed (non‐dropped) packet, we now transfer the throttled packet data into a secondary ByteQueue. This approach reduces unnecessary allocations when a packet is delayed and ensures that dropped packets are simply removed from the main ByteQueue without allocation.

This PR addresses an issue where, over time, the server began sending packets with erroneously long lengths. The root cause was traced to the throttling mechanism: when a packet was throttled (i.e., delayed rather than dropped), its header and associated data were not properly removed from the ByteQueue. This leftover data could later be combined with new incoming bytes, resulting in a misinterpreted (and overly long) packet.