### PR TITLE
Fixes Incognito name change from character select menu

### DIFF
--- a/Scripts/Network/Packets/CharacterListPacket.cs
+++ b/Scripts/Network/Packets/CharacterListPacket.cs
@@ -29,7 +29,7 @@ namespace Server.Network.Packets
             {
                 if (a[i] != null)
                 {
-                    m_Stream.WriteAsciiFixed(a[i].Name, 30);
+                    m_Stream.WriteAsciiFixed(a[i].RawName, 30);
                     m_Stream.Fill(30); // password
                 }
                 else

--- a/Scripts/Network/Packets/CharacterListUpdatePacket.cs
+++ b/Scripts/Network/Packets/CharacterListUpdatePacket.cs
@@ -30,7 +30,7 @@ namespace Server.Network.Packets
 
                 if (m != null)
                 {
-                    m_Stream.WriteAsciiFixed(m.Name, 30);
+                    m_Stream.WriteAsciiFixed(m.RawName, 30);
                     m_Stream.Fill(30); // password
                 }
                 else


### PR DESCRIPTION
When casting Incognito, if you log out and back in, the Incognito name (Name/NameMod) shows on the Character List. It should always just display the character's name. Using RawName fixes this. Also, when logging back in, clients will create new "profile" folders for the Incognitoed name. This also fixes that.