### PR TITLE
Fixes travel spells getting stuck in regards to boats

### DIFF
--- a/Scripts/Spells/Chivalry/SacredJourney.cs
+++ b/Scripts/Spells/Chivalry/SacredJourney.cs
@@ -111,14 +111,17 @@ namespace Server.Spells.Chivalry
             if (galleon == null)
             {
                 Caster.SendLocalizedMessage(1116767); // The ship could not be located.
+                FinishSequence();
             }
             else if (galleon.Map == Map.Internal)
             {
                 Caster.SendLocalizedMessage(1149569); // That ship is in dry dock.
+                FinishSequence();
             }
             else if (!galleon.HasAccess(Caster))
             {
                 Caster.SendLocalizedMessage(1116617); // You do not have permission to board this ship.
+                FinishSequence();
             }
             else
             {

--- a/Scripts/Spells/Fourth/Recall.cs
+++ b/Scripts/Spells/Fourth/Recall.cs
@@ -138,14 +138,17 @@ namespace Server.Spells.Fourth
             if (galleon == null)
             {
                 Caster.SendLocalizedMessage(1116767); // The ship could not be located.
+                FinishSequence();
             }
             else if (galleon.Map == Map.Internal)
             {
                 Caster.SendLocalizedMessage(1149569); // That ship is in dry dock.
+                FinishSequence();
             }
             else if (!galleon.HasAccess(Caster))
             {
                 Caster.SendLocalizedMessage(1116617); // You do not have permission to board this ship.
+                FinishSequence();
             }
             else
             {

--- a/Scripts/Spells/Seventh/GateTravel.cs
+++ b/Scripts/Spells/Seventh/GateTravel.cs
@@ -99,14 +99,17 @@ namespace Server.Spells.Seventh
             if (galleon == null)
             {
                 Caster.SendLocalizedMessage(1116767); // The ship could not be located.
+                FinishSequence();
             }
             else if (galleon.Map == Map.Internal)
             {
                 Caster.SendLocalizedMessage(1149569); // That ship is in dry dock.
+                FinishSequence();
             }
             else if (!galleon.HasAccess(Caster))
             {
                 Caster.SendLocalizedMessage(1116617); // You do not have permission to board this ship.
+                FinishSequence();
             }
             else
             {


### PR DESCRIPTION
Fixes an issue where casting recall, sacred journey, or gate to a boat, could cause the spell to become "stuck" if the player does not have access to the boat or the boat has since been deleted.