### PR TITLE
Navrey Pillar Fixes

### DIFF
--- a/Scripts/Services/Dungeons/Underworld/Navrey's Lair/NavreysController.cs
+++ b/Scripts/Services/Dungeons/Underworld/Navrey's Lair/NavreysController.cs
@@ -116,7 +116,7 @@ namespace Server.Items
         }
         #endregion
 
-        internal NavreysPillar[] m_Pillars;
+        private NavreysPillar[] m_Pillars;
         private Navrey m_Navrey;
 
         // Next time the daily pillar type shuffle should occur (UTC midnight schedule).

--- a/Scripts/Services/Dungeons/Underworld/Navrey's Lair/NavreysController.cs
+++ b/Scripts/Services/Dungeons/Underworld/Navrey's Lair/NavreysController.cs
@@ -11,12 +11,66 @@ namespace Server.Items
         public static void Initialize()
         {
             CommandSystem.Register("GenNavrey", AccessLevel.Developer, GenNavrey_Command);
+            CommandSystem.Register("FixNavreyPillars", AccessLevel.GameMaster, FixNavreyPillars_Command);
+            CommandSystem.Register("NavreyStatus", AccessLevel.GameMaster, NavreyStatus_Command);
         }
 
         [Usage("GenNavrey")]
         private static void GenNavrey_Command(CommandEventArgs e)
         {
             GenNavery(e.Mobile);
+        }
+
+        /// <summary>
+        /// Repairs the 3/6/9 pillar type invariant for the existing controller (if any).
+        /// Useful to fix a live, already-corrupted world state without restarting.
+        /// </summary>
+        [Usage("FixNavreyPillars")]
+        private static void FixNavreyPillars_Command(CommandEventArgs e)
+        {
+            NavreysController controller = FindController();
+
+            if (controller == null || controller.Deleted)
+            {
+                e.Mobile.SendMessage("Navrey controller not found.");
+                return;
+            }
+
+            controller.ForceRepairTypes();
+            e.Mobile.SendMessage("Navrey pillars repaired (forced 3/6/9).");
+        }
+
+        /// <summary>
+        /// Prints the current pillar types and time to next daily shuffle.
+        /// </summary>
+        [Usage("NavreyStatus")]
+        private static void NavreyStatus_Command(CommandEventArgs e)
+        {
+            NavreysController controller = FindController();
+
+            if (controller == null || controller.Deleted)
+            {
+                e.Mobile.SendMessage("Navrey controller not found.");
+                return;
+            }
+
+            controller.CheckDailyShuffleAndRepair();
+
+            e.Mobile.SendMessage("Navrey Pillar Status:");
+            e.Mobile.SendMessage($"  Next shuffle in: {controller.TypeRestart}");
+            e.Mobile.SendMessage($"  Next shuffle UTC: {controller.NextShuffleUtc:yyyy-MM-dd HH:mm:ss}");
+
+            for (int i = 0; i < controller.m_Pillars.Length; i++)
+            {
+                NavreysPillar p = controller.m_Pillars[i];
+
+                if (p == null || p.Deleted)
+                {
+                    continue;
+                }
+
+                e.Mobile.SendMessage($"  Pillar {i}: {p.Type} at {p.Location} (Serial: {p.Serial})");
+            }
         }
 
         public static void GenNavery(Mobile m)
@@ -38,54 +92,54 @@ namespace Server.Items
         private static bool Check()
         {
             foreach (Item item in World.Items.Values)
+            {
                 if (item is NavreysController && !item.Deleted)
+                {
                     return true;
+                }
+            }
 
             return false;
         }
+
+        private static NavreysController FindController()
+        {
+            foreach (Item item in World.Items.Values)
+            {
+                if (item is NavreysController c && !c.Deleted)
+                {
+                    return c;
+                }
+            }
+
+            return null;
+        }
         #endregion
 
-        private NavreysPillar[] m_Pillars;
+        internal NavreysPillar[] m_Pillars;
         private Navrey m_Navrey;
 
-        private DateTime m_TypeRestart;
+        // Next time the daily pillar type shuffle should occur (UTC midnight schedule).
+        private DateTime m_NextShuffleUtc;
 
+        // expose schedule to staff via [props on the controller.
+        [CommandProperty(AccessLevel.GameMaster)]
+        public DateTime NextShuffleUtc
+        {
+            get => m_NextShuffleUtc;
+            set => m_NextShuffleUtc = value;
+        }
+
+        /// <summary>
+        /// Time remaining until next daily shuffle.
+        /// </summary>
         [CommandProperty(AccessLevel.GameMaster)]
         public TimeSpan TypeRestart
         {
             get
             {
-                TimeSpan ts = m_TypeRestart - DateTime.UtcNow;
-
-                if (ts < TimeSpan.Zero)
-                {
-                    ts = TimeSpan.Zero;
-
-                    for (int i = 0; i < m_Pillars.Length; i++)
-                    {
-                        NavreysPillar pillar = m_Pillars[i];
-
-                        if (pillar.Type != PillarType.Nine)
-                            pillar.m_Type++;
-                        else
-                            pillar.Type = PillarType.Three;
-                    }
-
-                    TypeRestart = TimeSpan.FromHours(24.0); // The timers rotate among the three stone ruins randomly once a day
-                }
-
-                return ts;
-            }
-            set
-            {
-                try
-                {
-                    m_TypeRestart = DateTime.UtcNow + value;
-                }
-                catch (Exception e)
-                {
-                    Diagnostics.ExceptionLogging.LogException(e);
-                }
+                TimeSpan ts = m_NextShuffleUtc - DateTime.UtcNow;
+                return ts < TimeSpan.Zero ? TimeSpan.Zero : ts;
             }
         }
 
