### PR TITLE
Harden Loot.Construct with null checks and exception logging

### DIFF
--- a/Scripts/Misc/Loot.cs
+++ b/Scripts/Misc/Loot.cs
@@ -709,6 +709,12 @@ namespace Server
         #region Construction methods
         public static Item Construct(Type type)
         {
+            if (type == null)
+            {
+                Diagnostics.ExceptionLogging.LogException(new ArgumentNullException(nameof(type), "Loot.Construct received a null type reference."));
+                return null;
+            }
+
             Item item;
 
             try
@@ -726,7 +732,7 @@ namespace Server
 
         public static Item Construct(Type[] types)
         {
-            if (types.Length > 0)
+            if (types?.Length > 0)
             {
                 return Construct(types, Utility.Random(types.Length));
             }
@@ -736,8 +742,16 @@ namespace Server
 
         public static Item Construct(Type[] types, int index)
         {
-            if (index >= 0 && index < types.Length)
+            if (types != null && index >= 0 && index < types.Length)
             {
+                if (types[index] == null)
+                {
+                    Diagnostics.ExceptionLogging.LogException(
+                        new InvalidOperationException($"Loot.Construct selected a null type entry from a {nameof(Type)}[] pool at index {index} (length {types.Length})."));
+
+                    return null;
+                }
+
                 return Construct(types[index]);
             }
 
@@ -746,11 +760,16 @@ namespace Server
 
         public static Item Construct(params Type[][] types)
         {
+            if (types == null || types.Length == 0)
+            {
+                return null;
+            }
+
             int totalLength = 0;
 
             for (int i = 0; i < types.Length; ++i)
             {
-                totalLength += types[i].Length;
+                totalLength += types[i]?.Length ?? 0;
             }
 
             if (totalLength > 0)
@@ -759,12 +778,20 @@ namespace Server
 
                 for (int i = 0; i < types.Length; ++i)
                 {
-                    if (index >= 0 && index < types[i].Length)
+                    if (types[i] != null && index >= 0 && index < types[i].Length)
                     {
+                        if (types[i][index] == null)
+                        {
+                            Diagnostics.ExceptionLogging.LogException(
+                                new InvalidOperationException($"Loot.Construct selected a null type entry from nested pool {i} at index {index} (pool length {types[i].Length})."));
+
+                            return null;
+                        }
+
                         return Construct(types[i][index]);
                     }
 
-                    index -= types[i].Length;
+                    index -= types[i]?.Length ?? 0;
                 }
             }
 


### PR DESCRIPTION
### Motivation

- Prevent null-reference crashes and provide diagnostic information when loot construction receives null inputs or contains null entries.

### Description

- Added a null check to `Construct(Type)` that logs an `ArgumentNullException` via `Diagnostics.ExceptionLogging.LogException` and returns `null` when `type` is `null`.
- Made `Construct(Type[])` tolerant of a `null` array by using `types?.Length` and returning `null` for empty or `null` inputs, delegating to the indexed overload otherwise.
- Strengthened `Construct(Type[], int)` to validate the `types` array and the selected entry, logging an `InvalidOperationException` and returning `null` if the selected element is `null` or out of range.
- Hardened `Construct(params Type[][])` to handle a `null` or empty outer array, to sum inner lengths safely using `types[i]?.Length ?? 0`, to skip `null` inner arrays, and to log and return `null` if a selected nested entry is `null`.
- Preserved existing `Activator.CreateInstance` error handling and centralized logging for instantiation exceptions.

### Testing

- Built the project to validate compilation after the changes and the build succeeded. 
- Ran the project's automated unit test suite and existing tests completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a712d9ea48832abe0b8e87d5690ad6)