### PR TITLE
ThrottleTweak

### DIFF
--- a/Scripts/Network/PacketThrottles.cs
+++ b/Scripts/Network/PacketThrottles.cs
@@ -6,9 +6,9 @@ namespace Server.Network
 {
     public static class PacketThrottles
     {
-        private static readonly int[] _Delays = new int[Byte.MaxValue];
+        private static readonly int[] _Delays = new int[Byte.MaxValue + 1];
 
-        private static readonly bool[] _Reserved = new bool[Byte.MaxValue];
+        private static readonly bool[] _Reserved = new bool[Byte.MaxValue + 1];
 
         static PacketThrottles()
         {
@@ -52,7 +52,7 @@ namespace Server.Network
 
         public static void Initialize()
         {
-            for (byte i = 0; i < Byte.MaxValue; i++)
+            for (int i = 0; i < _Delays.Length; i++)
             {
                 if (!_Reserved[i] && _Delays[i] > 0)
                 {

--- a/Server/Network/NetState.cs
+++ b/Server/Network/NetState.cs
@@ -1066,7 +1066,7 @@ namespace Server.Network
 			return string.Compare(m_ToString, other.m_ToString, StringComparison.Ordinal);
 		}
 
-        private readonly long[] _Throttles = new long[byte.MaxValue];
+        private readonly long[] _Throttles = new long[byte.MaxValue + 1];
 
         public void SetPacketTime(byte packetID)
         {


### PR DESCRIPTION
Ensure packet throttle and reserved arrays can index the full range of byte values (0–255) to avoid out-of-range accesses and off-by-one bugs.