### PR TITLE
Serialize send-queue operations with _SendLock and ensure safe disposal

### DIFF
--- a/Server/Network/NetState.cs
+++ b/Server/Network/NetState.cs
@@ -729,33 +729,33 @@ namespace Server.Network
 					_SendingGramOffset = 0;
 				}
 
-				SendQueue.Gram gram;
-
-				lock (m_SendQueue)
+				lock (_SendLock)
 				{
-					gram = m_SendQueue.Dequeue();
+					SendQueue.Gram gram;
 
-					if (gram == null && m_SendQueue.IsFlushReady)
+					lock (m_SendQueue)
 					{
-						gram = m_SendQueue.CheckFlushReady();
-					}
-				}
+						gram = m_SendQueue.Dequeue();
 
-				if (gram != null)
-				{
-					try
-					{
-						BeginSendGram(s, gram, 0);
+						if (gram == null && m_SendQueue.IsFlushReady)
+						{
+							gram = m_SendQueue.CheckFlushReady();
+						}
 					}
-					catch (Exception ex)
+
+					if (gram != null)
 					{
-						TraceException(ex);
-						Dispose(false);
+						try
+						{
+							BeginSendGram(s, gram, 0);
+						}
+						catch (Exception ex)
+						{
+							TraceException(ex);
+							Dispose(false);
+						}
 					}
-				}
-				else
-				{
-					lock (_SendLock)
+					else
 					{
 						_Sending = false;
 					}
@@ -1001,11 +1001,14 @@ namespace Server.Network
 				m_Disposed.Enqueue(this);
 			}
 
-			lock (m_SendQueue)
+			lock (_SendLock)
 			{
-				if (!m_SendQueue.IsEmpty)
+				lock (m_SendQueue)
 				{
-					m_SendQueue.Clear();
+					if (!m_SendQueue.IsEmpty)
+					{
+						m_SendQueue.Clear();
+					}
 				}
 
 				_SendingGram = null;


### PR DESCRIPTION
### Motivation

- Ensure atomic interaction between the send queue and the `_Sending` state to avoid race conditions when starting or stopping async sends.
- Make disposal of pending send state deterministic by holding the same send lock when clearing the queue and resetting send-related fields.

### Description

- Acquire `_SendLock` around dequeueing/sending logic so the dequeue + `BeginSendGram` or `_Sending = false` decision is performed atomically while still locking `m_SendQueue` to dequeue.  
- In `Dispose`, acquire `_SendLock` first and then lock `m_SendQueue` to clear pending grams if any before resetting `_SendingGram`, `_SendingGramOffset`, and `_Sending`.  
- Cleaned up indentation and moved locking blocks to centralize send-state synchronization.

### Testing

- Built the solution with `msbuild` and verified compilation succeeded.  
- Ran the automated test suite with `dotnet test` including networking/unit tests and observed no regressions.  
- Performed a basic integration run of the server to exercise send/dispose paths and did not observe send-state races or crashes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2e90e4ca0832ab8447995315f58e5)