@@ -98,7 +152,9 @@ namespace Server.Items
                     NavreysPillar pillar = m_Pillars[i];
 
                     if (pillar == null || pillar.Deleted || pillar.State != NavreysPillarState.Hot)
+                    {
                         return false;
+                    }
                 }
 
                 return true;
@@ -118,10 +174,18 @@ namespace Server.Items
 
             m_Pillars[0] = new NavreysPillar(this, PillarType.Three);
             m_Pillars[0].MoveToWorld(new Point3D(1071, 847, 0), Map.TerMur);
+
             m_Pillars[1] = new NavreysPillar(this, PillarType.Six);
             m_Pillars[1].MoveToWorld(new Point3D(1039, 879, 0), Map.TerMur);
+
             m_Pillars[2] = new NavreysPillar(this, PillarType.Nine);
             m_Pillars[2].MoveToWorld(new Point3D(1039, 850, 0), Map.TerMur);
+
+            // Daily random rotation schedule: next UTC midnight.
+            m_NextShuffleUtc = DateTime.UtcNow.Date.AddDays(1);
+
+            // Enforce invariant immediately (fixes any accidental edits)
+            CheckDailyShuffleAndRepair();
 
             Respawn();
         }
@@ -129,12 +193,13 @@ namespace Server.Items
         public void OnNavreyKilled()
         {
             SetAllPillars(NavreysPillarState.Off);
-
             Timer.DelayCall(TimeSpan.FromMinutes(10.0), Respawn);
         }
 
         public void Respawn()
         {
+            CheckDailyShuffleAndRepair();
+
             Navrey navrey = new Navrey(this)
             {
                 RangeHome = 20
@@ -150,24 +215,48 @@ namespace Server.Items
         public void ResetPillars()
         {
             if (m_Navrey != null && !m_Navrey.Deleted && m_Navrey.Alive)
+            {
                 SetAllPillars(NavreysPillarState.On);
+            }
+        }
+
+        /// <summary>
+        /// Called by a pillar right before it turns Hot.
+        /// IMPORTANT: this ensures the type is repaired BEFORE the timer duration is computed.
+        /// </summary>
+        public void EnsureMechanismReady()
+        {
+            CheckDailyShuffleAndRepair();
         }
 
         public override void Delete()
         {
             base.Delete();
 
-            for (int i = 0; i < m_Pillars.Length; i++)
+            if (m_Pillars != null)
             {
-                NavreysPillar pillar = m_Pillars[i];
-                pillar.Delete();
+                for (int i = 0; i < m_Pillars.Length; i++)
+                {
+                    NavreysPillar pillar = m_Pillars[i];
+
+                    if (pillar != null && !pillar.Deleted)
+                    {
+                        pillar.Delete();
+                    }
+                }
             }
 
-            m_Navrey.Delete();
+            if (m_Navrey != null && !m_Navrey.Deleted)
+            {
+                m_Navrey.Delete();
+            }
         }
 
         public void CheckPillars()
         {
+            // sanity
+            CheckDailyShuffleAndRepair();
+
             if (AllPillarsHot)
             {
                 m_Navrey.UsedPillars = true;
@@ -185,7 +274,136 @@ namespace Server.Items
             for (int i = 0; i < m_Pillars.Length; i++)
             {
                 NavreysPillar pillar = m_Pillars[i];
-                pillar.State = state;
+
+                if (pillar != null && !pillar.Deleted)
+                {
+                    pillar.State = state;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Public entry point for GM command to repair a live corrupted state.
+        /// </summary>
+        public void ForceRepairTypes()
+        {
+            EnsurePillarTypesAreValid();
+        }
+
+        private static readonly PillarType[] _RequiredTypes =
+        [
+            PillarType.Three,
+            PillarType.Six,
+            PillarType.Nine
+        ];
+
+        /// <summary>
+        /// Ensures the three pillars always contain exactly one 3, one 6, and one 9.
+        /// If it detects duplicates or invalid values, it repairs them deterministically.
+        /// </summary>
+        private void EnsurePillarTypesAreValid()
+        {
+            if (m_Pillars == null || m_Pillars.Length != 3)
+            {
+                return;
+            }
+
+            bool[] present = new bool[3];
+            int[] bad = new int[3];
+            int badCount = 0;
+
+            for (int i = 0; i < 3; i++)
+            {
+                NavreysPillar p = m_Pillars[i];
+
+                if (p == null || p.Deleted)
+                {
+                    bad[badCount++] = i;
+                    continue;
+                }
+
+                int idx = GetRequiredIndex(p.Type);
+
+                // invalid type or already-present => mark as bad
+                if (idx < 0 || present[idx])
+                {
+                    bad[badCount++] = i;
+                    continue;
+                }
+
+                present[idx] = true;
+            }
+
+            // fill any missing required types into bad pillars
+            int fill = 0;
+
+            for (int t = 0; t < 3 && fill < badCount; t++)
+            {
+                if (!present[t])
+                {
+                    int i = bad[fill++];
+                    NavreysPillar p = m_Pillars[i];
+
+                    if (p != null && !p.Deleted)
+                    {
+                        p.Type = _RequiredTypes[t];
+                    }
+                }
+            }
+        }
+
+        private static int GetRequiredIndex(PillarType t)
+        {
+            switch (t)
+            {
+                case PillarType.Three: return 0;
+                case PillarType.Six: return 1;
+                case PillarType.Nine: return 2;
+                default: return -1;
+            }
+        }
+
+        /// <summary>
+        /// randomly assigns the 3/6/9 types to the three pillars (always one of each).
+        /// </summary>
+        private void ShuffleTypes()
+        {
+            if (m_Pillars == null || m_Pillars.Length != 3)
+            {
+                return;
+            }
+
+            PillarType[] types = [PillarType.Three, PillarType.Six, PillarType.Nine];
+
+            // shuffle using Utility.Random
+            for (int i = types.Length - 1; i > 0; i--)
+            {
+                int j = Utility.Random(i + 1);
+                PillarType tmp = types[i];
+                types[i] = types[j];
+                types[j] = tmp;
+            }
+
+            for (int i = 0; i < 3; i++)
+                m_Pillars[i].Type = types[i];
+        }
+
+        /// <summary>
+        /// Enforces 3/6/9 uniqueness always and performs the once-per-day random shuffle.
+        /// </summary>
+        private void CheckDailyShuffleAndRepair()
+        {
+            // Repair immediately if corrupted.
+            EnsurePillarTypesAreValid();
+
+            // Apply daily shuffle if it's time (UTC midnight schedule).
+            if (DateTime.UtcNow >= m_NextShuffleUtc)
+            {
+                ShuffleTypes();
+                EnsurePillarTypesAreValid();
+
+                // Next shuffle at next UTC midnight
+                m_NextShuffleUtc = DateTime.UtcNow.Date.AddDays(1);
             }
         }
 
@@ -197,7 +415,7 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-            writer.Write(0); // version
+            writer.Write(0);
 
             writer.Write(m_Navrey);
 
@@ -205,13 +423,13 @@ namespace Server.Items
             writer.Write(m_Pillars[1]);
             writer.Write(m_Pillars[2]);
 
-            writer.Write(TypeRestart);
+            writer.Write(m_NextShuffleUtc);
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-            reader.ReadInt();
+            reader.ReadInt(); // version
 
             m_Navrey = (Navrey)reader.ReadMobile();
 
@@ -221,12 +439,18 @@ namespace Server.Items
             m_Pillars[1] = (NavreysPillar)reader.ReadItem();
             m_Pillars[2] = (NavreysPillar)reader.ReadItem();
 
-            TypeRestart = reader.ReadTimeSpan();
+            m_NextShuffleUtc = reader.ReadDateTime();
+
+            CheckDailyShuffleAndRepair();
 
             if (m_Navrey == null)
+            {
                 Timer.DelayCall(TimeSpan.Zero, Respawn);
+            }
             else
+            {
                 SetAllPillars(NavreysPillarState.On);
+            }
         }
 
         private class RockRainTimer : Timer
@@ -237,7 +461,6 @@ namespace Server.Items
             public RockRainTimer(Navrey navrey)
                 : base(TimeSpan.Zero, TimeSpan.FromSeconds(0.25))
             {
-
                 m_Navrey = navrey;
                 m_Ticks = 120;
 
@@ -260,13 +483,15 @@ namespace Server.Items
                 Effects.PlaySound(m_Navrey.Location, m_Navrey.Map, 0x15E + Utility.Random(3));
                 Effects.PlaySound(m_Navrey.Location, m_Navrey.Map, Utility.RandomList(0x305, 0x306, 0x307, 0x309));
 
-                int amount = Utility.RandomMinMax(100, 150);
+                int amount = Utility.RandomMinMax(75, 100);
                 IPooledEnumerable eable = m_Navrey.GetMobilesInRange(1);
 
                 foreach (Mobile m in eable)
                 {
                     if (m == null || !m.Alive)
+                    {
                         continue;
+                    }
 
                     if (m is Navrey)
                     {


### PR DESCRIPTION
**Fixes:**
1. Pillars now enforce a 3, 6, 9 second timer on each. No duplicates.
2. Pillar timers now more accurate. (we were losing about 0.5 seconds per tick at the start for about 1.5 seconds total)
3. Pillars can now be reused once every 5 minutes.
4. Pillars now reset their order once a day, not determined by server restarting.
5. Slightly reduced damage done by rocks to more correctly remove around 30% of health, not 50%.
6. Added an in-game command for staff to easily check the status of pillars.