### PR TITLE
Potential Network/Ping Improvements

### DIFF
--- a/Server/Network/NetState.cs
+++ b/Server/Network/NetState.cs
@@ -690,41 +690,41 @@ namespace Server.Network
 					Thread.Sleep(m_CoalesceSleep);
 				}
 
-				SendQueue.Gram gram;
+                lock (_SendLock)
+                {
+                    SendQueue.Gram gram;
 
-				lock (m_SendQueue)
-				{
-					gram = m_SendQueue.Dequeue();
+                    lock (m_SendQueue)
+                    {
+                        gram = m_SendQueue.Dequeue();
 
-					if (gram == null && m_SendQueue.IsFlushReady)
-					{
-						gram = m_SendQueue.CheckFlushReady();
-					}
-				}
+                        if (gram == null && m_SendQueue.IsFlushReady)
+                        {
+                            gram = m_SendQueue.CheckFlushReady();
+                        }
+                    }
 
-				if (gram != null)
-				{
-					try
-					{
-						s.BeginSend(gram.Buffer, 0, gram.Length, SocketFlags.None, m_OnSend, s);
-					}
-					catch (Exception ex)
-					{
-						TraceException(ex);
-						Dispose(false);
-					}
-				}
-				else
-				{
-					lock (_SendLock)
-					{
-						_Sending = false;
-					}
-				}
-			}
-			catch (Exception)
-			{
-				Dispose(false);
+                    if (gram != null)
+                    {
+                        try
+                        {
+                            s.BeginSend(gram.Buffer, 0, gram.Length, SocketFlags.None, m_OnSend, s);
+                        }
+                        catch (Exception ex)
+                        {
+                            TraceException(ex);
+                            Dispose(false);
+                        }
+                    }
+                    else
+                    {
+                        _Sending = false;
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                Dispose(false);
 			}
 		}
 


### PR DESCRIPTION
Before the fix, there was a tiny timing gap in OnSend:

1. Send callback checked queue and found “nothing else to send”.
2. Another thread enqueued new data right then.
3. Callback then set _Sending = false.
4. Result: new data could sit queued with no send started until some later event.

That can feel like random lag spikes.

The change makes that decision atomic by using the same lock (_SendLock) while:
- checking/dequeuing the next packet,
- deciding whether to call BeginSend,
- or setting _Sending = false.

So now it becomes:
- If there is data → immediately schedule next BeginSend.
- If there is not data → set _Sending = false safely.
- No race window in between.

There’s also a small complementary improvement in Send: if only a partial buffer is waiting and the connection is idle, it flushes that immediately instead of waiting for another packet to arrive.